### PR TITLE
[1LP][RFR] fixed select in adding new orchestration template

### DIFF
--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -18,7 +18,11 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.version import LOWEST
+from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import PaginationPane
+from widgetastic_manageiq import ReactCodeMirror
+from widgetastic_manageiq import ReactSelect
 from widgetastic_manageiq import ScriptBox
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
@@ -49,11 +53,17 @@ class CopyTemplateForm(ServicesCatalogView):
 
 class TemplateForm(ServicesCatalogView):
     title = Text('#explorer_title_text')
-    template_type = BootstrapSelect("type")
+    template_type = VersionPicker({
+        "5.11": ReactSelect("type"),
+        LOWEST: BootstrapSelect("type")
+    })
     name = Input(name='name')
     description = Input(name="description")
     draft = Checkbox(name='draft')
-    content = ScriptBox(locator="//pre[@class=' CodeMirror-line ']/span")
+    content = VersionPicker({
+        "5.11": ReactCodeMirror(),
+        LOWEST: ScriptBox(locator="//pre[@class=' CodeMirror-line ']/span")
+    })
 
 
 class AddTemplateView(TemplateForm):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1022,6 +1022,43 @@ class ScriptBox(Widget):
         )
 
 
+class ReactCodeMirror(Widget):
+    """Looks the same as ScriptBox but it is changed in 5.11
+    https://github.com/JedWatson/react-codemirror"""
+
+    ROOT = "//div[contains(@class,'miq-codemirror')]//textarea"
+    PARENT_DIV = "./.."  # we need to change visibility of this one
+    CLICK_DIV = "./../.."  # the widget has very nested divs,we need to click on that one ¯\_(ツ)_/¯
+
+    def __init__(self, parent, logger=None):
+        Widget.__init__(self, parent, logger=logger)
+
+    @property
+    def element(self):
+        return self.browser.element(self)
+
+    @property
+    def is_editable(self):
+        return self.element.get_attribute("contentEditable") == "true"
+
+    def make_editable(self):
+        if not self.is_editable:
+            self.browser.set_attribute("contentEditable", "true", self)
+
+    def fill(self, value):
+        # TODO(anikifor): remove the 2 workarounds below as soon as BZ 1740753 is verified
+        self.make_editable()
+        self.browser.set_attribute("style", "overflow: visible", self.PARENT_DIV)
+        self.browser.element(self.CLICK_DIV).click()
+        self.element.send_keys(value)
+        return True
+
+    def read(self):
+        # TODO: implement, the text is stored separately on each line in the page
+        # locator for read is somewhere there "//pre[@class=' CodeMirror-line ']/span"
+        raise NotImplementedError("Read method is not implemented yet")
+
+
 class SettingsGroupSubmenu(NavDropdown):
     """
     Widget for the Group 'Dropdown' menu that allows a user assigned to multiple groups


### PR DESCRIPTION
## Purpose or Intent
Fixes 
```
E           selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator='.//div[contains(@class, "bootstrap-select")]/button[normalize-space(@data-id)="type"]/..')

/var/ci/cfme_venv3/lib64/python3.7/site-packages/widgetastic/browser.py:347: NoSuchElementException
NoSuchElementException
b'Message: Could not find an element Locator(by=\'xpath\', locator=\'.//div[contains(@class, "bootstrap-select")]/button[normalize-space(@data-id)="type"]/..\')\n'
```
~~in 5.11 but there's another frontend change that will fail the PRT.~~

I also had to create a new widget `ReactCodemirror` which is incomplete. I'd also like to implement `read` method there but so far tests pass and I can do it in a separate PR.

### PRT Run

{{ pytest: -v cfme/tests/services/test_orchestration_template.py::test_tag_orchestration_template --long-running }}