### PR TITLE
[1LP][RFR]Add request.addfinalizer wherever missing in reports

### DIFF
--- a/cfme/tests/intelligence/reports/test_import_export_reports_widgets.py
+++ b/cfme/tests/intelligence/reports/test_import_export_reports_widgets.py
@@ -88,6 +88,7 @@ def test_export_widget(appliance, widget):
         startsin: 5.3
     """
     collection = appliance.collections.dashboard_report_widgets
+    # created widget will be deleted from the `widget` fixture
     collection.create(
         widget_class=getattr(collection, widget.TITLE.upper()),
         title=widget.title,

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -275,6 +275,7 @@ def test_send_text_custom_report_with_long_condition(
         "email_options": {"send_if_empty": True, "send_txt": True},
     }
     schedule = report.create_schedule(**data)
+    request.addfinalizer(schedule.delete_if_exists)
 
     # prepare LogValidator
     log = LogValidator(

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -23,8 +23,7 @@ def report(appliance):
         menu_name="Guest OS Information - any OS",
     ).queue(wait_for_finish=True)
     yield report
-    if report.exists:
-        report.delete()
+    report.delete_if_exists()
 
 
 @pytest.mark.rhv3


### PR DESCRIPTION
## Purpose or Intent
- __Extending__ reports tests by adding finalizer wherever missing.

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_crud.py cfme/tests/intelligence/reports/test_views.py -vvv }}