### PR TITLE
[1LP][RFR] Adding more Tower workflow tests

### DIFF
--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -12,6 +12,9 @@ from cfme.utils.log import logger
 pytestmark = [
     test_requirements.service,
     pytest.mark.tier(2),
+    pytest.mark.parametrize('workflow_type', ['multiple_job_workflow', 'inventory_sync_workflow'],
+        ids=['multiple_job_workflow', 'inventory_sync_workflow'],
+        scope='module'),
     pytest.mark.ignore_stream('upstream')
 ]
 
@@ -65,7 +68,8 @@ def ansible_workflow_catitem(appliance, request, tower_manager, dialog, catalog)
 
 
 @pytest.mark.meta(automates=[BZ(1719051)])
-def test_tower_workflow_item(appliance, tower_manager, ansible_workflow_catitem, request):
+def test_tower_workflow_item(appliance, tower_manager, ansible_workflow_catitem, request,
+        workflow_type):
     """Tests ordering of catalog items for Ansible Workflow templates
     Metadata:
         test_flag: provision
@@ -91,7 +95,7 @@ def test_tower_workflow_item(appliance, tower_manager, ansible_workflow_catitem,
     )
 
 
-def test_retire_ansible_workflow(appliance, ansible_workflow_catitem, request):
+def test_retire_ansible_workflow(appliance, ansible_workflow_catitem, request, workflow_type):
     """Tests retiring of catalog items for Ansible Workflow templates
     Metadata:
         test_flag: provision

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -46,14 +46,13 @@ def tower_manager(config_manager_obj):
 
 
 @pytest.fixture(scope="function")
-def ansible_workflow_catitem(appliance, request, tower_manager, dialog, catalog):
-    job_type = 'workflow'
+def ansible_workflow_catitem(appliance, request, tower_manager, dialog, catalog, workflow_type):
     config_manager_obj = tower_manager
     provider_name = config_manager_obj.yaml_data.get('name')
     try:
-        template = config_manager_obj.yaml_data['provisioning_data'][job_type]
+        template = config_manager_obj.yaml_data['provisioning_data'][workflow_type]
     except KeyError:
-        pytest.skip("No such Ansible template: {} found in cfme_data.yaml".format(job_type))
+        pytest.skip("No such Ansible template: {} found in cfme_data.yaml".format(workflow_type))
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_TOWER,
         name=dialog.label,


### PR DESCRIPTION
{{ py.test: cfme/tests/services/test_ansible_workflow_servicecatalogs.py }}

Added tests for automating ordering of Ansible workflow service based on project sync up and inventory sync up.

PRT results:
510 - PASS
511 - PASS

Note
The latest PRT run[0] passed on both 510 and 511.But, GH still shows the failure from run#34025
[0]http://infra-trackerbot2.cfme2.lab.eng.rdu2.redhat.com/pr/run/34040