### PR TITLE
[RFR] fixed test_collect_single_servers

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -406,4 +406,4 @@ def test_collect_single_servers(log_depot, appliance, depot_machine_ip, request,
     else:
         collect_logs.collect_current()
 
-    check_ftp(appliance, log_depot.ftp, appliance.server.name, appliance.server.zone.id)
+    check_ftp(appliance, log_depot.ftp, appliance.server.name, appliance.server.sid)


### PR DESCRIPTION
## Purpose or Intent

Previously it worked by coincidence as zone was the same as server id (1). Since the introduction of the maintenance zone, it's no longer true.

### PRT Run

{{ pytest: -v cfme/tests/configure/test_log_depot_operation.py::test_collect_single_servers --long-running }}