### PR TITLE
[1LP][RFR] fixed division in slicing

### DIFF
--- a/cfme/tests/networks/test_sdn_topology.py
+++ b/cfme/tests/networks/test_sdn_topology.py
@@ -38,7 +38,7 @@ def test_topology_search(request, elements_collection):
     elements = elements_collection.all()
     logger.info(str(elements))
     element_to_search = random.choice(elements)
-    search_term = element_to_search.name[:len(element_to_search.name) / 2]
+    search_term = element_to_search.name[:len(element_to_search.name) // 2]
     elements_collection.search(search_term)
     request.addfinalizer(elements_collection.clear_search)
     for element in elements:


### PR DESCRIPTION
## Purpose or Intent
py3 produced the error in  the error in `test_topology_search` tests

E       TypeError: slice indices must be integers or None or have an __index__ method

cfme/tests/networks/test_sdn_topology.py:41: TypeError
TypeError
b'slice indices must be integers or None or have an __index__ method'

### PRT Run

{{ pytest: -v cfme/tests/networks/test_sdn_topology.py::test_topology_search }}