### PR TITLE
[1LP][RFR] Don't loosen DB

### DIFF
--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -214,7 +214,7 @@ def test_create_appliance_on_scvmm_using_the_vhd_image(scvmm_appliance):
     # use appliance to get the stream so this test only runs once per test run
     # this will always use the downstream stable build, not the version of the appliance
     # configure the appliance
-    scvmm_appliance.configure(loosen_psql=False, fix_ntp_clock=False)
+    scvmm_appliance.configure(fix_ntp_clock=False)
 
 
 @pytest.mark.tier(1)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -627,7 +627,6 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             name_to_set: Name to set the appliance name to if not ``None`` (default ``None``)
             region: Number to assign to region (default ``0``)
             fix_ntp_clock: Fixes appliance time if ``True`` (default ``True``)
-            loosen_pgssl: Loosens postgres connections if ``True`` (default ``True``)
             key_address: Fetch encryption key from this address if set, generate a new key if
                          ``None`` (default ``None``)
             on_openstack: If appliance is running on Openstack provider (default ``False``)
@@ -639,7 +638,6 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         """
 
         log_callback("Configuring appliance {}".format(self.hostname))
-        loosen_pgssl = kwargs.pop('loosen_pgssl', True)
         fix_ntp_clock = kwargs.pop('fix_ntp_clock', True)
         region = kwargs.pop('region', 0)
         key_address = kwargs.pop('key_address', None)
@@ -690,9 +688,6 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             # Some conditionally ran items require the evm service be
             # restarted:
             restart_evm = False
-            if loosen_pgssl:
-                self.db.loosen_pgssl()
-                restart_evm = True
             if self.version < '5.11':
                 self.configure_vm_console_cert(log_callback=log_callback)
                 restart_evm = True
@@ -2714,7 +2709,6 @@ class Appliance(IPAppliance):
             name_to_set: Name to set the appliance name to if not ``None`` (default ``None``)
             region: Number to assign to region (default ``0``)
             fix_ntp_clock: Fixes appliance time if ``True`` (default ``True``)
-            loosen_pgssl: Loosens postgres connections if ``True`` (default ``True``)
             key_address: Fetch encryption key from this address if set, generate a new key if
                          ``None`` (default ``None``)
             on_openstack: If appliance is running on Openstack provider (default ``False``)

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -146,11 +146,10 @@ started as quickly as possible:
 
 * ``cfme_tests`` also expects that the appliance it is running against is configured. Without it it
   won't work at all! By configured, we mean the database is set up and seeded (therefore UI
-  running), database permissions loosened so ``cfme_tests`` can access it and a couple of other
-  fixes. Check out :py:meth:`utils.appliance.IPAppliance.configure`, and subsequent method calls.
-  The most common error is that a person tries to execute ``cfme_tests`` code against an appliance
-  that does not have the DB permissions loosened. The second place is SSH unavailable, meaning that
-  the appliance is NAT-ed
+  running) and a couple of other fixes. Check out :py:meth:`utils.appliance.IPAppliance.configure`,
+  and subsequent method calls.  The most common error is that a person tries to execute ``cfme_tests``
+  code against an appliance that does not have the DB permissions loosened. The second place is SSH
+  unavailable, meaning that the appliance is NAT-ed
 
   * Framework contains code that can be used to configure the appliance exactly as ``cfme_tests``
     desires. There are two ways of using it:


### PR DESCRIPTION
The tests started loosening the DB in far past (commit 6695364f56).
As the commit message states, it was a temporary solution to some
problem. It seems to me we do not need it any more and we should
rather use the default db permissions to do real testing.

Also, an invalid BZ#1741481 was reported because we are modifying the permissions in such a way that it doesn't allow replication

The unmodified permissions on CFME 5.11 are:

            # TYPE  DATABASE    USER  ADDRESS METHOD
            local   all         all           peer map=usermap
            local   replication all           peer map=usermap
            hostssl all         all   all     md5
            host    replication all   all     md5