### PR TITLE
[1LP][RFR]Fix SavedReportDetailsView is_displayed

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -247,15 +247,11 @@ class SavedReportDetailsView(CloudIntelReportsView):
 
     @property
     def is_displayed(self):
-        expected_title = 'Saved Report "{} - {}"'.format(
-            self.context["object"].report.title or self.context['object'].report.menu_name,
-            self.context["object"].queued_datetime_in_title
-        )
         return (
-            self.in_intel_reports and
-            self.reports.is_opened and
-            self.reports.tree.currently_selected == self.context["object"].tree_path and
-            self.title.text == expected_title
+            self.in_intel_reports
+            and self.reports.is_opened
+            and self.reports.tree.currently_selected == self.context["object"].tree_path
+            and self.context["object"].queued_datetime_in_title in self.title.text
         )
 
 

--- a/cfme/tests/intelligence/reports/test_generate_report.py
+++ b/cfme/tests/intelligence/reports/test_generate_report.py
@@ -54,8 +54,6 @@ def test_reports_generate_report(request, path, appliance):
         subtype=path[1],
         menu_name=path[2]
     ).queue(wait_for_finish=True)
+    request.addfinalizer(report.delete_if_exists)
 
-    @request.addfinalizer
-    def _finalize():
-        if report.exists:
-            report.delete()
+    assert report.exists


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ `is_displayed` method of `SavedReportDetailsView`. There are many reports whose title changes after they're generated.
See this screenshot to understand better:
![Screenshot from 2019-08-14 14-39-10](https://user-images.githubusercontent.com/11015077/63020243-33478e00-bebb-11e9-9c2d-439b28c0c353.png)

Here `view.title.text` is `Saved Report "Processes for prod VMs sorted by CPU Time - Wed, 14 Aug 2019 07:54:53 +0000"`
but `expected_title` is `Saved Report "Processes for prod VMs sort by CPU Time - Wed, 14 Aug 2019 07:54:53 +0000"`

This is not a bug. There are other reports which have different name than it's `menu_name`, so instead of exactly matching the titles, we only check if `saved_report.queued_datetime_in_title` is present in `view.title.text`.

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_generate_report.py -vvv }}