### PR TITLE
[1LP][RFR]Vmware automation tests

### DIFF
--- a/cfme/tests/infrastructure/test_vmware_provider.py
+++ b/cfme/tests/infrastructure/test_vmware_provider.py
@@ -272,7 +272,8 @@ def test_vmware_cdrom_dropdown_not_blank(appliance, provider):
             5.Dropdown of ISO files is not empty for CD/DVD Drive
     """
     datastore_collection = appliance.collections.datastores
-    ds = [ds.name for ds in provider.data['datastores'] if ds.type == 'iso']
+    ds = [ds.name for ds in provider.data['datastores'] if ds.type == 'iso' and
+        ds.get('tag') == 'ssa']
     try:
         iso_ds = datastore_collection.instantiate(name=ds[0], provider=provider)
     except IndexError:


### PR DESCRIPTION

## Purpose or Intent

- __Updating tests__ to use smaller ISO Data store as bigger datastore was taking over 15 mins for SSA and would cause failure - false negative. 

### PRT Run
- {{pytest: cfme/tests/infrastructure/test_vmware_provider.py --use-provider vsphere67-nested -k 'test_vmware_cdrom_dropdown_not_blank'  --long-running -v  }}
