### PR TITLE
[RFR] fixed test_collect_unconfigured

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -298,10 +298,10 @@ def test_collect_unconfigured(appliance):
 
     view = navigate_to(server_log_depot, 'DiagnosticsCollectLogs')
     # check button is enable after adding log depot
-    assert view.toolbar.collect.item_enabled('Collect all logs') is True
+    assert view.toolbar.collect.is_displayed
     server_log_depot.clear()
     # check button is disable after removing log depot
-    assert view.toolbar.collect.item_enabled('Collect all logs') is False
+    assert not view.toolbar.collect.is_displayed
 
 
 @pytest.mark.parametrize('from_slave', [True, False], ids=['from_slave', 'from_master'])


### PR DESCRIPTION
## Purpose or Intent
fixes
```
E           selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator='.//div[contains(@class, "dropdown") and ./button[normalize-space(.)="Collect Logs" or normalize-space(@title)="Collect Logs"]]')

/var/ci/cfme_venv3/lib64/python3.7/site-packages/widgetastic/browser.py:347: NoSuchElementException
NoSuchElementException
b'Message: Could not find an element Locator(by=\'xpath\', locator=\'.//div[contains(@class, "dropdown") and ./button[normalize-space(.)="Collect Logs" or normalize-space(@title)="Collect Logs"]]\')\n'
```

### PRT Run

{{ pytest: -v cfme/tests/configure/test_log_depot_operation.py::test_collect_unconfigured --long-running }}