### PR TITLE
[RFR] Fix RuntimeError in parallelizer due to dict size change

### DIFF
--- a/cfme/fixtures/parallelizer/__init__.py
+++ b/cfme/fixtures/parallelizer/__init__.py
@@ -219,7 +219,7 @@ class ParallelSession(object):
 
         # If a slave was terminated for any reason, kill that slave
         # the terminated flag implies the appliance has died :(
-        for slave in self.slaves.values():
+        for slave in list(self.slaves.values()):  # wrap list because we're modifying self.slaves
             if slave.forbid_restart:
                 if slave.process is None:
                     self.config.hook.pytest_miq_node_shutdown(


### PR DESCRIPTION
Resolve:

```
02:28:20 INTERNALERROR>   File "/var/ci/workspace/downstream-511z-tests/integration_tests/cfme/fixtures/parallelizer/__init__.py", line 416, in pytest_runtestloop
02:28:20 INTERNALERROR>     self._slave_audit()
02:28:20 INTERNALERROR>   File "/var/ci/workspace/downstream-511z-tests/integration_tests/cfme/fixtures/parallelizer/__init__.py", line 222, in _slave_audit
02:28:20 INTERNALERROR>     for slave in self.slaves.values():
02:28:20 INTERNALERROR> RuntimeError: dictionary changed size during iteration
```