### PR TITLE
[1LP][RFR] removed workaround for BZ 1703744

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -13,7 +13,6 @@ from widgetastic_patternfly import Dropdown
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import TimelinesView
 from cfme.common.host_views import HostEntitiesView
-from cfme.utils.blockers import BZ
 from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import BaseEntitiesView
@@ -95,14 +94,9 @@ class ProviderDetailsView(BaseLoggedInPage):
             name=self.context['object'].name,
             subtitle=subtitle
         )
-        if BZ(1703744).blocks:
-            return (self.logged_in_as_current_user and
-                    self.breadcrumb.is_displayed and
-                    self.breadcrumb.active_location in title)
-        else:
-            return (self.logged_in_as_current_user and
-                    self.breadcrumb.is_displayed and
-                    self.breadcrumb.active_location == title)
+        return (self.logged_in_as_current_user and
+                self.breadcrumb.is_displayed and
+                self.breadcrumb.active_location == title)  # BZ 1703744
 
 
 class InfraProviderDetailsView(ProviderDetailsView):


### PR DESCRIPTION
## Purpose or Intent
The BZ is verified and the workaround is no longer needed. However, I'd like to keep the BZ number nearby as it helps with finding qe_test_coverage - I'm not sure which test exactly automates this check.