### PR TITLE
[1LP][RFR] Added test for BZ1734904.

### DIFF
--- a/cfme/fixtures/ansible_fixtures.py
+++ b/cfme/fixtures/ansible_fixtures.py
@@ -100,6 +100,26 @@ def ansible_service_catalog(appliance, ansible_catalog_item, ansible_catalog):
     return service_catalog
 
 
+@pytest.fixture(scope="function")
+def ansible_service_request_funcscope(appliance, ansible_catalog_item):
+    request_descr = "Provisioning Service [{0}] from [{0}]".format(ansible_catalog_item.name)
+    service_request = appliance.collections.requests.instantiate(description=request_descr)
+    yield service_request
+
+    if service_request.exists():
+        service_id = appliance.rest_api.collections.service_requests.get(description=request_descr)
+        appliance.rest_api.collections.service_requests.action.delete(id=service_id.id)
+
+
+@pytest.fixture(scope="function")
+def ansible_service_funcscope(appliance, ansible_catalog_item):
+    service = MyService(appliance, ansible_catalog_item.name)
+    yield service
+
+    if service.exists:
+        service.delete()
+
+
 @pytest.fixture(scope="module")
 def ansible_service_request(appliance, ansible_catalog_item):
     request_descr = "Provisioning Service [{0}] from [{0}]".format(ansible_catalog_item.name)


### PR DESCRIPTION
## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

- [x] Automated BZ 1734904
Ansible Galaxy role fetching and asserting service finished with okay status.
### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/ansible/test_embedded_ansible_services.py -k "test_ansible_service_ansible_galaxy_role" --long-running -svvvv }} 