### PR TITLE
[RFR] Fixed type error in automate method

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -96,7 +96,7 @@ class Inputs(View, ClickableMixin):
         keys = set(value.keys())
         value = copy(value)
 
-        present = list(self.inputs.read().keys())
+        present = set(self.inputs.read().keys())
         to_delete = present - keys
         changed = False
 


### PR DESCRIPTION
## Purpose or Intent
- Fixed error:
```
>       to_delete = present - keys
E       TypeError: unsupported operand type(s) for -: 'list' and 'set'

cfme/automate/explorer/method.py:100: TypeError
TypeError
b"unsupported operand type(s) for -: 'list' and 'set'"
```

### PRT Run
{{ pytest: cfme/tests/automate/test_method.py -k 'test_automate_method_inputs_crud' --use-template-cache -qsvv }}