### PR TITLE
[1LP][RFR] Use non-binary NamedTemporaryFile (fixes TypeError)

### DIFF
--- a/cfme/utils/datafile.py
+++ b/cfme/utils/datafile.py
@@ -27,7 +27,7 @@ def load_data_file(filename, replacements=None):
 
         output = template.substitute(replacements)
 
-        outfile = NamedTemporaryFile()
+        outfile = NamedTemporaryFile(mode="w+")
         outfile.write(output)
         outfile.flush()
         outfile.seek(0)


### PR DESCRIPTION
This fixes

`E       TypeError: a bytes-like object is required, not 'str'`

{{pytest: cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py -k test_provision_cloud_init -v}}

Tests are failing for
`cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py::test_provision_cloud_init[ec2]`
but the other variants are fixed.

Also, there is https://github.com/ManageIQ/wrapanapi/pull/403 fixing wrapanapi issue with `next()`.