### PR TITLE
[NOTEST][WIP]Initial draft of integrating dynaconf and vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ geckodriver.log
 
 #vscode workspace config
 .vscode/
+
+# Ignore dynaconf .env files
+.env

--- a/cfme/scripting/conf.py
+++ b/cfme/scripting/conf.py
@@ -11,6 +11,8 @@ import io
 
 import click
 import yaycl_crypt
+from dynaconf import settings
+from dynaconf.loaders import vault_loader
 
 from cfme.scripting import link_config
 from cfme.utils import conf
@@ -99,6 +101,25 @@ def decrypt(conf_name, delete, skip):
             raise
 
     print('{} conf decrypted'.format(conf_name))
+
+
+@main.command("write", help="Write a username and password into vault")
+@click.argument("env")
+@click.argument("username")
+@click.argument("password")
+def write(env, username, password):
+    with settings.using_env(env):
+        data = {"username": username, "password": password}
+        vault_loader.write(settings, data)
+        print(f"Username '{username}' and password written to '{env}' successfully")
+
+
+@main.command("read", help="Write a username and password into vault")
+@click.argument("env")
+def read(env):
+    with settings.using_env(env):
+        d = settings.as_dict()
+        print(d)
 
 
 if __name__ == "__main__":

--- a/cfme/utils/config_data.py
+++ b/cfme/utils/config_data.py
@@ -4,6 +4,21 @@ from yaycl import AttrDict
 
 
 @attr.s
+class ConfigDataWrapper(object):
+    """A wrapper for credentials"""
+    config = attr.ib(default=AttrDict())
+    env = attr.ib(default='cfme-qe-test-envs')
+
+    def __getitem__(self, key):
+        return self.__getattr__(key)
+
+    def __getattr__(self, key):
+        with settings.using_env(self.env):
+            self.config = AttrDict(settings.as_dict()[key.upper()])
+            return self.config
+
+
+@attr.s
 class CredsWrapper(object):
     """A wrapper for credentials"""
     credential = attr.ib(default=AttrDict())
@@ -17,4 +32,5 @@ class CredsWrapper(object):
             return self.credential
 
 
+cfme_data = ConfigDataWrapper()
 credentials = CredsWrapper()

--- a/cfme/utils/credentials.py
+++ b/cfme/utils/credentials.py
@@ -1,0 +1,20 @@
+import attr
+from dynaconf import settings
+from yaycl import AttrDict
+
+
+@attr.s
+class CredsWrapper(object):
+    """A wrapper for credentials"""
+    credential = attr.ib(default=AttrDict())
+
+    def __getitem__(self, env):
+        return self.__getattr__(env)
+
+    def __getattr__(self, env):
+        with settings.using_env(env):
+            self.credential = AttrDict(settings.as_dict())
+            return self.credential
+
+
+credentials = CredsWrapper()

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -131,6 +131,7 @@ docker-pycreds==0.4.0
 docutils==0.15.2
 dogpile.cache==0.7.1
 dump2polarion==0.40.0
+dynaconf[all]==2.1.0
 entrypoints==0.3
 fauxfactory==3.0.6
 flake8==3.7.7

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -130,6 +130,7 @@ docker-pycreds==0.4.0
 docutils==0.15.2
 dogpile.cache==0.7.1
 dump2polarion==0.40.0
+dynaconf[all]==2.1.0
 entrypoints==0.3
 fauxfactory==3.0.6
 flake8==3.7.7


### PR DESCRIPTION
## Purpose or Intent

- __Extending miq conf__ command to read from and write to Vault using dynaconf

**requirement**  pip3 install "dynaconf[vault]" 

Ask me personally on chat for `.env` file that is required to make this work on your computer

**Usage**
```
miq conf read <env> <key>
miq conf write  <env>  <key> <username> <password>
```

`<key>` cannot contain underscores, only hyphens are allowed