### PR TITLE
[1LP][RFR] New View in 5.11 for Settings > Server > Workers

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -28,6 +28,8 @@ from cfme.base.login import BaseLoggedInPage
 from cfme.configure.about import AboutView
 from cfme.configure.configuration.server_settings import ServerAuthenticationView
 from cfme.configure.configuration.server_settings import ServerInformationView
+from cfme.configure.configuration.server_settings import ServerWorkersTab510
+from cfme.configure.configuration.server_settings import ServerWorkersTab511
 from cfme.configure.documentation import DocView
 from cfme.configure.tasks import TasksView
 from cfme.dashboard import DashboardView
@@ -45,6 +47,8 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.appliance.implementations.ui import ViaUI
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
+from cfme.utils.version import Version
+from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import AttributeValueForm
 from widgetastic_manageiq import Checkbox
 from widgetastic_manageiq import InputButton
@@ -486,34 +490,10 @@ class ServerView(ConfigurationView):
         TAB_NAME = "Authentication"
         including_view = View.include(ServerAuthenticationView, use_parent=True)
 
-    @View.nested
-    class workers(WaitTab):  # noqa
-        TAB_NAME = "Workers"
-        # TODO move workers tab view into server_settings as ServerWorkersView
-        generic_worker_count = BootstrapSelect("generic_worker_count")
-        generic_worker_threshold = BootstrapSelect("generic_worker_threshold")
-        cu_data_collector_worker_count = BootstrapSelect("ems_metrics_collector_worker_count")
-        cu_data_collector_worker_threshold = BootstrapSelect(
-            "ems_metrics_collector_worker_threshold")
-        event_monitor_worker_threshold = BootstrapSelect("event_catcher_threshold")
-        connection_broker_worker_threshold = BootstrapSelect("vim_broker_worker_threshold")
-        ui_worker_count = BootstrapSelect("ui_worker_count")
-        reporting_worker_count = BootstrapSelect("reporting_worker_count")
-        reporting_worker_threshold = BootstrapSelect("reporting_worker_threshold")
-        web_service_worker_count = BootstrapSelect("web_service_worker_count")
-        web_service_worker_threshold = BootstrapSelect("web_service_worker_threshold")
-        priority_worker_count = BootstrapSelect("priority_worker_count")
-        priority_worker_threshold = BootstrapSelect("priority_worker_threshold")
-        cu_data_processor_worker_count = BootstrapSelect("ems_metrics_processor_worker_count")
-        cu_data_processor_worker_threshold = BootstrapSelect(
-            "ems_metrics_processor_worker_threshold")
-        refresh_worker_threshold = BootstrapSelect("ems_refresh_worker_threshold")
-        vm_analysis_collectors_worker_count = BootstrapSelect("proxy_worker_count")
-        vm_analysis_collectors_worker_threshold = BootstrapSelect("proxy_worker_threshold")
-        websocket_worker_count = BootstrapSelect("websocket_worker_count")
-
-        save = Button('Save')
-        reset = Button('Reset')
+    workers = VersionPicker({
+        '5.11': View.nested(ServerWorkersTab511),
+        Version.lowest(): View.nested(ServerWorkersTab510)
+    })
 
     @View.nested
     class customlogos(WaitTab):  # noqa

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -20,6 +20,8 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from widgetastic_manageiq import ReactSelect
+from widgetastic_manageiq import WaitTab
 
 
 AUTH_MODES = {
@@ -726,3 +728,59 @@ class AuthenticationSetting(NavigatableMixin, Updateable, Pretty):
                 view.flash.assert_no_error()
         else:
             logger.info('No authentication settings changed, not saving form.')
+
+
+class ServerWorkersTab510(WaitTab):
+    TAB_NAME = "Workers"
+    generic_worker_count = BootstrapSelect("generic_worker_count")
+    generic_worker_threshold = BootstrapSelect("generic_worker_threshold")
+    cu_data_collector_worker_count = BootstrapSelect("ems_metrics_collector_worker_count")
+    cu_data_collector_worker_threshold = BootstrapSelect(
+        "ems_metrics_collector_worker_threshold")
+    event_monitor_worker_threshold = BootstrapSelect("event_catcher_threshold")
+    connection_broker_worker_threshold = BootstrapSelect("vim_broker_worker_threshold")
+    ui_worker_count = BootstrapSelect("ui_worker_count")
+    reporting_worker_count = BootstrapSelect("reporting_worker_count")
+    reporting_worker_threshold = BootstrapSelect("reporting_worker_threshold")
+    web_service_worker_count = BootstrapSelect("web_service_worker_count")
+    web_service_worker_threshold = BootstrapSelect("web_service_worker_threshold")
+    priority_worker_count = BootstrapSelect("priority_worker_count")
+    priority_worker_threshold = BootstrapSelect("priority_worker_threshold")
+    cu_data_processor_worker_count = BootstrapSelect("ems_metrics_processor_worker_count")
+    cu_data_processor_worker_threshold = BootstrapSelect(
+        "ems_metrics_processor_worker_threshold")
+    refresh_worker_threshold = BootstrapSelect("ems_refresh_worker_threshold")
+    vm_analysis_collectors_worker_count = BootstrapSelect("proxy_worker_count")
+    vm_analysis_collectors_worker_threshold = BootstrapSelect("proxy_worker_threshold")
+    websocket_worker_count = BootstrapSelect("websocket_worker_count")
+
+    save = Button('Save')
+    reset = Button('Reset')
+
+
+class ServerWorkersTab511(WaitTab):
+    TAB_NAME = "Workers"
+    generic_worker_count = ReactSelect("generic_worker.count")
+    generic_worker_threshold = ReactSelect("generic_worker.memory_threshold")
+    priority_worker_count = ReactSelect("priority_worker.count")
+    priority_worker_threshold = ReactSelect("priority_worker.memory_threshold")
+    cu_data_collector_worker_count = ReactSelect("ems_metrics_collector_worker.defaults.count")
+    cu_data_collector_worker_threshold = ReactSelect(
+        "ems_metrics_collector_worker.defaults.memory_threshold")
+    cu_data_processor_worker_count = ReactSelect("ems_metrics_processor_worker.count")
+    cu_data_processor_worker_threshold = ReactSelect(
+        "ems_metrics_processor_worker.memory_threshold")
+    event_monitor_worker_threshold = ReactSelect("event_catcher.memory_threshold")
+    refresh_worker_threshold = ReactSelect("ems_refresh_worker.defaults.memory_threshold")
+    connection_broker_worker_threshold = ReactSelect("vim_broker_worker.memory_threshold")
+    vm_analysis_collectors_worker_count = ReactSelect("smart_proxy_worker.count")
+    vm_analysis_collectors_worker_threshold = ReactSelect("smart_proxy_worker.memory_threshold")
+    ui_worker_count = ReactSelect("ui_worker.count")
+    remote_console_worker_count = ReactSelect("remote_console_worker.count")
+    reporting_worker_count = ReactSelect("reporting_worker.count")
+    reporting_worker_threshold = ReactSelect("reporting_worker.memory_threshold")
+    web_service_worker_count = ReactSelect("web_service_worker.count")
+    web_service_worker_threshold = ReactSelect("web_service_worker.memory_threshold")
+
+    save = Button('Save')
+    reset = Button('Reset')


### PR DESCRIPTION
In 5.11, the Settings > Server > Workers configuration tab has been refactored:
- The ordering of elements in the HTML is different
- The dropdowns have changed from BootstrapSelect to ReactSelect widgets

This PR implements those changes by moving ServerWorkersView from cfme.base.ui into ServerWorkersTab510 in cfme.configure.configuration.server_settings, and creating a new class ServerWorkersTab511 with the above changes. ServerView in cfme.base.ui now uses VersionPicker to determine which of these classes to set as its nested 'workers' view.

The test_set_memory_threshold_in_ui test now works for both 5.10 and 5.11.

{{pytest: cfme/tests/configure/test_paginator.py cfme/tests/configure/test_workers.py::test_set_memory_threshold_in_ui -v}}
