### PR TITLE
[WIP] fixed server id for multiple servers log collection

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -358,11 +358,11 @@ def test_collect_multiple_servers(log_depot, temp_appliance_preconfig, depot_mac
 
     if from_slave and zone_collect:
         check_ftp(appliance, log_depot.ftp, first_slave_server.name, first_slave_server.sid)
-        check_ftp(appliance, log_depot.ftp, appliance.server.name, appliance.server.zone.id)
+        check_ftp(appliance, log_depot.ftp, appliance.server.name, appliance.server.sid)
     elif from_slave:
         check_ftp(appliance, log_depot.ftp, first_slave_server.name, first_slave_server.sid)
     else:
-        check_ftp(appliance, log_depot.ftp, appliance.server.name, appliance.server.zone.id)
+        check_ftp(appliance, log_depot.ftp, appliance.server.name, appliance.server.sid)
 
 
 @pytest.mark.parametrize('zone_collect', [True, False], ids=['zone_collect', 'server_collect'])


### PR DESCRIPTION
## Purpose or Intent

Some tests failed because it didn't find the logs. The way it worked before is a coincidence as zone was the same as server id. This was revealed due to introduction of maintenance zone and now it's not the same.
Tested locally on 5.11.

### PRT Run

{{ pytest: -v cfme/tests/configure/test_log_depot_operation.py::test_collect_multiple_servers --long-running }}
