### PR TITLE
[1LP][RFR] Test cleanup and other changes

### DIFF
--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -181,7 +181,7 @@ def test_new_report_fields(appliance, based_on, request):
 
 
 @pytest.mark.tier(1)
-@pytest.mark.meta(automates=[1565171])
+@pytest.mark.meta(automates=[1565171, 1519809])
 def test_report_edit_secondary_display_filter(
     appliance, request, soft_assert, get_report
 ):
@@ -200,6 +200,7 @@ def test_report_edit_secondary_display_filter(
 
     Bugzilla:
         1565171
+        1519809
     """
     report = get_report("filter_report.yaml", "test_filter_report")
     report.update(

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -38,37 +38,6 @@ def test_reports_generate_custom_conditional_filter_report():
 @pytest.mark.manual
 @test_requirements.report
 @pytest.mark.tier(1)
-def test_after_setting_certain_types_of_filters_filter_tab_should_be_accessible_and_editable():
-    """
-    Bugzilla:
-        1519809
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/4h
-        title: After setting certain types of filters filter tab should be
-                accessible and editable
-        setup:
-            1. Navigate to Cloud Intel > Reports > All Reports.
-            2. Click on `Configuration` and select `Add a new Report`.
-            3. Add a report using a filter based on "EVM Custom Attributes:
-            Name" and "EVM Custom Attributes: Value".
-            4. Edit the report.
-        testSteps:
-            1. Try editing the filter.
-        expectedResults:
-            1. Editing the filter should not result in screen freeze.
-            Report must be accessible without causing puma consumption of all cpu on at least one
-            thread.
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
-@pytest.mark.tier(1)
 def test_date_should_be_change_in_editing_reports_scheduled():
     """
     Bugzilla:
@@ -90,35 +59,6 @@ def test_date_should_be_change_in_editing_reports_scheduled():
         expectedResults:
             1. "Timer" must change accordingly.
             2. "Starting Date" must change accordingly.
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
-@pytest.mark.tier(1)
-def test_report_secondary_display_filter_should_be_editable():
-    """
-    Bugzilla:
-        1565171
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/6h
-        title: Report secondary (display) filter should be editable
-        setup:
-            1. Create report based on container images.
-            2. Select some fields for the report.
-            3. Go to the filter tab and add a primary filter.
-            4. Add secondary filter.
-            5. Save the report.
-            6. Edit the report.
-        testSteps:
-            1.Try to edit the secondary filter.
-        expectedResults:
-            1. Secondary filter must be editable.
     """
     pass
 

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -322,6 +322,7 @@ def test_tls_openssl_verify_mode(temp_appliance_preconfig, request):
     # start_tls will be set to False since it's default value is True,
     # although value of start_tls doesn't really affect the value of openssl_verify_mode
     appliance.server.settings.update_smtp_server({"start_tls": not old_tls})
+    assert view.smtp_server.start_tls.read() == (not old_tls)
 
     # 3
     wait_for(
@@ -334,6 +335,7 @@ def test_tls_openssl_verify_mode(temp_appliance_preconfig, request):
     # reset `Start TLS Automatically` and assert that
     # the value of openssl_verify_mode is still none.
     appliance.server.settings.update_smtp_server({"start_tls": old_tls})
+    assert view.smtp_server.start_tls.read() == old_tls
     assert appliance.advanced_settings["smtp"]["openssl_verify_mode"] == "none"
 
 


### PR DESCRIPTION
## Purpose or Intent
- __Updating tests__ `test_tls_openssl_verify_mode` to validate smtp_server updates.
- __Removing tests__ `test_after_setting_certain_types_of_filters_filter_tab_should_be_accessible_and_editable` and `test_report_secondary_display_filter_should_be_editable` which have already been automated in `test_report_edit_secondary_display_filter`.

### PRT Run
{{ pytest: cfme/tests/webui/test_general_ui.py::test_tls_openssl_verify_mode -vvv }}