### PR TITLE
[1LP][RFR]Fix schedules starting_date

### DIFF
--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -10,6 +10,7 @@ from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
+from widgetastic_patternfly import DatePicker
 from widgetastic_patternfly import FlashMessages
 
 from cfme.intelligence.reports import CloudIntelReportsView
@@ -21,7 +22,6 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
 from widgetastic_manageiq import AlertEmail
-from widgetastic_manageiq import Calendar
 from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import SummaryForm
 from widgetastic_manageiq import Table
@@ -69,7 +69,7 @@ class SchedulesFormCommon(CloudIntelReportsView):
         timer_month = BootstrapSelect("timer_months")
         timer_week = BootstrapSelect("timer_weeks")
         time_zone = BootstrapSelect("time_zone")
-        starting_date = Calendar("miq_date_1")
+        starting_date = DatePicker("miq_date_1")
         hour = BootstrapSelect("start_hour")
         minute = BootstrapSelect("start_min")
 

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -105,9 +105,9 @@ def test_reports_schedule_crud(schedule_data, appliance):
     view.flash.assert_success_message('Schedule "{}" was added'.format(schedule.name))
 
     # update
-    date = datetime.date.today() + datetime.timedelta(5)
+    date = datetime.datetime.today() + datetime.timedelta(5)
     updated_description = "badger badger badger"
-    updated_timer = {"run": "Monthly", "starting_date": date.strftime("%m/%d/%y")}
+    updated_timer = {"run": "Monthly", "starting_date": date}
 
     with update(schedule):
         schedule.description = updated_description
@@ -118,9 +118,7 @@ def test_reports_schedule_crud(schedule_data, appliance):
 
     run_at = view.schedule_info.get_text_of("Run At")
     assert updated_timer["run"].lower() in run_at
-
-    if not BZ(1729882, forced_streams=["5.10"]).blocks:
-        assert str(date.day) in run_at
+    assert str(date.day) in run_at
 
     # queue
     schedule.queue()


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ `test_reports_schedule_crud` to choose Date for `Starting Date`. Using `DatePicker` instead of `Calendar`.
- __Remove__ BZ blocker which no longer blocks.

### PRT Run

{{ pytest: cfme/tests/intelligence/reports/test_crud.py::test_reports_schedule_crud -vvv }}