### PR TITLE
[1LP][RFR] Update Set Ownership view for 5.11

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -18,6 +18,8 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.exceptions import displayed_not_implemented
 from cfme.exceptions import ItemNotFound
 from cfme.utils.log import logger
+from cfme.utils.version import LOWEST
+from cfme.utils.version import VersionPicker
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import BaseEntitiesView
 from widgetastic_manageiq import BaseNonInteractiveEntitiesView
@@ -32,6 +34,7 @@ from widgetastic_manageiq import MultiBoxSelect
 from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import ParametrizedSummaryTable
 from widgetastic_manageiq import RadioGroup
+from widgetastic_manageiq import ReactSelect
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import WaitTab
 
@@ -481,10 +484,19 @@ class SetOwnershipView(BaseLoggedInPage):
     """
     @View.nested
     class form(View):  # noqa
-        user_name = BootstrapSelect('user_name')
-        group_name = BootstrapSelect('group_name')
+        user_name = VersionPicker({
+            "5.11": ReactSelect('user_name'),
+            LOWEST: BootstrapSelect('user_name')
+        })
+        group_name = VersionPicker({
+            "5.11": ReactSelect('group_name'),
+            LOWEST: BootstrapSelect('group_name')
+        })
         entities = View.nested(BaseNonInteractiveEntitiesView)
-        save_button = Button('Save')
+        save_button = VersionPicker({
+            "5.11": Button('Submit'),
+            LOWEST: Button('Save')
+        })
         reset_button = Button('Reset')
         cancel_button = Button('Cancel')
 


### PR DESCRIPTION
Some elements in SetOwnershipView have changed between 5.10 and 5.11, breaking all VM chargeback / metering report tests. The changes are:

- The Owner and Group dropdowns have changed from BootstrapSelect to ReactSelect elements.
- The 'Save' button is now titled 'Submit'.

This PR uses VersionPicker to define these three elements as appropriate, depending on whether we are testing against CFME 5.11 or not.

{{ pytest: -v --long-running --use-provider vsphere67-nested cfme/tests/intelligence/reports/test_validate_chargeback_report.py::test_validate_default_rate_cpu_usage_cost }}