### PR TITLE
[1LP][RFR] Remove use of six library

### DIFF
--- a/artifactor/plugins/filedump.py
+++ b/artifactor/plugins/filedump.py
@@ -14,8 +14,6 @@ import base64
 import os
 import re
 
-import six
-
 from artifactor import ArtifactorBasePlugin
 from cfme.utils import normalize_text
 from cfme.utils import safe_string
@@ -121,7 +119,7 @@ class Filedump(ArtifactorBasePlugin):
                 with open(filename) as f:
                     data = f.read()
                 for word in words:
-                    if not isinstance(word, six.string_types):
+                    if not isinstance(word, str):
                         word = str(word)
                     data = data.replace(word, "*" * len(word))
                 with open(filename, "w") as f:

--- a/artifactor/plugins/reporter.py
+++ b/artifactor/plugins/reporter.py
@@ -22,7 +22,6 @@ import shutil
 import time
 from copy import deepcopy
 
-import six
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
 from py.path import local
@@ -247,7 +246,7 @@ class ReporterBase(object):
         and the duration.
         """
 
-        if isinstance(path, six.string_types):
+        if isinstance(path, str):
             segs = process_pytest_path(path)
         else:
             segs = path

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import random
 
-import six
 from navmazing import NavigateToSibling
 from navmazing import NavigationDestinationNotFound
 from widgetastic.exceptions import NoSuchElementException
@@ -511,7 +510,7 @@ class Taggable(TaggableCommonBase):
         tags_text = tag_table.get_text_of(tenant)
         if tags_text != 'No {} have been assigned'.format(tenant):
             # check for users/groups page in case one tag string is returned
-            for tag in [tags_text] if isinstance(tags_text, six.string_types) else list(tags_text):
+            for tag in [tags_text] if isinstance(tags_text, str) else list(tags_text):
                 tag_category, tag_name = tag.split(':')
                 # instantiate category first, then use its tags collection to instantiate tag
                 tags_objs.append(
@@ -542,7 +541,7 @@ class TaggableCollection(TaggableCommonBase):
             try:
                 # setup a entities widget filter with the given key, using the item if its string
                 # or the item's attribute (given key) otherwise
-                entity_kwargs[entity_filter_key] = (item if isinstance(item, six.string_types)
+                entity_kwargs[entity_filter_key] = (item if isinstance(item, str)
                                                     else getattr(item, entity_filter_key))
             except AttributeError:
                 logger.exception('TaggableCollection item does not have attribute to search by: %s',
@@ -585,7 +584,7 @@ class TaggableCollection(TaggableCommonBase):
             try:
                 # setup a entities widget filter with the given key, using the item if its string
                 # or the item's attribute (given key) otherwise
-                entity_kwargs[entity_filter_key] = (item if isinstance(item, six.string_types)
+                entity_kwargs[entity_filter_key] = (item if isinstance(item, str)
                                                     else getattr(item, entity_filter_key))
             except AttributeError:
                 logger.exception('TaggableCollection item does not have attribute to search by: %s',

--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -1,5 +1,4 @@
 import attr
-import six
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
 from widgetastic.utils import Version
@@ -793,7 +792,7 @@ class Group(BaseEntity, Taggable):
         updated_result = False
         if item is not None:
             if update:
-                if isinstance(item, six.string_types):
+                if isinstance(item, str):
                     updated_result = tab_view.fill({
                         'tag_mode': 'Tags Based On Expression',
                         'tag_settings': {'tag_expression': item}})

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -6,7 +6,6 @@ from traceback import format_exc
 import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
-from six import string_types
 from widgetastic.widget import Text
 from widgetastic.widget import TextInput
 from widgetastic.widget import View
@@ -592,7 +591,7 @@ class ContainerObjectAllBaseView(ProvidersView):
 
     @property
     def summary_text(self):
-        if isinstance(self.SUMMARY_TEXT, (string_types, type(None))):
+        if isinstance(self.SUMMARY_TEXT, (str, type(None))):
             return self.SUMMARY_TEXT
         else:
             return self.SUMMARY_TEXT.pick(self.context['object'].appliance.version)
@@ -642,7 +641,7 @@ class ContainerObjectDetailsBaseView(BaseLoggedInPage, LoggingableView):
 
     @property
     def summary_text(self):
-        if isinstance(self.SUMMARY_TEXT, (string_types, type(None))):
+        if isinstance(self.SUMMARY_TEXT, (str, type(None))):
             return self.SUMMARY_TEXT
         else:
             return self.SUMMARY_TEXT.pick(self.context['object'].appliance.version)

--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -1,8 +1,8 @@
 from os import path
+from urllib.error import URLError
 
 import attr
 from cached_property import cached_property
-from six.moves.urllib.error import URLError
 from wrapanapi.systems.container import Openshift
 
 from cfme.common import Taggable

--- a/cfme/control/explorer/alerts.py
+++ b/cfme/control/explorer/alerts.py
@@ -3,7 +3,6 @@
 from copy import copy
 
 import attr
-import six
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
 from widgetastic.exceptions import NoSuchElementException
@@ -106,7 +105,7 @@ class AlertFormCommon(ControlExplorerView):
         expression = ExpressionEditor("//button[normalize-space(.)='Define Expression']")
 
         def fill(self, values):
-            if isinstance(values, six.string_types):
+            if isinstance(values, str):
                 new_values = dict(type=values)
             elif isinstance(values, (list, tuple)):
                 new_values = dict(type=values[0], **values[1])

--- a/cfme/fixtures/browser.py
+++ b/cfme/fixtures/browser.py
@@ -1,9 +1,8 @@
 import base64
+from urllib.error import URLError
 
 import pytest
-import six
 from py.error import ENOENT
-from six.moves.urllib_error import URLError
 
 import cfme.utils.browser
 from cfme.fixtures.artifactor_plugin import fire_art_test_hook
@@ -39,7 +38,7 @@ def pytest_runtest_setup(item):
 
 def pytest_exception_interact(node, call, report):
     from cfme.fixtures.pytest_store import store
-    from six.moves.http_client import BadStatusLine
+    from http.client import BadStatusLine
     from socket import error
     val = safe_string(call.excinfo.value)
     if isinstance(call.excinfo.value, (URLError, BadStatusLine, error)):
@@ -77,7 +76,7 @@ def pytest_exception_interact(node, call, report):
 
     # base64 encoded to go into a data uri, same for screenshots
     tb = report.longreprtext
-    if not isinstance(tb, six.binary_type):
+    if not isinstance(tb, bytes):
         tb = tb.encode('utf-8')
     full_tb = base64.b64encode(tb)
     # errors are when exceptions are thrown outside of the test call phase

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -2,13 +2,12 @@ import zlib
 from collections import namedtuple
 from configparser import ConfigParser
 from contextlib import contextmanager
+from io import StringIO
 
 import fauxfactory
 import pytest
 import requests
 from lxml import etree
-from six import iteritems
-from six import StringIO
 
 import cfme.utils.auth as authutil
 from cfme.cloud.provider.ec2 import EC2Provider
@@ -136,7 +135,7 @@ def ipa_crud():
     try:
         ipa_keys = [
             key
-            for key, yaml in iteritems(auth_data.auth_providers)
+            for key, yaml in auth_data.auth_providers.items()
             if yaml.type == authutil.FreeIPAAuthProvider.auth_type
         ]
         ipa_provider = authutil.get_auth_crud(ipa_keys[0])

--- a/cfme/fixtures/merkyl.py
+++ b/cfme/fixtures/merkyl.py
@@ -37,7 +37,6 @@ example of artifactor configuration:
 """
 import attr
 import pytest
-import six
 
 from cfme.fixtures.artifactor_plugin import fire_art_test_hook
 
@@ -123,7 +122,7 @@ class MerkylInspector(object):
                                         path/to/log/name.log)
         """
         contents = self.get_log(log_name)
-        if isinstance(needle, six.string_types):
+        if isinstance(needle, str):
             return needle in contents
         else:
             return bool(needle.search(contents))

--- a/cfme/fixtures/nelson.py
+++ b/cfme/fixtures/nelson.py
@@ -1,14 +1,11 @@
-import base64
 import os
 import re
 from textwrap import dedent
 from types import FunctionType
 
 import pytest
-import six
 import sphinx
 import yaml
-from six import iteritems
 from sphinx.ext.napoleon import _skip_member
 from sphinx.ext.napoleon import Config
 from sphinx.ext.napoleon import docstring
@@ -38,8 +35,7 @@ def pytest_collection_modifyitems(items):
         node_name = '{}.{}'.format(item_class, item_name)
         output[node_name] = {}
         docstring = getattr(item.function, '__doc__') or ''
-        output[node_name]['docstring'] = base64.b64encode(
-            docstring if six.PY2 else docstring.encode('utf-8'))
+        output[node_name]['docstring'] = docstring.encode('utf-8')
         output[node_name]['name'] = item_name
 
         # This is necessary to convert AttrDict in metadata, or even metadict(previously)
@@ -136,7 +132,7 @@ def setup(app):
     app.connect('autodoc-process-docstring', _process_docstring)
     app.connect('autodoc-skip-member', _skip_member)
 
-    for name, (default, rebuild) in iteritems(Config._config_values):
+    for name, (default, rebuild) in getattr(Config, '_config_values', {}).items():
         app.add_config_value(name, default, rebuild)
     return {'version': sphinx.__version__, 'parallel_read_safe': True}
 

--- a/cfme/fixtures/parallelizer/parallelizer_tester.py
+++ b/cfme/fixtures/parallelizer/parallelizer_tester.py
@@ -10,7 +10,6 @@ import random
 from time import sleep
 
 import pytest
-from six.moves import range
 # uncommment this to slow things down, if desired
 # pytestmark= pytest.mark.usefixtures("wait")
 

--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -42,7 +42,6 @@ from collections import defaultdict
 from collections import Mapping
 
 import pytest
-import six
 from _pytest.compat import getimfunc
 from _pytest.fixtures import call_fixture_func
 from _pytest.outcomes import TEST_OUTCOME
@@ -310,7 +309,7 @@ def template(template_location, provider):
         except (IndexError, KeyError):
             logger.info("Cannot apply %r to %r in the template specification, ignoring.", field, o)
         else:
-            if not isinstance(o, six.string_types):
+            if not isinstance(o, str):
                 raise ValueError("{!r} is not a string! (for template)".format(o))
             if not TEMPLATES:
                 # There is nothing in TEMPLATES, that means no trackerbot URL and no data pulled.

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -3,7 +3,6 @@
 import json
 
 import attr
-import six
 from manageiq_client.api import APIException
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
@@ -258,7 +257,7 @@ class Host(
         # TODO: Move to Sentaku
         try:
             host = self.appliance.rest_api.collections.hosts.get(name=self.name)
-            if isinstance(credentials['default'], six.string_types):
+            if isinstance(credentials['default'], str):
                 creds = self.Credential.from_config(credentials["default"])
             elif isinstance(credentials['default'], self.Credential):
                 creds = credentials['default']

--- a/cfme/markers/env_markers/provider.py
+++ b/cfme/markers/env_markers/provider.py
@@ -3,7 +3,6 @@ from distutils.version import LooseVersion
 
 import attr
 import pytest
-import six
 from cached_property import cached_property
 
 from cfme.markers.env import EnvironmentMarker
@@ -203,7 +202,7 @@ def all_required(miq_version, filters=None):
     # Build up a list of data providers by iterating the types list from above
     dprovs = []
     for cat, prov_type_or_dict in types:
-        if isinstance(prov_type_or_dict, six.string_types):
+        if isinstance(prov_type_or_dict, str):
             # If the provider is versionless, ie, EC2, GCE, set the version number to 0
             dprovs.append(DataProvider(cat, prov_type_or_dict, 0))
         else:

--- a/cfme/metaplugins/server_roles.py
+++ b/cfme/metaplugins/server_roles.py
@@ -43,8 +43,6 @@ To ensure the appliance has the default roles::
 For a list of server role names currently exposed in the CFME interface,
 see keys of :py:data:`cfme.configure.configuration.server_roles`.
 """
-import six
-
 from cfme.configure.configuration.server_settings import ServerInformation
 from cfme.markers.meta import plugin
 from cfme.utils.conf import cfme_data
@@ -72,7 +70,7 @@ def add_server_roles(item, server_roles, server_roles_mode="add"):
         # The ones that are already enabled and enable/disable the ones specified
         # -server_role, +server_role or server_role
         roles_with_vals = server_settings.server_roles_db
-        if isinstance(server_roles, six.string_types):
+        if isinstance(server_roles, str):
             server_roles = server_roles.split(' ')
         for role in server_roles:
             if role.startswith('-'):

--- a/cfme/test_framework/appliance.py
+++ b/cfme/test_framework/appliance.py
@@ -1,6 +1,7 @@
+from urllib.parse import urlparse
+
 import attr
 import pytest
-import six.moves.urllib.parse
 
 from cfme.fixtures import terminalreporter
 from cfme.utils import conf
@@ -21,7 +22,7 @@ def pytest_addoption(parser):
 def appliances_from_cli(cli_appliances, appliance_version):
     appliance_config = dict(appliances=[])
     for appliance_data in cli_appliances:
-        parsed_url = six.moves.urllib.parse.urlparse(appliance_data['hostname'])
+        parsed_url = urlparse(appliance_data['hostname'])
         if not parsed_url.hostname:
             raise ValueError(
                 "Invalid appliance url: {}".format(appliance_data)

--- a/cfme/test_framework/sprout/plugin.py
+++ b/cfme/test_framework/sprout/plugin.py
@@ -1,11 +1,11 @@
 import random
 import re
 from threading import Timer
+from urllib.parse import urlparse
 
 import attr
 import pytest
 from cached_property import cached_property
-from six.moves.urllib.parse import urlparse
 
 from cfme.test_framework.sprout.client import AuthException
 from cfme.test_framework.sprout.client import SproutClient

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -1,6 +1,7 @@
+from urllib.parse import urlparse
+
 import fauxfactory
 import pytest
-from six.moves.urllib.parse import urlparse
 
 from cfme import test_requirements
 from cfme.automate.explorer.domain import DomainDetailsView

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -712,7 +712,7 @@ class TestProvidersRESTAPI(object):
 
     @pytest.mark.tier(3)
     @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
-    def test_cloud_networks_query(self, cloud_provider, appliance, from_detail):
+    def test_cloud_networks_query(self, cloud_provider, appliance, from_detail, setup_provider):
         """Tests querying cloud providers and cloud_networks collection for network info.
 
         Metadata:
@@ -730,8 +730,8 @@ class TestProvidersRESTAPI(object):
         else:
             networks = appliance.rest_api.collections.cloud_networks
         assert_response(appliance)
-        assert networks
-        assert len(networks) == networks.subcount
+        assert networks.name == 'cloud_networks'
+        assert len(networks.all) == networks.subcount
 
         enabled_networks = 0
         networks.reload(expand=True)
@@ -742,7 +742,7 @@ class TestProvidersRESTAPI(object):
         assert enabled_networks >= 1
 
     @pytest.mark.tier(3)
-    def test_security_groups_query(self, cloud_provider, appliance):
+    def test_security_groups_query(self, cloud_provider, appliance, setup_provider):
         """Tests querying cloud networks subcollection for security groups info.
 
         Metadata:

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -239,7 +239,7 @@ def test_cloud_provider_add_with_bad_credentials(provider, enable_regions):
         flash = 'Credential validation was not successful: Invalid Google JSON key'
         default_credentials.service_account = '{"test": "bad"}'
     elif provider.one_of(OpenStackProvider):
-        for endp_name in provider.endpoints.keys():
+        for endp_name in list(provider.endpoints.keys()):
             if endp_name != 'default':
                 del provider.endpoints[endp_name]
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -3,10 +3,10 @@
 # pylint: disable=W0621
 import os
 import uuid
+from urllib.parse import urljoin
 
 import fauxfactory
 import pytest
-from six.moves.urllib.parse import urljoin
 from wait_for import wait_for
 from widgetastic.exceptions import MoveTargetOutOfBoundsException
 from wrapanapi import VmState

--- a/cfme/tests/configure/test_db_backup_schedule.py
+++ b/cfme/tests/configure/test_db_backup_schedule.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
+from urllib.parse import urlparse
 
 import fauxfactory
 import pytest
 from dateutil.relativedelta import relativedelta
-from six.moves.urllib.parse import urlparse
 
 from cfme.utils import conf
 from cfme.utils import testgen

--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -2,7 +2,6 @@
 import random
 
 import pytest
-from six import string_types
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
@@ -66,7 +65,7 @@ def test_cloud_default_view(appliance, group_name, expected_view):
     old_default = default_views.get_default_view(group_name, fieldset='Clouds')
     default_views.set_default_view(group_name, expected_view, fieldset='Clouds')
     # gtl_params.values(), source of page, are mix of class and collection name
-    nav_cls = getattr(appliance.collections, page) if isinstance(page, string_types) else page
+    nav_cls = getattr(appliance.collections, page) if isinstance(page, str) else page
     selected_view = navigate_to(nav_cls, 'All', use_resetter=False).toolbar.view_selector.selected
     assert expected_view == selected_view, '{} view setting failed'.format(expected_view)
     default_views.set_default_view(group_name, old_default, fieldset='Clouds')

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -2,7 +2,6 @@
 import random
 
 import pytest
-from six import string_types
 
 from cfme import test_requirements
 from cfme.exceptions import ItemNotFound
@@ -58,7 +57,7 @@ def _get_page(page, appliance):
     if page in [TemplatesImages, VmsInstances]:
         # one-off instantiation of class
         return page(appliance)
-    if isinstance(page, string_types):
+    if isinstance(page, str):
         # Appliance collection instantiation of class
         return getattr(appliance.collections, page)
     # Nav class provided

--- a/cfme/tests/configure/test_visual_cloud.py
+++ b/cfme/tests/configure/test_visual_cloud.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import pytest
-import six
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
@@ -77,7 +76,7 @@ def test_cloud_grid_page_per_item(appliance, request, page, value, set_grid):
         initialEstimate: 1/10h
         tags: settings
     """
-    if isinstance(page, six.string_types):
+    if isinstance(page, str):
         page = getattr(appliance.collections, page)
     if appliance.user.my_settings.visual.grid_view_limit != value:
         appliance.user.my_settings.visual.grid_view_limit = int(value)
@@ -111,7 +110,7 @@ def test_cloud_tile_page_per_item(appliance, request, page, value, set_tile):
         initialEstimate: 1/10h
         tags: settings
     """
-    if isinstance(page, six.string_types):
+    if isinstance(page, str):
         page = getattr(appliance.collections, page)
     if appliance.user.my_settings.visual.tile_view_limit != value:
         appliance.user.my_settings.visual.tile_view_limit = int(value)
@@ -145,7 +144,7 @@ def test_cloud_list_page_per_item(appliance, request, page, value, set_list):
         initialEstimate: 1/10h
         tags: settings
     """
-    if isinstance(page, six.string_types):
+    if isinstance(page, str):
         page = getattr(appliance.collections, page)
     if appliance.user.my_settings.visual.list_view_limit != value:
         appliance.user.my_settings.visual.list_view_limit = int(value)

--- a/cfme/tests/configure/test_visual_infra.py
+++ b/cfme/tests/configure/test_visual_infra.py
@@ -2,7 +2,6 @@
 from random import choice
 
 import pytest
-import six
 
 from cfme import test_requirements
 from cfme.infrastructure import virtual_machines as vms  # NOQA
@@ -121,7 +120,7 @@ def test_infra_grid_page_per_item(appliance, request, page, value, set_grid):
         initialEstimate: 1/12h
         tags: settings
     """
-    if isinstance(page, six.string_types):
+    if isinstance(page, str):
         page = getattr(appliance.collections, page)
     if appliance.user.my_settings.visual.grid_view_limit != value:
         appliance.user.my_settings.visual.grid_view_limit = int(value)
@@ -155,7 +154,7 @@ def test_infra_tile_page_per_item(appliance, request, page, value, set_tile):
         initialEstimate: 1/10h
         tags: settings
     """
-    if isinstance(page, six.string_types):
+    if isinstance(page, str):
         page = getattr(appliance.collections, page)
     if appliance.user.my_settings.visual.tile_view_limit != value:
         appliance.user.my_settings.visual.tile_view_limit = int(value)
@@ -189,7 +188,7 @@ def test_infra_list_page_per_item(appliance, request, page, value, set_list):
         initialEstimate: 1/10h
         tags: settings
     """
-    if isinstance(page, six.string_types):
+    if isinstance(page, str):
         page = getattr(appliance.collections, page)
     if appliance.user.my_settings.visual.list_view_limit != value:
         appliance.user.my_settings.visual.list_view_limit = int(value)

--- a/cfme/tests/distributed/test_appliance_replication.py
+++ b/cfme/tests/distributed/test_appliance_replication.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from time import sleep
+from urllib.parse import urlparse
 
 import pytest
-from six.moves.urllib.parse import urlparse
 
 from cfme import test_requirements
 from cfme.base.ui import ServerView

--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
+from urllib.request import urlopen
 
 import fauxfactory
 import pytest
-from six.moves.urllib.request import urlopen
 
 from cfme import test_requirements
 from cfme.infrastructure.provider.scvmm import SCVMMProvider

--- a/cfme/tests/infrastructure/test_vmware_provider.py
+++ b/cfme/tests/infrastructure/test_vmware_provider.py
@@ -3,10 +3,10 @@
 import os
 import re
 import tarfile
+from urllib import request as url_request
 
 import fauxfactory
 import pytest
-from six.moves.urllib import request as url_request
 
 from cfme import test_requirements
 from cfme.infrastructure.host import Host

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 from fauxfactory import gen_alphanumeric
-from six import iteritems
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
@@ -84,7 +83,7 @@ def pytest_generate_tests(metafunc):
     for mode in test_param_maps.keys():
         for auth_type in test_param_maps.get(mode, {}):
             eligible_providers = {key: prov_dict
-                                  for key, prov_dict in iteritems(auth_data.auth_providers)
+                                  for key, prov_dict in auth_data.auth_providers.items()
                                   if prov_dict.type == auth_type}
             for user_type in test_param_maps[mode][auth_type]['user_types']:
                 for key, prov_dict in eligible_providers.items():

--- a/cfme/tests/intelligence/test_dashboard.py
+++ b/cfme/tests/intelligence/test_dashboard.py
@@ -93,7 +93,7 @@ def test_custom_dashboards(request, soft_assert, number_dashboards, dashboards, 
         for dash in dashboards.all():
             soft_assert(dash.name in dash_dict, "Dashboard {} not found!".format(dash.name))
             dash.dashboard_view.click()
-            if dash.name in dash_dict:
+            if dash.name in list(dash_dict.keys()):
                 for widget in dash.collections.widgets.all():
                     soft_assert(widget.name in dash_dict[dash.name].widgets,
                                 "Widget {} not found in {}!".format(widget.name, dash.name))

--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 import fauxfactory
 import pytest
-import six
 
 from cfme import test_requirements
 from cfme.infrastructure.config_management import ConfigManager
@@ -122,7 +121,7 @@ pytestmark = [
 
 
 def _navigation(param, appliance):
-    if isinstance(param.collection, six.string_types):
+    if isinstance(param.collection, str):
         view = navigate_to(getattr(appliance.collections, param.collection), param.destination)
     else:
         view = navigate_to(param.collection, param.destination)

--- a/cfme/utils/__init__.py
+++ b/cfme/utils/__init__.py
@@ -6,7 +6,6 @@ import subprocess
 from functools import partial
 
 import diaper
-import six
 from cached_property import cached_property
 from werkzeug.local import LocalProxy
 # import diaper for backward compatibility
@@ -25,7 +24,7 @@ class FakeObject(object):
 
 
 def fakeobject_or_object(obj, attr, default=None):
-    if isinstance(obj, six.string_types):
+    if isinstance(obj, str):
         return FakeObject(**{attr: obj})
     elif not obj:
         return FakeObject(**{attr: default})
@@ -191,13 +190,13 @@ def safe_string(o):
     Args:
         o: Anything.
     """
-    if not isinstance(o, six.string_types):
+    if not isinstance(o, str):
         o = str(o)
     if isinstance(o, bytes):
         o = o.decode('utf-8', "ignore")
     if not isinstance(o, str):
         o = o.encode("ascii", "xmlcharrefreplace")
-    elif not six.PY2:
+    else:
         o = o.encode("ascii", "xmlcharrefreplace").decode('ascii')
     return o
 

--- a/cfme/utils/auth/__init__.py
+++ b/cfme/utils/auth/__init__.py
@@ -2,7 +2,6 @@ from copy import deepcopy
 
 import attr
 from cached_property import cached_property
-from six import iteritems
 
 from cfme.configure.configuration.server_settings import AmazonAuthenticationView
 from cfme.configure.configuration.server_settings import ExternalAuthenticationView
@@ -115,7 +114,7 @@ class BaseAuthProvider(object):
         config_copy = deepcopy(prov_config)  # copy to avoid modifying passed attrdict
         config_copy.update(credentials[config_copy.get('credentials')])
         class_params = {k: v
-                        for k, v in iteritems(config_copy)
+                        for k, v in config_copy.items()
                         if k in attr.fields_dict(cls)}
         return cls(key=prov_key, **class_params)
 

--- a/cfme/utils/blockers.py
+++ b/cfme/utils/blockers.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
+from urllib.parse import urlparse
+from xmlrpc.client import Fault as RPCFault
 
-import six.moves.xmlrpc_client
 from github import Github
-from six.moves.urllib.parse import urlparse
 
 from cfme.fixtures.pytest_store import store
 from cfme.utils import classproperty
@@ -49,7 +49,7 @@ class Blocker(object):
         """Create a blocker object from some representation"""
         if isinstance(blocker, cls):
             return blocker
-        elif isinstance(blocker, six.string_types):
+        elif isinstance(blocker, str):
             if "#" in blocker:
                 # Generic blocker
                 engine, spec = blocker.split("#", 1)
@@ -102,7 +102,7 @@ class GH(Blocker):
             if self.DEFAULT_REPOSITORY is None:
                 raise ValueError("You must specify github/default_repo in env.yaml!")
             self.issue = description
-        elif isinstance(description, six.string_types):
+        elif isinstance(description, str):
             try:
                 owner, repo, issue_num = re.match(r"^([^/]+)/([^/:]+):([0-9]+)$",
                                                   str(description).strip()).groups()
@@ -236,7 +236,7 @@ class BZ(Blocker):
                 if bug.fixed_in is not None:
                     return version.current_version() < bug.fixed_in
             return result
-        except six.moves.xmlrpc_client.Fault as e:
+        except RPCFault as e:
             code = e.faultCode
             s = e.faultString.strip().split("\n")[0]
             logger.error("Bugzilla thrown a fault: %s/%s", code, s)

--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -8,6 +8,7 @@ from collections import namedtuple
 from shutil import rmtree
 from string import Template
 from tempfile import mkdtemp
+from urllib.error import URLError
 
 import requests
 from cached_property import cached_property
@@ -18,7 +19,6 @@ from selenium.webdriver.common import keys
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.firefox.firefox_profile import FirefoxProfile
 from selenium.webdriver.remote.file_detector import UselessFileDetector
-from six.moves.urllib_error import URLError
 from werkzeug.local import LocalProxy
 
 from cfme.fixtures.pytest_store import store

--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -3,7 +3,6 @@ import re
 from collections import Sequence
 from contextlib import contextmanager
 
-import six
 from bugzilla import Bugzilla as _Bugzilla
 from bugzilla.transport import BugzillaError
 from cached_property import cached_property
@@ -289,7 +288,7 @@ class BugWrapper(object):
         """
         value = getattr(self._bug, attr)
         if attr in self.loose:
-            if isinstance(value, Sequence) and not isinstance(value, six.string_types):
+            if isinstance(value, Sequence) and not isinstance(value, str):
                 value = value[0]
             value = value.strip()
             if not value:
@@ -301,7 +300,7 @@ class BugWrapper(object):
             if not value:
                 return None
             return Version(value)
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             if len(value.strip()) == 0:
                 return None
             else:

--- a/cfme/utils/dockerbot/dockerbot.py
+++ b/cfme/utils/dockerbot/dockerbot.py
@@ -4,12 +4,12 @@ import os.path
 import re
 import subprocess
 import sys
+from urllib.parse import urlsplit
 
 import docker
 import fauxfactory
 import requests
 import yaml
-from six.moves.urllib.parse import urlsplit
 
 from cfme.utils.conf import docker as docker_conf
 from cfme.utils.net import my_ip_address

--- a/cfme/utils/providers.py
+++ b/cfme/utils/providers.py
@@ -13,8 +13,6 @@ from collections import Mapping
 from collections import OrderedDict
 from copy import copy
 
-import six
-
 from cfme.common.provider import all_types
 from cfme.exceptions import UnknownProviderType
 from cfme.utils import conf
@@ -97,7 +95,7 @@ class ProviderFilter(object):
                 field_ident, field_value = field_or_fields
             else:
                 field_ident, field_value = field_or_fields, None
-            if isinstance(field_ident, six.string_types):
+            if isinstance(field_ident, str):
                 if field_ident not in provider.data:
                     return False
                 else:
@@ -135,12 +133,12 @@ class ProviderFilter(object):
             test_flags = [flag.strip() for flag in self.required_flags]
 
             defined_flags = conf.cfme_data.get('test_flags', '')
-            if isinstance(defined_flags, six.string_types):
+            if isinstance(defined_flags, str):
                 defined_flags = defined_flags.split(',')
             defined_flags = [flag.strip() for flag in defined_flags]
 
             excluded_flags = provider.data.get('excluded_test_flags', '')
-            if isinstance(excluded_flags, six.string_types):
+            if isinstance(excluded_flags, str):
                 excluded_flags = excluded_flags.split(',')
             excluded_flags = [flag.strip() for flag in excluded_flags]
 
@@ -250,7 +248,7 @@ def list_providers(filters=None, use_global_filters=True):
 
     Returns: List of provider crud objects.
     """
-    if isinstance(filters, six.string_types):
+    if isinstance(filters, str):
         raise TypeError(
             'You are probably using the old-style invocation of provider setup functions! '
             'You need to change it appropriately.')
@@ -388,7 +386,7 @@ def get_mgmt(provider_key, providers=None, credentials=None):
         provider_kwargs['username'] = provider_kwargs['principal']
         provider_kwargs['password'] = provider_kwargs['secret']
 
-    if isinstance(provider_key, six.string_types):
+    if isinstance(provider_key, str):
         provider_kwargs['provider_key'] = provider_key
     provider_kwargs['logger'] = logger
 

--- a/cfme/utils/smem_memory_monitor.py
+++ b/cfme/utils/smem_memory_monitor.py
@@ -7,7 +7,6 @@ from collections import OrderedDict
 from datetime import datetime
 from threading import Thread
 
-import six
 import yaml
 from yaycl import AttrDict
 
@@ -982,7 +981,7 @@ def get_scenario_html(scenario_data):
 
 def create_dict(attr_dict):
     main_dict = dict(attr_dict)
-    for key, value in six.iteritems(main_dict):
+    for key, value in main_dict.items():
         if type(value) == AttrDict:
             main_dict[key] = create_dict(value)
     return main_dict

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -11,7 +11,6 @@ import fauxfactory
 import gevent
 import iso8601
 import paramiko
-import six
 from cached_property import cached_property
 from scp import SCPClient
 
@@ -65,7 +64,7 @@ class SSHResult(object):
 
     def __contains__(self, what):
         # Handling 'something' in x
-        if not isinstance(what, six.string_types):
+        if not isinstance(what, str):
             raise ValueError('You can only check strings using the in operator')
         return what in self.output
 
@@ -80,7 +79,7 @@ class SSHResult(object):
     def __eq__(self, other):
         if isinstance(other, int):
             return self.rc == other
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             return self.output == other
         else:
             raise ValueError('You can only compare SSHResult with str or int')
@@ -88,7 +87,7 @@ class SSHResult(object):
     def __lt__(self, other):
         if isinstance(other, int):
             return self.rc < other
-        elif isinstance(other, six.string_types):
+        elif isinstance(other, str):
             return self.output < other
         else:
             raise ValueError('You can only compare SSHResult with str or int')

--- a/cfme/utils/template/base.py
+++ b/cfme/utils/template/base.py
@@ -3,14 +3,14 @@ import re
 from contextlib import closing
 from os import path
 from threading import Lock
+from urllib import request
+from urllib.error import URLError
+from urllib.request import urlopen
 from zipfile import ZipFile
 
 from cached_property import cached_property
 from fauxfactory import gen_alphanumeric
 from glanceclient import Client
-from six.moves.urllib import request
-from six.moves.urllib.error import URLError
-from six.moves.urllib.request import urlopen
 
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider

--- a/cfme/utils/trackerbot.py
+++ b/cfme/utils/trackerbot.py
@@ -2,11 +2,11 @@ import argparse
 import json
 import time
 from collections import defaultdict
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
 
 import requests
 import slumber
-from six.moves.urllib_parse import parse_qs
-from six.moves.urllib_parse import urlparse
 
 from cfme.utils.conf import env
 from cfme.utils.log import logger

--- a/cfme/utils/units.py
+++ b/cfme/utils/units.py
@@ -4,8 +4,6 @@ import math
 import re
 from collections import namedtuple
 
-import six
-
 
 # TODO: Split the 1000 and 1024 factor out. Now it is not an issue as it is used FOR COMPARISON ONLY
 FACTOR = 1024
@@ -77,7 +75,7 @@ class Unit(object):
         return type(self)(int_or_float, PREFIXES[0], self.unit_type)
 
     def _cast_other_to_same(self, other):
-        if isinstance(other, six.string_types):
+        if isinstance(other, str):
             other = self.parse(other)
         elif isinstance(other, (int, float)):
             other = self._as_same_unit(other)

--- a/cfme/utils/virtual_machines.py
+++ b/cfme/utils/virtual_machines.py
@@ -3,7 +3,6 @@
 from ssl import SSLError
 
 import pytest
-import six
 from novaclient.exceptions import OverLimit as OSOverLimit
 from wrapanapi import AzureSystem
 from wrapanapi.exceptions import VMInstanceNotCloned
@@ -32,7 +31,7 @@ def deploy_template(provider_key, vm_name, template_name=None, timeout=900, **de
     if isinstance(allow_skip, dict):
         skip_exceptions = list(allow_skip.keys())
         callable_mapping = allow_skip
-    elif isinstance(allow_skip, six.string_types) and allow_skip.lower() == "default":
+    elif isinstance(allow_skip, str) and allow_skip.lower() == "default":
         skip_exceptions = DEFAULT_SKIP
         callable_mapping = {}
     else:

--- a/docs/guides/dev_guide.rst
+++ b/docs/guides/dev_guide.rst
@@ -306,7 +306,6 @@ General Notes
 * If you feel icky about something you've written but don't know how to make
   it better, ask someone. It's better to have it fixed before submitting it as
   a pull request ;)
-* Use :py:mod:`six` library to write Python 3 compatible code.
 
 Other useful code style guidelines:
 

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -285,7 +285,6 @@ sentaku==0.6.4
 setuptools-scm==3.3.3
 shyaml==0.6.1
 simplejson==3.16.0
-six==1.12.0
 slumber==0.7.1
 smmap2==2.0.5
 snowballstemmer==1.2.1

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -284,7 +284,6 @@ sentaku==0.6.4
 setuptools-scm==3.3.3
 shyaml==0.6.1
 simplejson==3.16.0
-six==1.12.0
 slumber==0.7.1
 smmap2==2.0.5
 snowballstemmer==1.2.1

--- a/requirements/template_docs.txt
+++ b/requirements/template_docs.txt
@@ -77,7 +77,6 @@ click
 # docs requirements
 Sphinx==1.3.5
 sphinx-rtd-theme
-six>=1.9
 
 debtcollector
 

--- a/scripts/coverage_report_jenkins.py
+++ b/scripts/coverage_report_jenkins.py
@@ -5,6 +5,8 @@ import re
 import subprocess
 import time
 from collections import namedtuple
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
 
 import click
 import diaper
@@ -12,8 +14,6 @@ import jenkins
 import py
 import requests
 from requests.auth import HTTPBasicAuth
-from six.moves.urllib.parse import urlsplit
-from six.moves.urllib.parse import urlunsplit
 
 from cfme.test_framework.sprout.client import SproutClient
 from cfme.utils.appliance import IPAppliance

--- a/scripts/install_vddk.py
+++ b/scripts/install_vddk.py
@@ -3,8 +3,7 @@
 """
 import argparse
 import sys
-
-from six.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 from cfme.utils.appliance import get_or_create_current_appliance
 from cfme.utils.appliance import IPAppliance

--- a/scripts/list_tests.py
+++ b/scripts/list_tests.py
@@ -3,8 +3,6 @@ import os.path
 import re
 import sys
 
-import six
-
 if len(sys.argv) == 1:
     print("""
 Invoke either by supplying a path or a file and optionally a string to find in a test name
@@ -27,7 +25,7 @@ def parser(filename, exp=None):
 
     p = re.findall(r'\s*def\s*[a-zA-Z0-9_]*?(test_.*?{}.*?)\('.format(exp), data)
     for test in p:
-        if isinstance(test, six.string_types):
+        if isinstance(test, str):
             print("{} :: {}".format(filename, test))
         else:
             print("{} :: {}".format(filename, test[0]))

--- a/sprout/appliances/models.py
+++ b/sprout/appliances/models.py
@@ -2,12 +2,7 @@
 import base64
 import re
 import yaml
-import six
-
-try:
-    import six.moves.cPickle as pickle
-except ImportError:
-    import pickle   # NOQA
+import pickle   # NOQA
 
 import wrapanapi
 from wrapanapi import VmState, Openshift
@@ -1338,12 +1333,12 @@ class AppliancePool(MetadataMixin):
                                            template_type=template_type, **user_filter)
             if dates:
                 date = dates[0]
-        if isinstance(group, six.string_types):
+        if isinstance(group, str):
             group = Group.objects.get(id=group)
-        if isinstance(provider_type, six.string_types):
+        if isinstance(provider_type, str):
             if provider_type not in Provider.get_available_provider_types(owner):
                 raise Exception('There are no providers for type {!r}'.format(provider_type))
-        if isinstance(provider, six.string_types):
+        if isinstance(provider, str):
             provider = Provider.objects.get(id=provider, working=True, disabled=False)
             if provider_type is not None and provider.provider_type != provider_type:
                 raise Exception(

--- a/sprout/appliances/views.py
+++ b/sprout/appliances/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import json
-import six.moves.xmlrpc_client
 from functools import wraps
+from xmlrpc.client import Fault as RPCFault
 
 from celery import chain, group
 from celery.result import AsyncResult
@@ -961,7 +961,7 @@ def view_bug_query(request, query_id):
             return go_home(request)
     try:
         bugs = query.list_bugs(request.user)
-    except six.moves.xmlrpc_client.Fault as e:
+    except RPCFault as e:
         messages.error(request, 'Bugzilla query error {}: {}'.format(e.faultCode, e.faultString))
         return go_home(request)
     return render(request, 'bugs/list_query.html', locals())

--- a/sprout/logserver.py
+++ b/sprout/logserver.py
@@ -2,15 +2,13 @@
 # -*- coding: utf-8 -*-
 # Based on: https://docs.python.org/2.4/lib/network-logging.html
 import atexit
-try:
-    import six.moves.cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
 import logging
 import logging.handlers
-import six.moves.socketserver
 import signal
 import struct
+from socketserver import StreamRequestHandler
+from socketserver import ThreadingTCPServer
 from threading import Lock
 
 from sprout import sprout_path
@@ -61,7 +59,7 @@ def create_logger(name, filename, max_file_size, max_backups):
     return logger
 
 
-class LogRecordStreamHandler(six.moves.socketserver.StreamRequestHandler):
+class LogRecordStreamHandler(StreamRequestHandler):
     """Handler for a streaming logging request.
 
     This basically logs the record using whatever logging policy is
@@ -121,13 +119,13 @@ class LogRecordStreamHandler(six.moves.socketserver.StreamRequestHandler):
                 logger.handle(record)
 
 
-class LogRecordSocketReceiver(six.moves.socketserver.ThreadingTCPServer):
+class LogRecordSocketReceiver(ThreadingTCPServer):
     allow_reuse_address = 1
 
     def __init__(self, host='localhost',
                  port=logging.handlers.DEFAULT_TCP_LOGGING_PORT,
                  handler=LogRecordStreamHandler):
-        six.moves.socketserver.ThreadingTCPServer.__init__(self, (host, port), handler)
+        ThreadingTCPServer.__init__(self, (host, port), handler)
         self.abort = 0
         self.timeout = 1
         self.logname = None

--- a/sprout/sprout/__init__.py
+++ b/sprout/sprout/__init__.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from contextlib import contextmanager
-try:
-    import six.moves.cPickle as pickle
-except ImportError:
-    import pickle
+import pickle
+
 from sprout.sprout.celery import app as celery_app
 assert celery_app
 

--- a/sprout/sprout/log.py
+++ b/sprout/sprout/log.py
@@ -8,7 +8,6 @@ import inspect
 import sys
 from django.db.models import Model
 from types import ModuleType
-import six
 
 logger_cache = {}
 logger_cache_lock = Lock()
@@ -60,7 +59,7 @@ def create_logger(o, additional_id=None):
         Instance of logger.
     """
     wrap = None
-    if isinstance(o, six.string_types):
+    if isinstance(o, str):
         if o in sys.modules:
             # str -> module
             return create_logger(sys.modules[o], additional_id)

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -11,7 +11,6 @@ from datetime import timedelta
 from math import ceil
 from tempfile import NamedTemporaryFile
 
-import six
 from cached_property import cached_property
 from jsmin import jsmin
 from lxml.html import document_fromstring
@@ -912,7 +911,7 @@ class SNMPHostsField(View):
 
     def fill(self, values):
         fields = self.host_fields
-        if isinstance(values, six.string_types):
+        if isinstance(values, str):
             values = [values]
         if len(values) > len(fields):
             raise ValueError("You cannot specify more hosts than the form allows!")
@@ -2889,7 +2888,7 @@ class AlertEmail(View):
         self.id = id
 
     def fill(self, values):
-        if isinstance(values, six.string_types):
+        if isinstance(values, str):
             values = [values]
         if self.all_emails == set(values):
             return False
@@ -3615,7 +3614,7 @@ class DashboardWidgetsPicker(View):
         return list(set(values) - set(self.all_dashboard_widgets))
 
     def fill(self, values):
-        if isinstance(values, six.string_types):
+        if isinstance(values, str):
             values = [values]
         if set(values) == set(self.all_dashboard_widgets):
             return False
@@ -3704,7 +3703,7 @@ class MenuShortcutsPicker(View):
 
     def fill(self, values):
         dict_values = None
-        if isinstance(values, six.string_types):
+        if isinstance(values, str):
             values = [values]
         if isinstance(values, dict):
             dict_values = values
@@ -4403,7 +4402,7 @@ class LineChart(Widget, ClickableMixin):
         return [leg.id for leg in self.browser.elements(self.LEGENDS)]
 
     def legend_is_displayed(self, leg):
-        if isinstance(leg, six.string_types):
+        if isinstance(leg, str):
             leg = self._legends.get(leg)
         return "c3-legend-item-hidden" not in self.browser.classes(leg)
 
@@ -5659,7 +5658,7 @@ class RolesSelector(Widget):
 
     def role_selected(self, role):
         """Check role is selected or not"""
-        if isinstance(role, six.string_types):
+        if isinstance(role, str):
             role = self._cell_input_map.get(role)
         return self.browser.is_selected(role)
 

--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -6,7 +6,6 @@ import re
 import time
 from functools import partial
 
-import six
 from selenium.common.exceptions import NoSuchElementException
 from widgetastic.utils import WaitFillViewStrategy
 from widgetastic.widget import Text
@@ -383,9 +382,7 @@ class ExpressionEditor(View, Pretty):
         if not no_date:
             # Flip the right part of form
             view = self.field_date_form
-            if isinstance(value, six.string_types) and not re.match(
-                r"^[0-9]{2}/[0-9]{2}/[0-9]{4}$", value
-            ):
+            if isinstance(value, str) and not re.match(r"^[0-9]{2}/[0-9]{2}/[0-9]{4}$", value):
                 if not view.dropdown_select.is_displayed:
                     self.click_switch_to_relative()
                 view.fill({"dropdown_select": value})
@@ -396,7 +393,7 @@ class ExpressionEditor(View, Pretty):
                     self.click_switch_to_specific()
                 if (isinstance(value, tuple) or isinstance(value, list)) and len(value) == 2:
                     date, time = value
-                elif isinstance(value, six.string_types):  # is in correct format mm/dd/yyyy
+                elif isinstance(value, str):  # is in correct format mm/dd/yyyy
                     # Date only (for now)
                     date = value[:]
                     time = None
@@ -496,7 +493,7 @@ def run_commands(command_list, clear_expression=True, context=None):
     assert isinstance(command_list, list) or isinstance(command_list, tuple)
     step_list = []
     for command in command_list:
-        if isinstance(command, six.string_types):
+        if isinstance(command, str):
             # Single command, no params
             step_list.append(get_func(command, context))
         elif isinstance(command, dict):


### PR DESCRIPTION
Remove all uses of `six`, since we're running in py3 only now.

Trying to find a balance in fixing PRT results. I've pushed 3 specific commits related to test fixes for PRT, and will continue to try and keep those fixes in individual commits. 

Per reviewer feedback and PRT results/confidence, I'll either include those here and we can squash them, or I can split them out into another PR that is only test fixes.