### PR TITLE
[1LP][RFR] Avoid warning from relative imports

### DIFF
--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -13,7 +13,7 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import Input
 
-from .playbooks import PlaybooksCollection
+from cfme.ansible.playbooks import PlaybooksCollection
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
 from cfme.common import TagPageView

--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -16,7 +16,7 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import AutomateCustomizationView
+from cfme.automate import AutomateCustomizationView
 from cfme.base.ui import AutomateSimulationView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity

--- a/cfme/automate/dialogs/dialog_box.py
+++ b/cfme/automate/dialogs/dialog_box.py
@@ -2,9 +2,8 @@ import attr
 from cached_property import cached_property
 from navmazing import NavigateToAttribute
 
-from . import AddBoxView
-from . import BoxForm
-from .dialog_element import ElementCollection
+from cfme.automate.dialogs import AddBoxView
+from cfme.automate.dialogs import BoxForm
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.modeling.base import parent_of_type
@@ -29,6 +28,7 @@ class Box(BaseEntity):
     box_label = attr.ib()
     box_desc = attr.ib(default=None)
 
+    from cfme.automate.dialogs.dialog_element import ElementCollection
     _collections = {'elements': ElementCollection}
 
     @cached_property
@@ -41,7 +41,7 @@ class Box(BaseEntity):
 
     @property
     def tab(self):
-        from .dialog_tab import Tab
+        from cfme.automate.dialogs.dialog_tab import Tab
         return parent_of_type(self, Tab)
 
 

--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -8,8 +8,8 @@ from widgetastic_patternfly import BootstrapSwitch
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import AddBoxView
-from . import AutomateCustomizationView
+from cfme.automate.dialogs import AddBoxView
+from cfme.automate.dialogs import AutomateCustomizationView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.modeling.base import parent_of_type
@@ -135,7 +135,7 @@ class Element(BaseEntity):
     @property
     def dialog(self):
         """ Returns parent object - Dialog"""
-        from .service_dialogs import Dialog
+        from cfme.automate.dialogs.service_dialogs import Dialog
         return parent_of_type(self, Dialog)
 
     def element_loc(self, element_type):

--- a/cfme/automate/dialogs/dialog_tab.py
+++ b/cfme/automate/dialogs/dialog_tab.py
@@ -2,9 +2,8 @@ import attr
 from navmazing import NavigateToAttribute
 from widgetastic.widget import Text
 
-from . import AddTabView
-from . import TabForm
-from .dialog_box import BoxCollection
+from cfme.automate.dialogs import AddTabView
+from cfme.automate.dialogs import TabForm
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.modeling.base import parent_of_type
@@ -40,6 +39,7 @@ class Tab(BaseEntity):
     tab_label = attr.ib()
     tab_desc = attr.ib(default=None)
 
+    from cfme.automate.dialogs.dialog_box import BoxCollection
     _collections = {'boxes': BoxCollection}
 
     @property
@@ -53,7 +53,7 @@ class Tab(BaseEntity):
     @property
     def dialog(self):
         """ Returns parent object - Dialog"""
-        from .service_dialogs import Dialog
+        from cfme.automate.dialogs.service_dialogs import Dialog
         return parent_of_type(self, Dialog)
 
 

--- a/cfme/automate/dialogs/service_dialogs.py
+++ b/cfme/automate/dialogs/service_dialogs.py
@@ -5,10 +5,10 @@ from navmazing import NavigateToSibling
 from widgetastic.utils import Fillable
 from widgetastic.widget import Text
 
-from . import AddDialogView
-from . import AutomateCustomizationView
-from . import EditDialogView
-from .dialog_tab import TabCollection
+from cfme.automate.dialogs import AddDialogView
+from cfme.automate.dialogs import AutomateCustomizationView
+from cfme.automate.dialogs import EditDialogView
+from cfme.automate.dialogs.dialog_tab import TabCollection
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -12,7 +12,7 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Input
 
-from . import AutomateExplorerView
+from cfme.automate.explorer import AutomateExplorerView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -112,7 +112,7 @@ class Domain(BaseEntity, Fillable):
     def __init__(
             self, collection, name, description=None, enabled=None, locked=None,
             git_repository=None, git_checkout_type=None, git_checkout_value=None, db_id=None):
-        from .namespace import NamespaceCollection
+        from cfme.automate.explorer.namespace import NamespaceCollection
         self._collections = {'namespaces': NamespaceCollection}
         super(Domain, self).__init__(collection)
         self.name = name

--- a/cfme/automate/explorer/instance.py
+++ b/cfme/automate/explorer/instance.py
@@ -12,11 +12,11 @@ from widgetastic.widget import Text
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import AutomateExplorerView
-from . import check_tree_path
-from .common import Copiable
-from .common import CopyViewBase
-from .klass import ClassDetailsView
+from cfme.automate.explorer import AutomateExplorerView
+from cfme.automate.explorer import check_tree_path
+from cfme.automate.explorer.common import Copiable
+from cfme.automate.explorer.common import CopyViewBase
+from cfme.automate.explorer.klass import ClassDetailsView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity

--- a/cfme/automate/explorer/klass.py
+++ b/cfme/automate/explorer/klass.py
@@ -15,11 +15,11 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import AutomateExplorerView
-from . import check_tree_path
-from .common import Copiable
-from .common import CopyViewBase
-from .namespace import NamespaceDetailsView
+from cfme.automate.explorer import AutomateExplorerView
+from cfme.automate.explorer import check_tree_path
+from cfme.automate.explorer.common import Copiable
+from cfme.automate.explorer.common import CopyViewBase
+from cfme.automate.explorer.namespace import NamespaceDetailsView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -114,8 +114,8 @@ class ClassEditView(ClassForm):
 
 class Class(BaseEntity, Copiable):
     def __init__(self, collection, name, display_name=None, description=None):
-        from .instance import InstanceCollection
-        from .method import MethodCollection
+        from cfme.automate.explorer.instance import InstanceCollection
+        from cfme.automate.explorer.method import MethodCollection
         self._collections = {
             'instances': InstanceCollection,
             'methods': MethodCollection

--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -16,11 +16,11 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import BootstrapSwitch
 from widgetastic_patternfly import Button
 
-from . import AutomateExplorerView
-from . import check_tree_path
-from .common import Copiable
-from .common import CopyViewBase
-from .klass import ClassDetailsView
+from cfme.automate.explorer import AutomateExplorerView
+from cfme.automate.explorer import check_tree_path
+from cfme.automate.explorer.common import Copiable
+from cfme.automate.explorer.common import CopyViewBase
+from cfme.automate.explorer.klass import ClassDetailsView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity

--- a/cfme/automate/explorer/namespace.py
+++ b/cfme/automate/explorer/namespace.py
@@ -7,10 +7,10 @@ from widgetastic.widget import Text
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import AutomateExplorerView
-from . import check_tree_path
-from .domain import Domain
-from .domain import DomainDetailsView
+from cfme.automate.explorer import AutomateExplorerView
+from cfme.automate.explorer import check_tree_path
+from cfme.automate.explorer.domain import Domain
+from cfme.automate.explorer.domain import DomainDetailsView
 from cfme.exceptions import ItemNotFound
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -81,7 +81,7 @@ class NamespaceEditView(NamespaceForm):
 class Namespace(BaseEntity):
 
     def __init__(self, collection, name, description=None):
-        from .klass import ClassCollection
+        from cfme.automate.explorer.klass import ClassCollection
         self._collections = {
             'namespaces': NamespaceCollection,
             'classes': ClassCollection

--- a/cfme/automate/provisioning_dialogs.py
+++ b/cfme/automate/provisioning_dialogs.py
@@ -8,7 +8,7 @@ from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Dropdown
 
-from . import AutomateCustomizationView
+from cfme.automate import AutomateCustomizationView
 from cfme.base.login import BaseLoggedInPage
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity

--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -366,7 +366,7 @@ class RegionCollection(BaseCollection, sentaku.modeling.ElementMixin):
         return regions
 
 
-from . import ui, ssui, rest  # NOQA last for import cycles
+from cfme.base import ui, ssui, rest  # NOQA last for import cycles
 importscan.scan(ui)
 importscan.scan(ssui)
 importscan.scan(rest)

--- a/cfme/base/ssui.py
+++ b/cfme/base/ssui.py
@@ -10,7 +10,7 @@ from widgetastic_patternfly import NavDropdown
 from widgetastic_patternfly import Text
 from widgetastic_patternfly.utils import PFIcon
 
-from . import Server
+from cfme.base import Server
 from cfme.base.credential import Credential
 from cfme.utils import conf
 from cfme.utils.appliance import MiqImplementationContext

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -19,10 +19,10 @@ from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import FlashMessages
 from widgetastic_patternfly import Input
 
-from . import Region
-from . import Server
-from . import Zone
-from . import ZoneCollection
+from cfme.base import Region
+from cfme.base import Server
+from cfme.base import Zone
+from cfme.base import ZoneCollection
 from cfme.base.credential import Credential
 from cfme.base.login import BaseLoggedInPage
 from cfme.configure.about import AboutView

--- a/cfme/cloud/instance/azure.py
+++ b/cfme/cloud/instance/azure.py
@@ -2,8 +2,8 @@
 import attr
 from riggerlib import recursive_update
 
-from . import Instance
-from . import InstanceCollection
+from cfme.cloud.instance import Instance
+from cfme.cloud.instance import InstanceCollection
 
 
 @attr.s

--- a/cfme/cloud/instance/ec2.py
+++ b/cfme/cloud/instance/ec2.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import attr
 
-from . import Instance
-from . import InstanceCollection
+from cfme.cloud.instance import Instance
+from cfme.cloud.instance import InstanceCollection
 
 
 @attr.s

--- a/cfme/cloud/instance/gce.py
+++ b/cfme/cloud/instance/gce.py
@@ -2,8 +2,8 @@
 import attr
 from riggerlib import recursive_update
 
-from . import Instance
-from . import InstanceCollection
+from cfme.cloud.instance import Instance
+from cfme.cloud.instance import InstanceCollection
 
 
 @attr.s

--- a/cfme/cloud/instance/image.py
+++ b/cfme/cloud/instance/image.py
@@ -6,8 +6,8 @@ from widgetastic.widget import View
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Dropdown
 
-from . import CloudInstanceView
-from . import InstanceAccordion
+from cfme.cloud.instance import CloudInstanceView
+from cfme.cloud.instance import InstanceAccordion
 from cfme.common.vm import Template
 from cfme.common.vm import TemplateCollection
 from cfme.common.vm_views import BasicProvisionFormView

--- a/cfme/cloud/instance/openstack.py
+++ b/cfme/cloud/instance/openstack.py
@@ -8,9 +8,9 @@ from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 
-from . import CloudInstanceView
-from . import Instance
-from . import InstanceCollection
+from cfme.cloud.instance import CloudInstanceView
+from cfme.cloud.instance import Instance
+from cfme.cloud.instance import InstanceCollection
 from cfme.common.vm_views import RightSizeView
 from cfme.exceptions import DestinationNotFound
 from cfme.exceptions import displayed_not_implemented

--- a/cfme/cloud/provider/azure.py
+++ b/cfme/cloud/provider/azure.py
@@ -1,8 +1,8 @@
 import attr
 from wrapanapi.systems import AzureSystem
 
-from . import CloudProvider
 from cfme.cloud.instance.azure import AzureInstance
+from cfme.cloud.provider import CloudProvider
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.provider import DefaultEndpointForm
 from cfme.infrastructure.provider.rhevm import RHEVMVMUtilizationView

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -5,8 +5,8 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 from wrapanapi.systems import EC2System
 
-from . import CloudProvider
 from cfme.cloud.instance.ec2 import EC2Instance
+from cfme.cloud.provider import CloudProvider
 from cfme.common.candu_views import AzoneCloudUtilizationView
 from cfme.common.candu_views import VMUtilizationView
 from cfme.common.provider import DefaultEndpoint

--- a/cfme/cloud/provider/gce.py
+++ b/cfme/cloud/provider/gce.py
@@ -4,9 +4,9 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 from wrapanapi.systems import GoogleCloudSystem
 
-from . import CloudProvider
 from cfme.base.credential import ServiceAccountCredential
 from cfme.cloud.instance.gce import GCEInstance
+from cfme.cloud.provider import CloudProvider
 from cfme.common.provider import DefaultEndpoint
 from cfme.services.catalogs.catalog_items import GoogleCatalogItem
 

--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -1,8 +1,8 @@
 import attr
 from wrapanapi.systems import OpenstackSystem
 
-from . import CloudProvider
 from cfme.cloud.instance.openstack import OpenStackInstance
+from cfme.cloud.provider import CloudProvider
 from cfme.common.provider import EventsEndpoint
 from cfme.common.provider import SSHEndpoint
 from cfme.exceptions import ItemNotFound

--- a/cfme/cloud/provider/vcloud.py
+++ b/cfme/cloud/provider/vcloud.py
@@ -3,7 +3,7 @@ from widgetastic.widget import View
 from widgetastic_patternfly import Input
 from wrapanapi.systems import VmwareCloudSystem
 
-from . import CloudProvider
+from cfme.cloud.provider import CloudProvider
 from cfme.common.provider import Credential
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.provider import DefaultEndpointForm

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -9,9 +9,9 @@ import attr
 from cached_property import cached_property
 from riggerlib import recursive_update
 
-from . import PolicyProfileAssignable
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import CustomButtonEventsMixin
+from cfme.common import PolicyProfileAssignable
 from cfme.common import Taggable
 from cfme.common.vm_console import ConsoleMixin
 from cfme.common.vm_views import DriftAnalysis

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -5,12 +5,12 @@ from cached_property import cached_property
 from six.moves.urllib.error import URLError
 from wrapanapi.systems.container import Openshift
 
-from . import ContainersProvider
-from . import ContainersProviderDefaultEndpoint
-from . import ContainersProviderEndpointsForm
 from cfme.common import Taggable
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.vm_console import ConsoleMixin
+from cfme.containers.provider import ContainersProvider
+from cfme.containers.provider import ContainersProviderDefaultEndpoint
+from cfme.containers.provider import ContainersProviderEndpointsForm
 from cfme.control.explorer.alert_profiles import NodeAlertProfile
 from cfme.control.explorer.alert_profiles import ProviderAlertProfile
 from cfme.utils import ssh

--- a/cfme/control/__init__.py
+++ b/cfme/control/__init__.py
@@ -1,4 +1,4 @@
-from . import explorer  # noqa: F401
-from . import import_export  # noqa: F401
-from . import log  # noqa: F401
-from . import simulation  # noqa: F401
+from cfme.control import explorer  # noqa: F401
+from cfme.control import import_export  # noqa: F401
+from cfme.control import log  # noqa: F401
+from cfme.control import simulation  # noqa: F401

--- a/cfme/control/explorer/actions.py
+++ b/cfme/control/explorer/actions.py
@@ -11,7 +11,7 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import ControlExplorerView
+from cfme.control.explorer import ControlExplorerView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/control/explorer/alert_profiles.py
+++ b/cfme/control/explorer/alert_profiles.py
@@ -9,7 +9,7 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import CheckableBootstrapTreeview as CbTree
 from widgetastic_patternfly import Input
 
-from . import ControlExplorerView
+from cfme.control.explorer import ControlExplorerView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils import ParamClassName

--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -15,8 +15,8 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 from widgetastic_patternfly import SelectorDropdown
 
-from . import ControlExplorerView
 from cfme.base.login import BaseLoggedInPage
+from cfme.control.explorer import ControlExplorerView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/control/explorer/conditions.py
+++ b/cfme/control/explorer/conditions.py
@@ -9,7 +9,7 @@ from widgetastic.widget import Widget
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import ControlExplorerView
+from cfme.control.explorer import ControlExplorerView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils import ParamClassName

--- a/cfme/control/explorer/policies.py
+++ b/cfme/control/explorer/policies.py
@@ -14,8 +14,8 @@ from widgetastic.widget import View
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import ControlExplorerView
-from .actions import Action
+from cfme.control.explorer import ControlExplorerView
+from cfme.control.explorer.actions import Action
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils import ParamClassName

--- a/cfme/control/explorer/policy_profiles.py
+++ b/cfme/control/explorer/policy_profiles.py
@@ -8,7 +8,7 @@ from widgetastic.widget import TextInput
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import ControlExplorerView
+from cfme.control.explorer import ControlExplorerView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/dashboard.py
+++ b/cfme/dashboard.py
@@ -16,7 +16,7 @@ from widgetastic.xpath import quote
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Dropdown
 
-from .base.login import BaseLoggedInPage
+from cfme.base.login import BaseLoggedInPage
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/fixtures/node_annotate.py
+++ b/cfme/fixtures/node_annotate.py
@@ -6,7 +6,7 @@ import py
 import pytest
 import yaml
 
-from .pytest_store import store
+from cfme.fixtures.pytest_store import store
 from cfme.utils.conf import cfme_data
 from cfme.utils.path import project_path
 

--- a/cfme/fixtures/parallelizer/__init__.py
+++ b/cfme/fixtures/parallelizer/__init__.py
@@ -64,7 +64,7 @@ if not conf.runtime['env'].get('ts'):
 
 
 def pytest_addhooks(pluginmanager):
-    from . import hooks
+    from cfme.fixtures.parallelizer import hooks
     pluginmanager.add_hookspecs(hooks)
 
 

--- a/cfme/generic_objects/definition/__init__.py
+++ b/cfme/generic_objects/definition/__init__.py
@@ -48,6 +48,6 @@ class GenericObjectDefinitionCollection(BaseCollection, sentaku.modeling.Element
     create = sentaku.ContextualMethod()
 
 
-from . import rest, ui  # NOQA last for import cycles
+from cfme.generic_objects.definition import rest, ui  # NOQA last for import cycles
 importscan.scan(rest)
 importscan.scan(ui)

--- a/cfme/generic_objects/definition/button_groups.py
+++ b/cfme/generic_objects/definition/button_groups.py
@@ -1,13 +1,13 @@
 import attr
 from navmazing import NavigateToAttribute
 
-from .definition_views import GenericObjectActionsDetailsView
-from .definition_views import GenericObjectAddButtonView
-from .definition_views import GenericObjectButtonGroupAddView
-from .definition_views import GenericObjectButtonGroupDetailsView
-from .definition_views import GenericObjectDefinitionAllView
-from .definition_views import GenericObjectDefinitionDetailsView
 from cfme.exceptions import OptionNotAvailable
+from cfme.generic_objects.definition.definition_views import GenericObjectActionsDetailsView
+from cfme.generic_objects.definition.definition_views import GenericObjectAddButtonView
+from cfme.generic_objects.definition.definition_views import GenericObjectButtonGroupAddView
+from cfme.generic_objects.definition.definition_views import GenericObjectButtonGroupDetailsView
+from cfme.generic_objects.definition.definition_views import GenericObjectDefinitionAllView
+from cfme.generic_objects.definition.definition_views import GenericObjectDefinitionDetailsView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/generic_objects/definition/ui.py
+++ b/cfme/generic_objects/definition/ui.py
@@ -2,13 +2,13 @@ from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
 from widgetastic_patternfly import CandidateNotFound
 
-from . import GenericObjectDefinition
-from . import GenericObjectDefinitionCollection
-from .definition_views import GenericObjectDefinitionAddView
-from .definition_views import GenericObjectDefinitionAllView
-from .definition_views import GenericObjectDefinitionDetailsView
-from .definition_views import GenericObjectDefinitionEditView
 from cfme.exceptions import ItemNotFound
+from cfme.generic_objects.definition import GenericObjectDefinition
+from cfme.generic_objects.definition import GenericObjectDefinitionCollection
+from cfme.generic_objects.definition.definition_views import GenericObjectDefinitionAddView
+from cfme.generic_objects.definition.definition_views import GenericObjectDefinitionAllView
+from cfme.generic_objects.definition.definition_views import GenericObjectDefinitionDetailsView
+from cfme.generic_objects.definition.definition_views import GenericObjectDefinitionEditView
 from cfme.generic_objects.instance.ui import GenericObjectInstanceAllView
 from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/generic_objects/instance/__init__.py
+++ b/cfme/generic_objects/instance/__init__.py
@@ -38,6 +38,6 @@ class GenericObjectInstanceCollection(BaseCollection, sentaku.modeling.ElementMi
     create = sentaku.ContextualMethod()
 
 
-from . import rest, ui  # NOQA last for import cycles
+from cfme.generic_objects.instance import rest, ui  # NOQA last for import cycles
 importscan.scan(rest)
 importscan.scan(ui)

--- a/cfme/generic_objects/instance/ui.py
+++ b/cfme/generic_objects/instance/ui.py
@@ -8,11 +8,11 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Dropdown
 
-from . import GenericObjectInstance
-from . import GenericObjectInstanceCollection
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import Taggable
 from cfme.common import TagPageView
+from cfme.generic_objects.instance import GenericObjectInstance
+from cfme.generic_objects.instance import GenericObjectInstanceCollection
 from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to

--- a/cfme/infrastructure/provider/kubevirt.py
+++ b/cfme/infrastructure/provider/kubevirt.py
@@ -1,7 +1,7 @@
 import attr
 
-from . import InfraProvider
 from cfme.containers.provider.openshift import VirtualizationEndpoint
+from cfme.infrastructure.provider import InfraProvider
 from cfme.utils.providers import get_crud
 
 

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -7,13 +7,13 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 from wrapanapi.systems import RHEVMSystem
 
-from . import InfraProvider
 from cfme.common.candu_views import VMUtilizationView
 from cfme.common.provider import CANDUEndpoint
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.provider import DefaultEndpointForm
 from cfme.common.provider_views import BeforeFillMixin
 from cfme.exceptions import ItemNotFound
+from cfme.infrastructure.provider import InfraProvider
 from cfme.services.catalogs.catalog_items import RHVCatalogItem
 from widgetastic_manageiq import LineChart
 from widgetastic_manageiq import WaitTab

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -3,9 +3,9 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Input
 from wrapanapi.systems import SCVMMSystem
 
-from . import InfraProvider
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.provider import DefaultEndpointForm
+from cfme.infrastructure.provider import InfraProvider
 from cfme.services.catalogs.catalog_items import SCVMMCatalogItem
 
 

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -2,11 +2,11 @@ import attr
 from widgetastic.exceptions import NoSuchElementException
 from wrapanapi.systems import VMWareSystem
 
-from . import InfraProvider
 from cfme.common.candu_views import VMUtilizationView
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.provider import DefaultEndpointForm
 from cfme.exceptions import ItemNotFound
+from cfme.infrastructure.provider import InfraProvider
 from cfme.services.catalogs.catalog_items import VMwareCatalogItem
 from widgetastic_manageiq import LineChart
 

--- a/cfme/intelligence/chargeback/assignments.py
+++ b/cfme/intelligence/chargeback/assignments.py
@@ -6,7 +6,7 @@ from widgetastic.widget import Text
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 
-from . import ChargebackView
+from cfme.intelligence.chargeback import ChargebackView
 from cfme.utils.appliance import Navigatable
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to

--- a/cfme/intelligence/chargeback/rates.py
+++ b/cfme/intelligence/chargeback/rates.py
@@ -16,8 +16,8 @@ from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import Input
 
-from . import ChargebackView
 from cfme.exceptions import ChargebackRateNotFound
+from cfme.intelligence.chargeback import ChargebackView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils import ParamClassName

--- a/cfme/intelligence/reports/dashboards.py
+++ b/cfme/intelligence/reports/dashboards.py
@@ -8,7 +8,7 @@ from widgetastic.widget import Text
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import CloudIntelReportsView
+from cfme.intelligence.reports import CloudIntelReportsView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance import Navigatable

--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -7,8 +7,8 @@ from navmazing import NavigateToAttribute
 from widgetastic.widget import Text
 from widgetastic_patternfly import Button
 
-from . import CloudIntelReportsView
-from . import ReportsMultiBoxSelect
+from cfme.intelligence.reports import CloudIntelReportsView
+from cfme.intelligence.reports import ReportsMultiBoxSelect
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -17,8 +17,8 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import CloudIntelReportsView
-from . import ReportsMultiBoxSelect
+from cfme.intelligence.reports import CloudIntelReportsView
+from cfme.intelligence.reports import ReportsMultiBoxSelect
 from cfme.intelligence.reports.schedules import SchedulesFormCommon
 from cfme.intelligence.timelines import CloudIntelTimelinesView
 from cfme.modeling.base import BaseCollection

--- a/cfme/intelligence/reports/saved.py
+++ b/cfme/intelligence/reports/saved.py
@@ -3,8 +3,8 @@ import attr
 from navmazing import NavigateToAttribute
 from widgetastic.widget import Text
 
-from . import CloudIntelReportsView
-from .reports import SavedReportDetailsView as BaseSavedReportDetailsView
+from cfme.intelligence.reports import CloudIntelReportsView
+from cfme.intelligence.reports.reports import SavedReportDetailsView as BaseSavedReportDetailsView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -12,7 +12,7 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import FlashMessages
 
-from . import CloudIntelReportsView
+from cfme.intelligence.reports import CloudIntelReportsView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep

--- a/cfme/intelligence/reports/widgets/chart_widgets.py
+++ b/cfme/intelligence/reports/widgets/chart_widgets.py
@@ -3,12 +3,12 @@
 import attr
 from widgetastic_patternfly import BootstrapSelect
 
-from . import BaseDashboardReportWidget
-from . import BaseDashboardWidgetFormCommon
-from . import BaseEditDashboardWidgetStep
-from . import BaseEditDashboardWidgetView
-from . import BaseNewDashboardWidgetStep
-from . import BaseNewDashboardWidgetView
+from cfme.intelligence.reports.widgets import BaseDashboardReportWidget
+from cfme.intelligence.reports.widgets import BaseDashboardWidgetFormCommon
+from cfme.intelligence.reports.widgets import BaseEditDashboardWidgetStep
+from cfme.intelligence.reports.widgets import BaseEditDashboardWidgetView
+from cfme.intelligence.reports.widgets import BaseNewDashboardWidgetStep
+from cfme.intelligence.reports.widgets import BaseNewDashboardWidgetView
 from cfme.utils.appliance.implementations.ui import navigator
 from widgetastic_manageiq import Calendar
 

--- a/cfme/intelligence/reports/widgets/menu_widgets.py
+++ b/cfme/intelligence/reports/widgets/menu_widgets.py
@@ -2,12 +2,12 @@
 """Page model for Cloud Intel / Reports / Dashboard Widgets / Menus"""
 import attr
 
-from . import BaseDashboardReportWidget
-from . import BaseDashboardWidgetFormCommon
-from . import BaseEditDashboardWidgetStep
-from . import BaseEditDashboardWidgetView
-from . import BaseNewDashboardWidgetStep
-from . import BaseNewDashboardWidgetView
+from cfme.intelligence.reports.widgets import BaseDashboardReportWidget
+from cfme.intelligence.reports.widgets import BaseDashboardWidgetFormCommon
+from cfme.intelligence.reports.widgets import BaseEditDashboardWidgetStep
+from cfme.intelligence.reports.widgets import BaseEditDashboardWidgetView
+from cfme.intelligence.reports.widgets import BaseNewDashboardWidgetStep
+from cfme.intelligence.reports.widgets import BaseNewDashboardWidgetView
 from cfme.utils.appliance.implementations.ui import navigator
 from widgetastic_manageiq import MenuShortcutsPicker
 

--- a/cfme/intelligence/reports/widgets/report_widgets.py
+++ b/cfme/intelligence/reports/widgets/report_widgets.py
@@ -3,12 +3,12 @@
 import attr
 from widgetastic_patternfly import BootstrapSelect
 
-from . import BaseDashboardReportWidget
-from . import BaseDashboardWidgetFormCommon
-from . import BaseEditDashboardWidgetStep
-from . import BaseEditDashboardWidgetView
-from . import BaseNewDashboardWidgetStep
-from . import BaseNewDashboardWidgetView
+from cfme.intelligence.reports.widgets import BaseDashboardReportWidget
+from cfme.intelligence.reports.widgets import BaseDashboardWidgetFormCommon
+from cfme.intelligence.reports.widgets import BaseEditDashboardWidgetStep
+from cfme.intelligence.reports.widgets import BaseEditDashboardWidgetView
+from cfme.intelligence.reports.widgets import BaseNewDashboardWidgetStep
+from cfme.intelligence.reports.widgets import BaseNewDashboardWidgetView
 from cfme.utils.appliance.implementations.ui import navigator
 from widgetastic_manageiq import Calendar
 

--- a/cfme/intelligence/reports/widgets/rss_widgets.py
+++ b/cfme/intelligence/reports/widgets/rss_widgets.py
@@ -4,12 +4,12 @@ import attr
 from widgetastic.widget import TextInput
 from widgetastic_patternfly import BootstrapSelect
 
-from . import BaseDashboardReportWidget
-from . import BaseDashboardWidgetFormCommon
-from . import BaseEditDashboardWidgetStep
-from . import BaseEditDashboardWidgetView
-from . import BaseNewDashboardWidgetStep
-from . import BaseNewDashboardWidgetView
+from cfme.intelligence.reports.widgets import BaseDashboardReportWidget
+from cfme.intelligence.reports.widgets import BaseDashboardWidgetFormCommon
+from cfme.intelligence.reports.widgets import BaseEditDashboardWidgetStep
+from cfme.intelligence.reports.widgets import BaseEditDashboardWidgetView
+from cfme.intelligence.reports.widgets import BaseNewDashboardWidgetStep
+from cfme.intelligence.reports.widgets import BaseNewDashboardWidgetView
 from cfme.utils.appliance.implementations.ui import navigator
 from widgetastic_manageiq import Calendar
 

--- a/cfme/networks/provider/nuage.py
+++ b/cfme/networks/provider/nuage.py
@@ -7,12 +7,12 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 from wrapanapi.systems import NuageSystem
 
-from . import NetworkProvider
 from cfme.cloud.tenant import TenantCollection
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.provider import DefaultEndpointForm
 from cfme.common.provider import EventsEndpoint
 from cfme.common.provider_views import BeforeFillMixin
+from cfme.networks.provider import NetworkProvider
 from cfme.networks.security_group import SecurityGroupCollection
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.varmeth import variable

--- a/cfme/optimize/bottlenecks.py
+++ b/cfme/optimize/bottlenecks.py
@@ -7,9 +7,9 @@ from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect
 
-from . import BottlenecksView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
+from cfme.optimize import BottlenecksView
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator

--- a/cfme/physical/provider/lenovo.py
+++ b/cfme/physical/provider/lenovo.py
@@ -2,9 +2,9 @@ import attr
 from widgetastic_patternfly import Input
 from wrapanapi.systems import LenovoSystem
 
-from . import PhysicalProvider
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.provider import DefaultEndpointForm
+from cfme.physical.provider import PhysicalProvider
 
 
 class LenovoEndpoint(DefaultEndpoint):

--- a/cfme/physical/provider/redfish.py
+++ b/cfme/physical/provider/redfish.py
@@ -6,7 +6,6 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Input
 from wrapanapi.systems import RedfishSystem
 
-from . import PhysicalProvider
 from cfme.common.provider import DefaultEndpoint
 from cfme.common.provider import DefaultEndpointForm
 from cfme.exceptions import HostStatsNotContains
@@ -18,6 +17,7 @@ from cfme.physical.physical_rack import PhysicalRack
 from cfme.physical.physical_rack import PhysicalRackCollection
 from cfme.physical.physical_server import PhysicalServer
 from cfme.physical.physical_server import PhysicalServerCollection
+from cfme.physical.provider import PhysicalProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.varmeth import variable

--- a/cfme/scripting/conf.py
+++ b/cfme/scripting/conf.py
@@ -12,7 +12,7 @@ import io
 import click
 import yaycl_crypt
 
-from . import link_config
+from cfme.scripting import link_config
 from cfme.utils import conf
 
 

--- a/cfme/scripting/ipyshell.py
+++ b/cfme/scripting/ipyshell.py
@@ -15,7 +15,7 @@ IMPORTS = [
 def main(no_quickstart):
     """Use quickstart to ensure we have correct env, then execute imports in ipython and done."""
     if not no_quickstart:
-        from . import quickstart
+        from cfme.scripting import quickstart
 
         quickstart.main(quickstart.args_for_current_venv())
     print('Welcome to IPython designed for running CFME QE code.')

--- a/cfme/scripting/quickstart/__init__.py
+++ b/cfme/scripting/quickstart/__init__.py
@@ -5,9 +5,9 @@ import os
 import subprocess
 import sys
 
-from .proc import PRISTINE_ENV
-from .proc import run_cmd_or_exit
-from .system import install_system_packages
+from cfme.scripting.quickstart.proc import PRISTINE_ENV
+from cfme.scripting.quickstart.proc import run_cmd_or_exit
+from cfme.scripting.quickstart.system import install_system_packages
 
 CREATED = object()
 

--- a/cfme/scripting/quickstart/__main__.py
+++ b/cfme/scripting/quickstart/__main__.py
@@ -1,8 +1,8 @@
 import sys
 
-from . import IN_VIRTUAL_ENV
-from . import main
-from . import mk_parser
+from cfme.scripting.quickstart import IN_VIRTUAL_ENV
+from cfme.scripting.quickstart import main
+from cfme.scripting.quickstart import mk_parser
 IS_SCRIPT = sys.argv[0] == __file__
 
 if IS_SCRIPT:

--- a/cfme/scripting/quickstart/system.py
+++ b/cfme/scripting/quickstart/system.py
@@ -2,7 +2,7 @@ import os
 import re
 import time
 
-from . import run_cmd_or_exit
+from cfme.scripting.quickstart import run_cmd_or_exit
 
 IS_ROOT = os.getuid() == 0
 REDHAT_RELEASE_FILE = '/etc/redhat-release'

--- a/cfme/scripting/runtest.py
+++ b/cfme/scripting/runtest.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-from . import quickstart
+from cfme.scripting import quickstart
 QUICKSTART_DONE = 'MIQ_RUNTEST_QUICKSTART_DONE'
 
 

--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -6,10 +6,10 @@ from widgetastic.widget import Text
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import ServicesCatalogView
 from cfme.common import Taggable
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
+from cfme.services.catalogs import ServicesCatalogView
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator

--- a/cfme/services/catalogs/catalog_items/ansible_catalog_items.py
+++ b/cfme/services/catalogs/catalog_items/ansible_catalog_items.py
@@ -13,8 +13,8 @@ from widgetastic_patternfly import BootstrapSwitch
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import BaseCatalogItem
 from cfme.services.catalogs import ServicesCatalogView
+from cfme.services.catalogs.catalog_items import BaseCatalogItem
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigator
 from widgetastic_manageiq import FileInput

--- a/cfme/services/catalogs/catalog_items/catalog_bundles.py
+++ b/cfme/services/catalogs/catalog_items/catalog_bundles.py
@@ -6,12 +6,12 @@ from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 
-from . import AllCatalogItemView
-from . import BasicInfoForm
-from . import DetailsCatalogItemView
-from . import NonCloudInfraCatalogItem
-from . import ServicesCatalogView
 from cfme.modeling.base import BaseCollection
+from cfme.services.catalogs.catalog_items import AllCatalogItemView
+from cfme.services.catalogs.catalog_items import BasicInfoForm
+from cfme.services.catalogs.catalog_items import DetailsCatalogItemView
+from cfme.services.catalogs.catalog_items import NonCloudInfraCatalogItem
+from cfme.services.catalogs.catalog_items import ServicesCatalogView
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator

--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -9,10 +9,10 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import ServicesCatalogView
 from cfme.common import Taggable
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
+from cfme.services.catalogs import ServicesCatalogView
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator

--- a/cfme/services/dashboard/__init__.py
+++ b/cfme/services/dashboard/__init__.py
@@ -24,5 +24,5 @@ class Dashboard(Navigatable, sentaku.modeling.ElementMixin):
         self.parent = self.appliance.context
 
 
-from . import ssui  # NOQA last for import cycles
+from cfme.services.dashboard import ssui  # NOQA last for import cycles
 importscan.scan(ssui)

--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -35,6 +35,6 @@ class MyService(Updateable, Navigatable, Taggable, sentaku.modeling.ElementMixin
         self.parent = self.appliance.context
 
 
-from . import ui, ssui  # NOQA last for import cycles
+from cfme.services.myservice import ui, ssui  # NOQA last for import cycles
 importscan.scan(ui)
 importscan.scan(ssui)

--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -8,9 +8,9 @@ from widgetastic.widget import Text
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
-from . import MyService
 from cfme.base.ssui import SSUIBaseLoggedInPage
 from cfme.dashboard import Kebab
+from cfme.services.myservice import MyService
 from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ssui import navigate_to
 from cfme.utils.appliance.implementations.ssui import navigator

--- a/cfme/services/service_catalogs/__init__.py
+++ b/cfme/services/service_catalogs/__init__.py
@@ -99,6 +99,6 @@ class BaseOrderForm(View):
         return was_change
 
 
-from . import ui, ssui  # NOQA last for import cycles
+from cfme.services.service_catalogs import ui, ssui  # NOQA last for import cycles
 importscan.scan(ui)
 importscan.scan(ssui)

--- a/cfme/test_framework/appliance.py
+++ b/cfme/test_framework/appliance.py
@@ -55,7 +55,7 @@ def pytest_configure(config):
         appliances = appliances_from_cli(config.option.appliances, config.option.appliance_version)
         reporter.write_line('Retrieved these appliances from the --appliance parameters', red=True)
     elif config.getoption('--use-sprout'):
-        from .sprout.plugin import mangle_in_sprout_appliances
+        from cfme.test_framework.sprout.plugin import mangle_in_sprout_appliances
 
         mangle_in_sprout_appliances(config)
         # TODO : handle direct sprout pass on?

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -15,8 +15,6 @@ import fauxfactory
 import pytest
 from wrapanapi import VmState
 
-from . import do_scan
-from . import wait_for_ssa_enabled
 from cfme import test_requirements
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.openstack import OpenStackProvider
@@ -25,6 +23,8 @@ from cfme.control.explorer import policies
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.tests.control import do_scan
+from cfme.tests.control import wait_for_ssa_enabled
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -6,8 +6,6 @@ import fauxfactory
 import pytest
 from wrapanapi import VmState
 
-from . import do_scan
-from . import wait_for_ssa_enabled
 from cfme import test_requirements
 from cfme.control.explorer import alert_profiles
 from cfme.control.explorer import policies
@@ -18,6 +16,8 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import providers
+from cfme.tests.control import do_scan
+from cfme.tests.control import wait_for_ssa_enabled
 from cfme.utils.conf import credentials
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -4,12 +4,12 @@ import fauxfactory
 import pytest
 from wrapanapi import VmState
 
-from . import do_scan
 from cfme import test_requirements
 from cfme.control.explorer.conditions import VMCondition
 from cfme.control.explorer.policies import HostCompliancePolicy
 from cfme.control.explorer.policies import VMCompliancePolicy
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.tests.control import do_scan
 from cfme.utils import conf
 from cfme.utils.update import update
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -30,18 +30,18 @@ from werkzeug.local import LocalStack
 from wrapanapi import VmState
 from wrapanapi.exceptions import VMInstanceNotFound
 
-from .db import ApplianceDB
-from .implementations.rest import ViaREST
-from .implementations.ssui import ViaSSUI
-from .implementations.ui import ViaUI
-from .services import SystemdException
-from .services import SystemdService
 from cfme.fixtures import ui_coverage
 from cfme.fixtures.pytest_store import store
 from cfme.utils import clear_property_cache
 from cfme.utils import conf
 from cfme.utils import ports
 from cfme.utils import ssh
+from cfme.utils.appliance.db import ApplianceDB
+from cfme.utils.appliance.implementations.rest import ViaREST
+from cfme.utils.appliance.implementations.ssui import ViaSSUI
+from cfme.utils.appliance.implementations.ui import ViaUI
+from cfme.utils.appliance.services import SystemdException
+from cfme.utils.appliance.services import SystemdService
 from cfme.utils.conf import hidden
 from cfme.utils.log import create_sublogger
 from cfme.utils.log import logger

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -176,7 +176,7 @@ class ApplianceDB(AppliancePlugin):
         Changed from Rake task due to a bug in 5.9
 
         """
-        from . import ApplianceException
+        from cfme.utils.appliance import ApplianceException
         self.logger.info('Backing up database')
         result = self.appliance.ssh_client.run_command(
             'pg_dump --format custom --file {} vmdb_production'.format(
@@ -190,7 +190,7 @@ class ApplianceDB(AppliancePlugin):
         """Restore VMDB database
 
         """
-        from . import ApplianceException
+        from cfme.utils.appliance import ApplianceException
         self.logger.info('Restoring database')
         result = self.appliance.ssh_client.run_rake_command(
             'evm:db:restore:local --trace -- --local-file "{}"'.format(database_path))
@@ -608,7 +608,7 @@ class ApplianceDB(AppliancePlugin):
             msg = ('Appliance {} failed to enable external DB running on {}'
                   .format(self.appliance.hostname, db_address))
             self.logger.error(msg)
-            from . import ApplianceException
+            from cfme.utils.appliance import ApplianceException
             raise ApplianceException(msg)
 
         return result.rc, result.output

--- a/cfme/utils/appliance/implementations/ssui.py
+++ b/cfme/utils/appliance/implementations/ssui.py
@@ -10,10 +10,10 @@ from selenium.common.exceptions import NoSuchElementException
 from widgetastic.browser import Browser
 from widgetastic.browser import DefaultPlugin
 
-from . import Implementation
-from .common import HandleModalsMixin
 from cfme import exceptions
 from cfme.fixtures.pytest_store import store
+from cfme.utils.appliance.implementations import Implementation
+from cfme.utils.appliance.implementations.common import HandleModalsMixin
 from cfme.utils.browser import manager
 from cfme.utils.log import create_sublogger
 from cfme.utils.log import logger

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -22,10 +22,10 @@ from widgetastic.utils import VersionPick
 from widgetastic.widget import Text
 from widgetastic.widget import View
 
-from . import Implementation
-from .common import HandleModalsMixin
 from cfme import exceptions
 from cfme.fixtures.pytest_store import store
+from cfme.utils.appliance.implementations import Implementation
+from cfme.utils.appliance.implementations.common import HandleModalsMixin
 from cfme.utils.browser import manager
 from cfme.utils.log import create_sublogger
 from cfme.utils.log import logger

--- a/cfme/utils/appliance/services.py
+++ b/cfme/utils/appliance/services.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import attr
 
-from .plugin import AppliancePlugin
-from .plugin import AppliancePluginException
+from cfme.utils.appliance.plugin import AppliancePlugin
+from cfme.utils.appliance.plugin import AppliancePluginException
 from cfme.utils.log import logger_wrap
 from cfme.utils.quote import quote
 from cfme.utils.wait import wait_for

--- a/cfme/utils/dockerbot/sel_container.py
+++ b/cfme/utils/dockerbot/sel_container.py
@@ -7,8 +7,8 @@ import click
 from wait_for import TimedOutError
 from wait_for import wait_for
 
-from .dockerbot import SeleniumDocker
 from cfme.utils.conf import docker as docker_conf
+from cfme.utils.dockerbot.dockerbot import SeleniumDocker
 from cfme.utils.net import random_port
 
 

--- a/cfme/utils/log_validator.py
+++ b/cfme/utils/log_validator.py
@@ -1,8 +1,8 @@
 import re
 from contextlib import contextmanager
 
-from .ssh import SSHTail
 from cfme.utils.log import logger
+from cfme.utils.ssh import SSHTail
 from cfme.utils.wait import wait_for
 
 

--- a/sprout/sprout/__init__.py
+++ b/sprout/sprout/__init__.py
@@ -5,7 +5,7 @@ try:
     import six.moves.cPickle as pickle
 except ImportError:
     import pickle
-from .celery import app as celery_app
+from sprout.sprout.celery import app as celery_app
 assert celery_app
 
 from django.core.cache import cache

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2379,9 +2379,9 @@ class AdvancedFilterUserInput(View):
 class AdvancedSearchView(View):
     """ Advanced Search View """
 
-    from . import expression_editor as exp_editor
+    from widgetastic_manageiq.expression_editor import ExpressionEditor
 
-    search_exp_editor = exp_editor.ExpressionEditor()
+    search_exp_editor = ExpressionEditor()
 
     load_filter_button = Button("Load")
     apply_filter_button = Button("Apply")


### PR DESCRIPTION
Remove relative imports to avoid warnings in py3 for resolving those imports.

I also happen to prefer explicit imports, fight me? Or just challenge this preference in a comment, and maybe we avoid these warnings another way if we want to allow them.