### PR TITLE
[1LP][RFR] Replace uncollectif with Provider markers

### DIFF
--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -17,12 +17,14 @@ from cfme.utils.wait import RefreshTimer
 from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for
 
+FILTER_FIELDS = dict(required_fields=['test_power_control'])
+
+
 pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.long_running,
     test_requirements.power,
-    pytest.mark.provider([CloudProvider], scope='function',
-                         required_fields=['test_power_control']),
+    pytest.mark.provider([CloudProvider], scope='function', **FILTER_FIELDS),
     pytest.mark.usefixtures('setup_provider'),
 ]
 
@@ -357,7 +359,8 @@ def test_power_on_or_off_multiple(provider, testing_instance, testing_instance2,
     wait_for_instance_state(soft_assert, testing_instance2, state="started")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+@pytest.mark.provider([OpenStackProvider],
+                      scope='function', override=True, **FILTER_FIELDS)
 def test_hard_reboot(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance hard reboot
 
@@ -380,7 +383,8 @@ def test_hard_reboot(appliance, provider, testing_instance, ensure_vm_running, s
     wait_for_instance_state(soft_assert, testing_instance, state="started")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider))
+@pytest.mark.provider([AzureProvider],
+                      scope='function', override=True, **FILTER_FIELDS)
 def test_hard_reboot_unsupported(appliance, testing_instance):
     """
     Tests that hard reboot throws an 'unsupported' error message on an Azure instance
@@ -403,7 +407,8 @@ def test_hard_reboot_unsupported(appliance, testing_instance):
     appliance.browser.create_view(BaseLoggedInPage).flash.assert_message(message)
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
+@pytest.mark.provider([AzureProvider, OpenStackProvider],
+                      scope='function', override=True, **FILTER_FIELDS)
 def test_suspend(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance suspend
 
@@ -425,7 +430,8 @@ def test_suspend(appliance, provider, testing_instance, ensure_vm_running, soft_
     wait_for_instance_state(soft_assert, testing_instance, state="suspended")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+@pytest.mark.provider([OpenStackProvider],
+                      scope='function', override=True, **FILTER_FIELDS)
 def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_assert):
     """ Tests instance unpause
 
@@ -445,7 +451,8 @@ def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_a
     wait_for_instance_state(soft_assert, testing_instance, state="started")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
+@pytest.mark.provider([AzureProvider, OpenStackProvider],
+                      scope='function', override=True, **FILTER_FIELDS)
 def test_resume(appliance, provider, testing_instance, ensure_vm_suspended, soft_assert):
     """ Tests instance resume
 
@@ -614,7 +621,8 @@ class TestInstanceRESTAPI(object):
             wait_for_pwr_state_change(testing_instance, state_change_time)
         wait_for_instance_state(soft_assert, testing_instance, state="started")
 
-    @pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+    @pytest.mark.provider([OpenStackProvider],
+                          scope='function', override=True, **FILTER_FIELDS)
     @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
     def test_hard_reboot(self, provider, testing_instance,
             soft_assert, ensure_vm_running, appliance, from_detail):
@@ -640,7 +648,8 @@ class TestInstanceRESTAPI(object):
             fail_func=vm.reload)
         wait_for_instance_state(soft_assert, testing_instance, state="started")
 
-    @pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
+    @pytest.mark.provider([AzureProvider, OpenStackProvider],
+                          scope='function', override=True, **FILTER_FIELDS)
     @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
     def test_suspend_resume(self, provider, testing_instance,
             soft_assert, ensure_vm_running, appliance, from_detail):
@@ -672,7 +681,8 @@ class TestInstanceRESTAPI(object):
         self.verify_action_result(appliance.rest_api)
         wait_for_instance_state(soft_assert, testing_instance, state="started")
 
-    @pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+    @pytest.mark.provider([OpenStackProvider],
+                          scope='function', override=True, **FILTER_FIELDS)
     @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
     def test_pause_unpause(self, provider, testing_instance,
             soft_assert, ensure_vm_running, appliance, from_detail):


### PR DESCRIPTION
Provider markers are preferred over using uncollectif. Especially without a reason! 

More of these to come as we change the behavior of uncollectif.