### PR TITLE
[RFR] fixed all_options in tagging dropdown

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -2831,9 +2831,7 @@ class ReactSelect(Widget, ClickableMixin):
     def all_options(self):
         # need to open the dropdown to see all available options
         self.open()
-        options = [
-            self.browser.text(e).encode("utf-8") for e in self.browser.elements(self.ALL_OPTIONS)
-        ]
+        options = [self.browser.text(e) for e in self.browser.elements(self.ALL_OPTIONS)]
         self.close()
         return options
 


### PR DESCRIPTION
## Purpose or Intent
Fixes
```
>           item = item.split(" *")[0]
E           TypeError: a bytes-like object is required, not 'str'

widgetastic_manageiq/__init__.py:2813: TypeError
TypeError
b"a bytes-like object is required, not 'str'"
```
I guess `encode("utf-8")` no longer needed with python3 and it works now without it.

### PRT Run

{{ pytest: -v cfme/tests/storage/test_volume.py::test_storage_volume_edit_tag --use-provider=complete --long-running }}
