### PR TITLE
[RFR]Add tests: test_about_region AND test_about_zone

### DIFF
--- a/cfme/configure/about.py
+++ b/cfme/configure/about.py
@@ -13,6 +13,8 @@ ROLE = 'User Role'
 BROWSER = 'Browser'
 BROWSER_VERSION = 'Browser Version'
 BROWSER_OS = 'Browser OS'
+ZONE = "Zone"
+REGION = "Region"
 
 
 class MIQAboutModal(AboutModal):

--- a/cfme/tests/configure/test_about.py
+++ b/cfme/tests/configure/test_about.py
@@ -1,0 +1,44 @@
+import pytest
+
+from cfme import test_requirements
+from cfme.configure import about
+
+pytestmark = [test_requirements.general_ui]
+
+
+@pytest.mark.ignore_stream("5.10")
+@pytest.mark.meta(automates=[1402112])
+def test_about_region(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: WebUI
+        caseimportance: medium
+        initialEstimate: 1/4h
+        testSteps:
+            1. Open `About` modal and check the value of Region.
+
+    Bugzilla:
+        1402112
+    """
+    about_version = about.get_detail(about.REGION, appliance.server)
+    assert about_version == appliance.region()[-1]
+
+
+@pytest.mark.ignore_stream("5.10")
+@pytest.mark.meta(automates=[1402112])
+def test_about_zone(appliance):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: WebUI
+        caseimportance: medium
+        initialEstimate: 1/4h
+        testSteps:
+            1. Open `About` modal and check the value of Zone.
+
+    Bugzilla:
+        1402112
+    """
+    about_version = about.get_detail(about.ZONE, appliance.server)
+    assert about_version == appliance.server.zone.name


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__ test_about_zone and test_about_region that automates BZ 1402112, which adds zone and region information in the About modal. They were implemented in 5.11.

### PRT Run

{{ pytest: cfme/tests/configure/test_about.py -v }}