### PR TITLE
[RFR] fixed test_set_default_host_filter

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -217,7 +217,7 @@ class HostsView(ComputeInfrastructureHostsView):
 
     @property
     def is_displayed(self):
-        return self.in_compute_infrastructure_hosts and self.title.text in "Hosts / Nodes"
+        return self.in_compute_infrastructure_hosts and "Hosts" in self.title.text
 
 
 class HostFormView(ComputeInfrastructureHostsView):


### PR DESCRIPTION
## Purpose or Intent
Fixed `test_set_default_host_filter` for 5.11

### PRT Run

{{ pytest: -v cfme/tests/infrastructure/test_set_default_filter.py::test_set_default_host_filter --use-provider=complete --long-running }}