### PR TITLE
[1LP][RFR] Automates BZ 1633867 for thick-lazy zero/eager zero provisioning

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -14,6 +14,8 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.common import TimelinesView
 from cfme.exceptions import displayed_not_implemented
 from cfme.utils.log import logger
+from cfme.utils.version import Version
+from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import BaseEntitiesView
 from widgetastic_manageiq import Button
@@ -193,7 +195,10 @@ class HostsView(ComputeInfrastructureHostsView):
 
     @View.nested
     class filters(Accordion):  # noqa
-        ACCORDION_NAME = "Filters"
+        ACCORDION_NAME = VersionPicker({
+            Version.lowest(): 'Filters',
+            '5.11': 'Global Filters'
+        })
 
         navigation = BootstrapNav('.//div/ul')
         tree = ManageIQTree()

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -165,21 +165,22 @@ def test_change_cpu_ram(provisioner, soft_assert, provider, prov_data, vm_name):
 
 @pytest.mark.rhv3
 # Special parametrization in testgen above
-@pytest.mark.meta(blockers=[1209847, 1380782])
-@pytest.mark.meta(automates=[1633867])
+@pytest.mark.meta(blockers=[1209847, 1380782], automates=[1633867])
 @pytest.mark.parametrize("disk_format", ["Thin", "Thick", "Preallocated",
-    "Thick - Lazy Zero", "Thick - Eager Zero"])
-@pytest.mark.uncollectif(lambda provider, disk_format, appliance:
-                         (provider.one_of(RHEVMProvider) and disk_format in ["Thick",
-                            "Thick - Lazy Zero", "Thick - Eager Zero"]) or
-                         (provider.one_of(VMwareProvider) and disk_format == "Thick" and
-                        appliance.version > '5.11') or
-                         (provider.one_of(VMwareProvider) and disk_format in ["Thick - Lazy Zero",
-                          "Thick - Eager Zero"] and appliance.version < '5.11') or
-                         (not provider.one_of(RHEVMProvider) and disk_format == "Preallocated") or
-                         # Temporarily, our storage domain cannot handle Preallocated disks
-                         (provider.one_of(RHEVMProvider) and disk_format == "Preallocated") or
-                         (provider.one_of(SCVMMProvider)))
+    "Thick - Lazy Zero", "Thick - Eager Zero"],
+    ids=["thin", "thick", "preallocated", "thick_lazy", "thick_eager"])
+@pytest.mark.uncollectif(
+    lambda provider, disk_format, appliance:
+    (provider.one_of(RHEVMProvider) and disk_format in ["Thick", "Thick - Lazy Zero",
+        "Thick - Eager Zero"]) or
+    (provider.one_of(VMwareProvider) and disk_format == "Thick" and appliance.version > '5.11') or
+    (provider.one_of(VMwareProvider) and disk_format in ["Thick - Lazy Zero",
+        "Thick - Eager Zero"] and appliance.version < '5.11') or
+    (not provider.one_of(RHEVMProvider) and disk_format == "Preallocated") or
+    # Temporarily, our storage domain cannot handle Preallocated disks
+    (provider.one_of(RHEVMProvider) and disk_format == "Preallocated") or
+    (provider.one_of(SCVMMProvider))
+)
 def test_disk_format_select(provisioner, disk_format, provider, prov_data, vm_name):
     """ Tests disk format selection in provisioning dialog.
 

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -166,9 +166,16 @@ def test_change_cpu_ram(provisioner, soft_assert, provider, prov_data, vm_name):
 @pytest.mark.rhv3
 # Special parametrization in testgen above
 @pytest.mark.meta(blockers=[1209847, 1380782])
-@pytest.mark.parametrize("disk_format", ["Thin", "Thick", "Preallocated"])
-@pytest.mark.uncollectif(lambda provider, disk_format:
-                         (provider.one_of(RHEVMProvider) and disk_format == "Thick") or
+@pytest.mark.meta(automates=[1633867])
+@pytest.mark.parametrize("disk_format", ["Thin", "Thick", "Preallocated",
+    "Thick - Lazy Zero", "Thick - Eager Zero"])
+@pytest.mark.uncollectif(lambda provider, disk_format, appliance:
+                         (provider.one_of(RHEVMProvider) and disk_format in ["Thick",
+                            "Thick - Lazy Zero", "Thick - Eager Zero"]) or
+                         (provider.one_of(VMwareProvider) and disk_format == "Thick" and
+                        appliance.version > '5.11') or
+                         (provider.one_of(VMwareProvider) and disk_format in ["Thick - Lazy Zero",
+                          "Thick - Eager Zero"] and appliance.version < '5.11') or
                          (not provider.one_of(RHEVMProvider) and disk_format == "Preallocated") or
                          # Temporarily, our storage domain cannot handle Preallocated disks
                          (provider.one_of(RHEVMProvider) and disk_format == "Preallocated") or
@@ -195,9 +202,6 @@ def test_disk_format_select(provisioner, disk_format, provider, prov_data, vm_na
         caseimportance: high
         initialEstimate: 1/6h
     """
-
-    if provider.key == "vsphere55" and disk_format == "Thick":
-        pytest.skip("Vsphere55 provider with disk_format == Thick isn't supported")
 
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['hardware']["disk_format"] = disk_format


### PR DESCRIPTION
## Purpose or Intent
- __Extending__ Test case for including "Thick - Lazy Zero/Eager Zero" that is being introduced in new 5.11 build.
![image](https://user-images.githubusercontent.com/8180469/62555417-dc99de80-b840-11e9-90a3-af7eff6f6858.png)

https://github.com/ManageIQ/manageiq-providers-vmware/pull/427
### PRT Run


Some examples are:
- {{pytest: cfme/tests/infrastructure/test_provisioning_dialog.py -k 'test_disk_format_select' --use-provider vsphere67-nested --long-running -v}}
