### PR TITLE
[1LP][RFR]New Test: test_reports_menu_with_duplicate_reports

### DIFF
--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -2,12 +2,13 @@
 import random
 
 import pytest
-import yaml
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.rest.gen_data import users as _users
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.conf import cfme_data
+from cfme.utils.ftp import FTPClientWrapper
 from cfme.utils.path import data_path
 
 pytestmark = [pytest.mark.tier(3), test_requirements.report]
@@ -36,26 +37,26 @@ def report_menus(group, appliance):
     report_menus.reset_to_default(group)
 
 
-def crud_files_reports():
-    result = []
-    REPORT_CRUD_DIR.ensure(dir=True)
-    for file_name in REPORT_CRUD_DIR.listdir():
-        if file_name.isfile() and file_name.basename.endswith(".yaml"):
-            result.append(file_name.basename)
-    return result
-
-
-@pytest.fixture(params=crud_files_reports())
-def custom_report_values(request):
-    with REPORT_CRUD_DIR.join(request.param).open(mode="r") as rep_yaml:
-        return yaml.safe_load(rep_yaml)
-
-
 @pytest.fixture(scope="function")
-def get_custom_report(appliance, custom_report_values):
-    custom_report = appliance.collections.reports.create(**custom_report_values)
-    yield custom_report
-    custom_report.delete_if_exists()
+def get_custom_report(appliance):
+    collection = appliance.collections.reports
+
+    # download the report from server
+    fs = FTPClientWrapper(cfme_data.ftpserver.entities.reports)
+    file_path = fs.download("testing_report.yaml")
+
+    # import the report
+    collection.import_report(file_path)
+
+    # instantiate report and return it
+    report = collection.instantiate(
+        type="My Company (All Groups)",
+        subtype="Custom",
+        menu_name="testing report",
+        title="testing report title",
+    )
+    yield report
+    report.delete_if_exists()
 
 
 @pytest.mark.parametrize("group", GROUPS)
@@ -132,16 +133,13 @@ def test_add_reports_to_available_reports_menu(
 @pytest.fixture()
 def rbac_user(appliance, request, group):
     user, user_data = _users(request, appliance, group=group)
-    yield appliance.collections.users.instantiate(
+    return appliance.collections.users.instantiate(
         name=user[0].name,
         credential=Credential(
             principal=user_data[0]["userid"], secret=user_data[0]["password"]
         ),
         groups=[group],
     )
-
-    if user[0].exists:
-        user[0].action.delete()
 
 
 @pytest.mark.tier(1)
@@ -171,3 +169,58 @@ def test_rbac_move_custom_report(
             type=folder, subtype=subfolder, menu_name=get_custom_report.menu_name
         )
         assert rbac_report.exists
+
+
+@pytest.mark.tier(1)
+@pytest.mark.ignore_stream("5.10")
+@pytest.mark.meta(automates=[1676638, 1731017])
+@pytest.mark.parametrize("group", GROUPS)
+def test_reports_menu_with_duplicate_reports(appliance, request, group, report_menus):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        initialEstimate: 1/10h
+        startsin: 5.9
+        setup:
+            1.Create a custom report or copy an existing report.
+            2. Move the custom report to 'Tenants > Tenant Quotas' menu in user's current group
+        testSteps:
+            1. See if the report is available under 'Tenants > Tenant Quotas'.
+            2. Delete the custom report.
+            3. See if the report is available under 'Tenants > Tenant Quotas'.
+            4. Add a new report with the same menu_name.
+            5. See if the report is available under 'Tenants > Tenant Quotas'.
+        expectedResults:
+            1. Report must be visible.
+            2.
+            3. Report must not be visible.
+            4.
+            5. Report must not be visible.
+    Bugzilla:
+        1731017
+        1676638
+    """
+    # Copy a report the first time and move it
+    custom_report_1 = appliance.collections.reports.instantiate(
+        type="Tenants", subtype="Tenant Quotas", menu_name="Tenant Quotas"
+    ).copy()
+    folder, subfolder = "Tenants", "Tenant Quotas"
+    report_menus.move_reports(group, folder, subfolder, custom_report_1.menu_name)
+
+    # instantiate the expected report and check for its existence
+    expected_report = appliance.collections.reports.instantiate(
+        type=folder, subtype=subfolder, menu_name=custom_report_1.menu_name
+    )
+    assert expected_report.exists
+
+    # delete the first report and check if the expected report exists
+    custom_report_1.delete()
+    assert not expected_report.exists
+
+    # Copy the report a second time and check for the existence of the expected report
+    custom_report_2 = appliance.collections.reports.instantiate(
+        type="Tenants", subtype="Tenant Quotas", menu_name="Tenant Quotas"
+    ).copy()
+    request.addfinalizer(custom_report_2.delete)
+    assert not expected_report.exists

--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -177,13 +177,17 @@ def test_rbac_move_custom_report(
 @pytest.mark.parametrize("group", GROUPS)
 def test_reports_menu_with_duplicate_reports(appliance, request, group, report_menus):
     """
+    Bugzilla:
+        1731017
+        1676638
+
     Polarion:
         assignee: pvala
         casecomponent: Reporting
         initialEstimate: 1/10h
-        startsin: 5.9
+        startsin: 5.11
         setup:
-            1.Create a custom report or copy an existing report.
+            1. Create a custom report or copy an existing report.
             2. Move the custom report to 'Tenants > Tenant Quotas' menu in user's current group
         testSteps:
             1. See if the report is available under 'Tenants > Tenant Quotas'.
@@ -197,14 +201,12 @@ def test_reports_menu_with_duplicate_reports(appliance, request, group, report_m
             3. Report must not be visible.
             4.
             5. Report must not be visible.
-    Bugzilla:
-        1731017
-        1676638
     """
     # Copy a report the first time and move it
     custom_report_1 = appliance.collections.reports.instantiate(
         type="Tenants", subtype="Tenant Quotas", menu_name="Tenant Quotas"
     ).copy()
+
     folder, subfolder = "Tenants", "Tenant Quotas"
     report_menus.move_reports(group, folder, subfolder, custom_report_1.menu_name)
 
@@ -222,5 +224,5 @@ def test_reports_menu_with_duplicate_reports(appliance, request, group, report_m
     custom_report_2 = appliance.collections.reports.instantiate(
         type="Tenants", subtype="Tenant Quotas", menu_name="Tenant Quotas"
     ).copy()
-    request.addfinalizer(custom_report_2.delete)
+    request.addfinalizer(custom_report_2.delete_if_exists)
     assert not expected_report.exists


### PR DESCRIPTION
## Purpose or Intent

- __Extending__ 
    1. `get_custom_report` fixture to import a report instead of creating a new report with the yaml data. 
    2. `rbac_api` to not delete user, since that is anyway done by `gen_data._create_skeleton`.
- __Adding tests__ `test_reports_menu_with_duplicate_reports` which automates BZ 1676638, 1731017
- __Updating tests__ `test_rbac_move_custom_report` and `test_add_reports_to_available_reports_menu` to use the updated `get_custom_report` fixture.

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_menus.py -k "test_add_reports_to_available_reports_menu or test_rbac_move_custom_report or test_reports_menu_with_duplicate_reports" -vvv }}