### PR TITLE
[1LP][RFR]Automate test: test_diagnostics_server

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -1225,6 +1225,7 @@ class RegionDiagnosticsView(ConfigurationView):
     @View.nested
     class servers(WaitTab):  # noqa
         TAB_NAME = "Servers"
+        table = Table('//*[@id="miq-gtl-view"]//table')
 
     @View.nested
     class database(WaitTab):  # noqa
@@ -1513,6 +1514,7 @@ class ZoneDiagnosticsView(ConfigurationView):
     @View.nested
     class servers(WaitTab):  # noqa
         TAB_NAME = "Servers"
+        table = Table('//*[@id="miq-gtl-view"]//table')
 
     @View.nested
     class collectlogs(WaitTab):  # noqa

--- a/cfme/tests/configure/test_config_diagnostics.py
+++ b/cfme/tests/configure/test_config_diagnostics.py
@@ -76,7 +76,8 @@ def test_configuration_dropdown_roles_by_server(appliance, request):
 @test_requirements.general_ui
 @pytest.mark.tier(1)
 @pytest.mark.meta(automates=[1498090])
-def test_diagnostics_server(appliance):
+@pytest.mark.parametrize("obj", ["Zone", "Region"])
+def test_diagnostics_server(appliance, obj):
     """
     Polarion:
         assignee: pvala
@@ -97,14 +98,13 @@ def test_diagnostics_server(appliance):
     Bugzilla:
         1498090
     """
+    context_obj = (
+        appliance.server.zone.region if obj == "Region" else appliance.server.zone
+    )
+
     required_view = appliance.server.create_view(ServerDiagnosticsView)
 
-    view = navigate_to(appliance.server.zone.region, "Servers")
-    view.servers.table.row(name=appliance.server.name).click()
-    assert required_view.is_displayed
-    assert required_view.summary.is_active()
-
-    view = navigate_to(appliance.server.zone, "Servers")
+    view = navigate_to(context_obj, "Servers")
     view.servers.table.row(name=appliance.server.name).click()
     assert required_view.is_displayed
     assert required_view.summary.is_active()

--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -76,36 +76,6 @@ def test_configure_icons_roles_by_server():
 
 
 @pytest.mark.manual
-@test_requirements.general_ui
-@pytest.mark.tier(1)
-@pytest.mark.meta(coverage=[1498090])
-def test_diagnostics_server():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Configuration
-        caseimportance: medium
-        initialEstimate: 1/15h
-        testSteps:
-            1. Navigate to Configuration and go to Diagnostics accordion.
-            2. Click on Region.
-            3. Click on `Servers` tab and select a server from the table and check the landing page.
-            4. Click Zone.
-            5. Click on `Servers` tab and select a server from the table and check the landing page.
-        expectedResults:
-            1.
-            2.
-            3. Landing page must be `Diagnostics Server` summary page.
-            4.
-            5. Landing page must be `Diagnostics Server` summary page.
-
-    Bugzilla:
-        1498090
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_replication_subscription_crud():
     """


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__ `test_diagnostics_server`.
- __Extending__ `ZoneDiagnosticsView.servers` and `RegionDiagnosticsView.servers` tab by adding `Table`.

### PRT Run
{{ pytest: cfme/tests/configure/test_config_diagnostics.py::test_diagnostics_server -vvv }}