### PR TITLE
[1LP][RFR] Automating RFE for open url general objects

### DIFF
--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -1,4 +1,5 @@
 import re
+from textwrap import dedent
 
 import fauxfactory
 import pytest
@@ -314,10 +315,51 @@ def test_custom_button_expression_evm_obj(appliance, request, setup_obj, button_
             assert button.text in custom_button_group.items
 
 
-@pytest.mark.manual
+@pytest.fixture(scope="module")
+def cls(appliance):
+    domain = appliance.collections.domains.create(
+        name=fauxfactory.gen_alphanumeric(start="domain"), enabled=True
+    )
+    original_class = (
+        domain.parent.instantiate(name="ManageIQ")
+        .namespaces.instantiate(name="System")
+        .classes.instantiate(name="Request")
+    )
+    original_class.copy_to(domain=domain)
+    yield domain.namespaces.instantiate(name="System").classes.instantiate(name="Request")
+    if domain.exists:
+        domain.delete()
+
+
+@pytest.fixture()
+def method(cls, button_group):
+    _, obj_type = button_group
+    obj_type = f"miq_{obj_type.lower()}" if obj_type == "GROUP" else obj_type.lower()
+
+    meth = cls.methods.create(
+        name=f"{obj_type}_{fauxfactory.gen_alphanumeric(8,start='meth', separator='_')}",
+        script=dedent(
+            f"""
+            # add external url to open
+            vm = $evm.root["{obj_type}"]
+            $evm.log(:info, "Opening url")
+            vm.remote_console_url = "https://example.com"
+            """
+        ),
+    )
+
+    instance = cls.instances.create(
+        name=f"{obj_type}_{fauxfactory.gen_alphanumeric(8,start='inst', separator='_')}",
+        fields={"meth1": {"value": meth.name}},
+    )
+    yield instance
+    meth.delete_if_exists()
+    instance.delete_if_exists()
+
+
 @pytest.mark.ignore_stream("5.10")
 @pytest.mark.meta(coverage=[1550002])
-def test_custom_button_open_url_evm_obj(setup_obj, button_group):
+def test_custom_button_open_url_evm_obj(request, setup_obj, button_group, method):
     """ Test Open url functionality of custom button.
 
     Polarion:
@@ -345,4 +387,40 @@ def test_custom_button_open_url_evm_obj(setup_obj, button_group):
     Bugzilla:
         1550002
     """
-    pass
+    group, obj_type = button_group
+
+    button = group.buttons.create(
+        text=fauxfactory.gen_alphanumeric(),
+        hover=fauxfactory.gen_alphanumeric(),
+        open_url=True,
+        system="Request",
+        request=method.name,
+    )
+    request.addfinalizer(button.delete_if_exists)
+
+    import ipdb; ipdb.set_trace()
+    view = navigate_to(setup_obj, "Details")
+    custom_button_group = Dropdown(view, group.hover)
+    assert custom_button_group.has_item(button.text)
+
+    # TODO: Move windows handling functionality to browser
+    initial_count = len(view.browser.selenium.window_handles)
+    main_window = view.browser.selenium.current_window_handle
+    custom_button_group.item_select(button.text)
+
+    wait_for(
+        lambda: len(view.browser.selenium.window_handles) > initial_count,
+        timeout=120,
+        message="Check for window open",
+    )
+    open_url_window = set(view.browser.selenium.window_handles) - {main_window}
+
+    view.browser.selenium.switch_to_window(open_url_window.pop())
+
+    @request.addfinalizer
+    def _reset_window():
+        if view.browser.selenium.current_window_handle != main_window:
+            view.browser.selenium.close()
+            view.browser.selenium.switch_to_window(main_window)
+
+    assert "example.com" in view.browser.url

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -336,7 +336,7 @@ wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.16.0
-widgetastic.core==0.40
+widgetastic.core==0.51
 widgetastic.patternfly==1.1.0
 widgetsnbextension==3.4.2
 wrapanapi==3.5.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -271,7 +271,7 @@ warlock==1.3.0
 wcwidth==0.1.7
 websocket-client==0.40.0
 Werkzeug==0.16.0
-widgetastic.core==0.39
+widgetastic.core==0.51
 widgetastic.patternfly==1.1.0
 widgetsnbextension==3.4.2
 wrapt==1.11.1


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- One step toward automating Open Url support for `User`, `Group` and `Tenanat`
- RFE: https://bugzilla.redhat.com/show_bug.cgi?id=1550002
- **one test will fail for tenant**

**Note:** RFE is in progress means Faild ON_QA but still I would like to make it as part of integration test as some objects are working fine.

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/automate/custom_button/test_generic_objects.py::test_custom_button_open_url_evm_obj -v}}

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].

Some examples are:
Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
