### PR TITLE
[WIPTEST] Change the default of the provider.delete() to False

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -587,7 +587,7 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
                 raise AssertionError("Provider wasn't updated. It seems form isn't accurately"
                                      " filled")
 
-    def delete(self, cancel=True):
+    def delete(self, cancel=False):
         """
         Deletes a provider from CFME using UI
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -274,7 +274,7 @@ def test_cloud_provider_crud(provider, enable_regions):
     with update(provider):
         provider.name = old_name  # old name
 
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()
 
 

--- a/cfme/tests/containers/test_container_provider_crud.py
+++ b/cfme/tests/containers/test_container_provider_crud.py
@@ -53,7 +53,7 @@ def test_container_provider_crud(request, appliance, has_no_providers, provider)
 
     assert provider.name == str(view.entities.get_first_entity().data.get('name', {}))
 
-    provider.delete(cancel=False)
+    provider.delete()
 
     assert view.is_displayed
 

--- a/cfme/tests/containers/test_ssl_providers.py
+++ b/cfme/tests/containers/test_ssl_providers.py
@@ -73,7 +73,7 @@ def test_add_provider_naming_conventions(provider, appliance, soft_assert, sync_
         except AssertionError:
             soft_assert(False, provider_name + ' wasn\'t added successfully')
         else:
-            new_provider.delete(cancel=False)
+            new_provider.delete()
             new_provider.wait_for_delete()
 
 
@@ -108,7 +108,7 @@ def test_add_provider_ssl(provider, default_sec_protocol, soft_assert, sync_ssl_
         soft_assert(False, provider.name + ' wasn\'t added successfully using ' +
                     default_sec_protocol + ' security protocol')
     else:
-        new_provider.delete(cancel=False)
+        new_provider.delete()
         new_provider.wait_for_delete()
 
 
@@ -156,7 +156,7 @@ def test_add_mertics_provider_ssl(provider, appliance, test_item,
                         default_sec_protocol=test_item.default_sec_protocol,
                         metrics_sec_protocol=test_item.metrics_sec_protocol))
     else:
-        new_provider.delete(cancel=False)
+        new_provider.delete()
         new_provider.wait_for_delete()
 
 

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -208,7 +208,7 @@ def test_tag_host_after_provider_delete(provider, appliance, setup_provider, req
         casecomponent: Tagging
     """
     host_on_provider = provider.hosts.all()[0]
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()
     all_hosts = appliance.collections.hosts.all()
     # need to find the host without the link to the provider,

--- a/cfme/tests/infrastructure/test_kubevirt.py
+++ b/cfme/tests/infrastructure/test_kubevirt.py
@@ -50,7 +50,7 @@ def test_k6t_provider_crud(provider):
     with update(provider):
         provider.name = fauxfactory.gen_alphanumeric() + '_updated'
 
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()
 
 

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -292,7 +292,7 @@ def test_infra_provider_crud(provider):
     with update(provider):
         provider.name = old_name  # old name
 
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()
 
 
@@ -330,7 +330,7 @@ def test_provider_rhv_create_delete_tls(request, provider, verify_tls):
     prov.create()
     prov.validate_stats(ui=True)
 
-    prov.delete(cancel=False)
+    prov.delete()
     prov.wait_for_delete()
 
 

--- a/cfme/tests/networks/test_network_providers.py
+++ b/cfme/tests/networks/test_network_providers.py
@@ -84,5 +84,5 @@ def test_network_provider_crud(provider, has_no_networks_providers):
     with update(provider):
         provider.name = old_name  # old name
 
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()

--- a/cfme/tests/openstack/infrastructure/test_provider.py
+++ b/cfme/tests/openstack/infrastructure/test_provider.py
@@ -50,7 +50,7 @@ def test_delete_provider(provider):
         casecomponent: Cloud
         initialEstimate: 1/4h
     """
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()
     view = navigate_to(provider, 'All')
     assert provider.name not in [item.name for item in view.entities.get_all(surf_pages=True)]

--- a/cfme/tests/physical_infrastructure/test_providers.py
+++ b/cfme/tests/physical_infrastructure/test_providers.py
@@ -38,5 +38,5 @@ def test_physical_infra_provider_crud(provider, has_no_providers):
     with update(provider):
         provider.name = old_name  # old name
 
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()

--- a/cfme/tests/physical_infrastructure/test_redfish_providers.py
+++ b/cfme/tests/physical_infrastructure/test_redfish_providers.py
@@ -29,5 +29,5 @@ def test_redfish_provider_crud(provider, has_no_physical_providers):
     with update(provider):
         provider.name = old_name  # old name
 
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -181,7 +181,7 @@ def test_request_with_orphaned_template(appliance, provider, catalog_item):
     request_description = catalog_item.name
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
-    provider.delete(cancel=False)
+    provider.delete()
     provider.wait_for_delete()
     provision_request.wait_for_request(method='ui')
     assert provision_request.row.status.text == 'Error'


### PR DESCRIPTION
provider.delete() defaults to cancel=True, it should delete unless the user explicitly specifies not to. 

Commits broken up in two:
1) The change of the default of cancel on the provider.delete() method
2) Removing cancel=False throughout the integration_tests

{{ pytest: cfme/tests/infrastructure/test_providers.py --use-provider complete }}