### PR TITLE
[RFR] Test to create service dialog from Tower job template

### DIFF
--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -126,6 +126,13 @@ class TowerExplorerJobTemplateDetailsView(TowerExplorerView):
         )
 
 
+class TowerExplorerJobServiceDialogView(TowerExplorerView):
+    @property
+    def is_displayed(self):
+        expected_title = 'Adding a new Service Dialog from "{}"'.format(self.context['object'].name)
+        return self.title.text == expected_title
+
+
 @attr.s
 class AnsibleTowerProvider(BaseEntity):
     pass
@@ -213,9 +220,10 @@ class TowerExplorerJobTemplateDetails(CFMENavigateStep):
 
 
 @navigator.register(AnsibleTowerJobTemplate, 'ServiceDialog')
-class ServiceDialogCreation(CFMENavigateStep):
+class TowerExplorerJobServiceDialog(CFMENavigateStep):
     VIEW = TowerExplorerJobServiceDialogView
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.toolbar.configuration.item_select('Create Service Dialog from this Template')
+        self.prerequisite_view.toolbar.configuration.item_select(
+            'Create Service Dialog from this Template')

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -60,7 +60,7 @@ class TowerExplorerSystemJobTemplatesToolbar(View):
 
 
 class TowerExplorerSystemJobTemplatesDetailsToolbar(View):
-    reload = Button(title='Refresh this page')
+    refresh = Button(title='Refresh this page')
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
 
@@ -140,11 +140,16 @@ class OptionForm(View):
 class TowerExplorerJobServiceDialogView(TowerExplorerView):
     options = View.nested(OptionForm)
     save_button = Button('Save')
+    cancel_button = Button('Cancel')
 
     @property
     def is_displayed(self):
-        expected_title = 'Adding a new Service Dialog from "{}"'.format(self.context['object'].name)
-        return self.title.text == expected_title
+        return (
+            self.in_tower_explorer
+            and self.title.text
+            == 'Adding a new Service Dialog from "{}"'.format(self.context['object'].name)
+            and self.sidebar.job_templates.is_opened
+        )
 
 
 @attr.s

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -133,12 +133,8 @@ class TowerExplorerJobTemplateDetailsView(TowerExplorerView):
         )
 
 
-class OptionForm(View):
+class TowerCreateServiceDialogFromTemplateView(TowerExplorerView):
     dialog_name = TextInput('dialog_name')
-
-
-class TowerExplorerJobServiceDialogView(TowerExplorerView):
-    options = View.nested(OptionForm)
     save_button = Button('Save')
     cancel_button = Button('Cancel')
 
@@ -175,6 +171,15 @@ class AnsibleTowerSystemsCollection(BaseCollection):
 @attr.s
 class AnsibleTowerJobTemplate(BaseEntity, Taggable):
     name = attr.ib()
+
+    def create_service_dailog(self, name):
+        view = navigate_to(self, "CreateServiceDialog")
+        changes = view.fill({"dialog_name": name})
+        if changes:
+            view.save_button.click()
+            return self.appliance.collections.service_dialogs.instantiate(label=name)
+        else:
+            view.cancel_button.click()
 
 
 @attr.s
@@ -238,9 +243,9 @@ class TowerExplorerJobTemplateDetails(CFMENavigateStep):
         row.click()
 
 
-@navigator.register(AnsibleTowerJobTemplate, 'ServiceDialog')
-class TowerExplorerJobServiceDialog(CFMENavigateStep):
-    VIEW = TowerExplorerJobServiceDialogView
+@navigator.register(AnsibleTowerJobTemplate, 'CreateServiceDialog')
+class TowerCreateServiceDialogFromTemplate(CFMENavigateStep):
+    VIEW = TowerCreateServiceDialogFromTemplateView
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -24,6 +24,7 @@ from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
+import pytest
 
 
 class TowerExplorerAccordion(View):
@@ -53,6 +54,15 @@ class TowerExplorerProviderToolbar(View):
 
 class TowerExplorerSystemJobTemplatesToolbar(View):
     reload = Button(title='Refresh this page')
+    configuration = Dropdown('Configuration')
+    policy = Dropdown('Policy')
+    download = Dropdown('Download')
+    view_selector = View.nested(ItemsToolBarViewSelector)
+
+
+class TowerExplorerSystemJobTemplatesDetailsToolbar(View):
+    reload = Button(title='Refresh this page')
+    configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     download = Dropdown('Download')
     view_selector = View.nested(ItemsToolBarViewSelector)
@@ -126,7 +136,14 @@ class TowerExplorerJobTemplateDetailsView(TowerExplorerView):
         )
 
 
+class OptionForm(View):
+    dialog_name = Text('//*[@id="dialog_name"]')
+
+
 class TowerExplorerJobServiceDialogView(TowerExplorerView):
+    toolbar = View.nested(TowerExplorerSystemJobTemplatesDetailsToolbar)
+    options = View.nested(OptionForm)
+
     @property
     def is_displayed(self):
         expected_title = 'Adding a new Service Dialog from "{}"'.format(self.context['object'].name)
@@ -225,5 +242,6 @@ class TowerExplorerJobServiceDialog(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):
+        pytest.set_trace()
         self.prerequisite_view.toolbar.configuration.item_select(
             'Create Service Dialog from this Template')

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -210,3 +210,12 @@ class TowerExplorerJobTemplateDetails(CFMENavigateStep):
         except ItemNotFound:
             raise ItemNotFound('Could not locate template "{}"'.format(self.obj.name))
         row.click()
+
+
+@navigator.register(AnsibleTowerJobTemplate, 'ServiceDialog')
+class ServiceDialogCreation(CFMENavigateStep):
+    VIEW = TowerExplorerJobServiceDialogView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.toolbar.configuration.item_select('Create Service Dialog from this Template')

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -2,6 +2,7 @@ import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
 from widgetastic.widget import Text
+from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic_patternfly import Dropdown
 
@@ -24,7 +25,6 @@ from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
-import pytest
 
 
 class TowerExplorerAccordion(View):
@@ -54,7 +54,6 @@ class TowerExplorerProviderToolbar(View):
 
 class TowerExplorerSystemJobTemplatesToolbar(View):
     reload = Button(title='Refresh this page')
-    configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
     download = Dropdown('Download')
     view_selector = View.nested(ItemsToolBarViewSelector)
@@ -64,8 +63,6 @@ class TowerExplorerSystemJobTemplatesDetailsToolbar(View):
     reload = Button(title='Refresh this page')
     configuration = Dropdown('Configuration')
     policy = Dropdown('Policy')
-    download = Dropdown('Download')
-    view_selector = View.nested(ItemsToolBarViewSelector)
 
 
 class TowerExplorerView(BaseLoggedInPage):
@@ -123,7 +120,7 @@ class TowerExplorerJobTemplateDetailsEntities(View):
 
 
 class TowerExplorerJobTemplateDetailsView(TowerExplorerView):
-    toolbar = View.nested(TowerExplorerSystemJobTemplatesToolbar)
+    toolbar = View.nested(TowerExplorerSystemJobTemplatesDetailsToolbar)
     entities = View.nested(TowerExplorerJobTemplateDetailsEntities)
 
     @property
@@ -137,12 +134,12 @@ class TowerExplorerJobTemplateDetailsView(TowerExplorerView):
 
 
 class OptionForm(View):
-    dialog_name = Text('//*[@id="dialog_name"]')
+    dialog_name = TextInput('dialog_name')
 
 
 class TowerExplorerJobServiceDialogView(TowerExplorerView):
-    toolbar = View.nested(TowerExplorerSystemJobTemplatesDetailsToolbar)
     options = View.nested(OptionForm)
+    save_button = Button('Save')
 
     @property
     def is_displayed(self):
@@ -242,6 +239,5 @@ class TowerExplorerJobServiceDialog(CFMENavigateStep):
     prerequisite = NavigateToSibling('Details')
 
     def step(self, *args, **kwargs):
-        pytest.set_trace()
         self.prerequisite_view.toolbar.configuration.item_select(
             'Create Service Dialog from this Template')

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -2,6 +2,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.testgen import config_managers
 from cfme.utils.testgen import generate
 from cfme.utils.update import update
@@ -29,6 +30,7 @@ def test_config_manager_detail_config_btn(request, config_manager):
     """
     Polarion:
         assignee: nachandr
+        caseimportance: medium
         initialEstimate: 1/2h
         casecomponent: Ansible
     """
@@ -52,6 +54,7 @@ def test_config_manager_add_invalid_url(request, config_manager_obj):
     """
     Polarion:
         assignee: nachandr
+        caseimportance: medium
         initialEstimate: 1/15h
         casecomponent: Ansible
     """
@@ -87,6 +90,7 @@ def test_config_manager_edit(request, config_manager):
     """
     Polarion:
         assignee: nachandr
+        caseimportance: medium
         initialEstimate: 1/15h
         casecomponent: Ansible
     """
@@ -104,6 +108,7 @@ def test_config_manager_remove(config_manager):
     """
     Polarion:
         assignee: nachandr
+        caseimportance: medium
         initialEstimate: 1/15h
         casecomponent: Ansible
     """
@@ -151,3 +156,21 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag):
 # def test_config_system_reprovision(config_system):
 #    # TODO specify machine per stream in yamls or use mutex (by tagging/renaming)
 #    pass
+
+
+@pytest.mark.tier(3)
+def test_ansible_tower_service_dialog_creation_from_template(request, config_manager):
+    """
+    Polarion:
+        assignee: nachandr
+        initialEstimate: 1/4h
+        casecomponent: Ansible
+        caseimportance: high
+
+    """
+    try:
+        job_template = config_manager.appliance.collections.ansible_tower_job_templates.all()[0]
+    except IndexError:
+        pytest.skip("No job template was found")
+    view = navigate_to(job_template, 'ServiceDialog')
+    view.flash.assert_success_message('Service Dialog {} was successfully created'.format(text))

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -2,7 +2,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.ansible_tower.explorer import TowerCreateServiceDialogFromTemplateView
 from cfme.utils.testgen import config_managers
 from cfme.utils.testgen import generate
 from cfme.utils.update import update
@@ -173,15 +173,11 @@ def test_ansible_tower_service_dialog_creation_from_template(request, config_man
         job_template = config_manager.appliance.collections.ansible_tower_job_templates.all()[0]
     except IndexError:
         pytest.skip("No job template was found")
-    view = navigate_to(job_template, 'ServiceDialog')
     dialog_label = fauxfactory.gen_alpha(8)
-    view.options.dialog_name.fill(dialog_label)
-    view.save_button.click()
+    dialog = job_template.create_service_dailog(dialog_label)
+    view = job_template.browser.create_view(TowerCreateServiceDialogFromTemplateView)
     view.flash.assert_success_message('Service Dialog "{}" was successfully created'.format(
         dialog_label))
+    assert dialog.exists
 
-    service_dialogs = appliance.collections.service_dialogs
-    service_dialog = service_dialogs.instantiate(
-        label=dialog_label
-    )
-    service_dialog.delete_if_exists()
+    dialog.delete_if_exists()

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -159,6 +159,7 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag):
 
 
 @pytest.mark.tier(3)
+@pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type != "Ansible Tower")
 def test_ansible_tower_service_dialog_creation_from_template(request, config_manager):
     """
     Polarion:
@@ -173,4 +174,5 @@ def test_ansible_tower_service_dialog_creation_from_template(request, config_man
     except IndexError:
         pytest.skip("No job template was found")
     view = navigate_to(job_template, 'ServiceDialog')
+    view.options.dialog_name.fill('test_dialog')
     view.flash.assert_success_message('Service Dialog {} was successfully created'.format(text))

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -25,19 +25,6 @@ def config_system(config_manager):
     return fauxfactory.gen_choice(config_manager.systems)
 
 
-@pytest.fixture
-def ansible_tower_dialog_through_ui(appliance):
-    """Returns service dialog object."""
-    service_dialogs = appliance.collections.service_dialogs
-    service_dialog = service_dialogs.instantiate(
-        label=fauxfactory.gen_alpha(8),
-        description=fauxfactory.gen_alpha(8)
-    )
-    yield service_dialog
-
-    service_dialog.delete_if_exists()
-
-
 @pytest.mark.tier(3)
 def test_config_manager_detail_config_btn(request, config_manager):
     """
@@ -173,8 +160,7 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag):
 
 @pytest.mark.tier(3)
 @pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type != "Ansible Tower")
-def test_ansible_tower_service_dialog_creation_from_template(request, config_manager,
-        ansible_tower_dialog_through_ui):
+def test_ansible_tower_service_dialog_creation_from_template(request, config_manager, appliance):
     """
     Polarion:
         assignee: nachandr
@@ -188,8 +174,14 @@ def test_ansible_tower_service_dialog_creation_from_template(request, config_man
     except IndexError:
         pytest.skip("No job template was found")
     view = navigate_to(job_template, 'ServiceDialog')
-    service_dialog = ansible_tower_dialog_through_ui
-    view.options.dialog_name.fill(service_dialog.label)
+    dialog_label = fauxfactory.gen_alpha(8)
+    view.options.dialog_name.fill(dialog_label)
     view.save_button.click()
     view.flash.assert_success_message('Service Dialog "{}" was successfully created'.format(
-        service_dialog.label))
+        dialog_label))
+
+    service_dialogs = appliance.collections.service_dialogs
+    service_dialog = service_dialogs.instantiate(
+        label=dialog_label
+    )
+    service_dialog.delete_if_exists()


### PR DESCRIPTION
{{pytest: cfme/tests/infrastructure/test_config_management.py -v}}

## Purpose or Intent
Test to automate creation of service dialog from Ansible Tower job template
1)The existing TowerExplorerJobTemplateDetailsView was using an incorrect toolbar. Fixed that.
2)Created a new view for creation of service dailogs from Tower job templates.
2)Added a new test to create service dialog from Tower job template

### PRT results 
The test_config_system_tag[satellite_62] test  is failing on both 510 and 511 . The failure is not related to the code changes made through this PR.
All the other tests passed on both 510 and 511.