### PR TITLE
[1LP][RFR] Some Generic obj fixture move to global

### DIFF
--- a/cfme/fixtures/generic_object.py
+++ b/cfme/fixtures/generic_object.py
@@ -12,14 +12,15 @@ def gen_rest_service(appliance):
 
     rest_service = appliance.rest_api.collections.services.action.create(
         name=fauxfactory.gen_numeric_string(16, start="gen_rest_serv", separator="-"), display=True
-    )
-    rest_service = rest_service[0]
+    )[0]
+
     yield rest_service
-    rest_service.action.delete()
+    if rest_service.exists:
+        rest_service.action.delete()
 
 
 @pytest.fixture(scope="module")
-def gen_definition(appliance):
+def generic_definition(appliance):
     """Generic object definition or class"""
 
     with appliance.context.use(ViaREST):
@@ -35,16 +36,17 @@ def gen_definition(appliance):
 
 
 @pytest.fixture(scope="module")
-def generic_object(gen_definition, gen_rest_service, appliance):
+def generic_object(generic_definition, gen_rest_service, appliance):
     """Generic object associated with service"""
 
     myservice = MyService(appliance, name=gen_rest_service.name)
+
     with appliance.context.use(ViaREST):
         instance = appliance.collections.generic_objects.create(
             name=fauxfactory.gen_numeric_string(20, start="gen_rest_instance", separator="-"),
-            definition=gen_definition,
+            definition=generic_definition,
             attributes={"addr01": "Test Address"},
-            associations={"services": [myservice]},
+            associations={"services": [gen_rest_service]},
         )
         instance.my_service = myservice
         yield instance

--- a/cfme/fixtures/generic_object.py
+++ b/cfme/fixtures/generic_object.py
@@ -1,0 +1,65 @@
+import fauxfactory
+import pytest
+
+from cfme.services.myservice import MyService
+from cfme.utils.appliance import ViaREST
+from cfme.utils.rest import assert_response
+
+
+@pytest.fixture(scope="module")
+def gen_rest_service(appliance):
+    """Simple service create with rest for generic object association"""
+
+    rest_service = appliance.rest_api.collections.services.action.create(
+        name=fauxfactory.gen_numeric_string(16, start="gen_rest_serv", separator="-"), display=True
+    )
+    rest_service = rest_service[0]
+    yield rest_service
+    rest_service.action.delete()
+
+
+@pytest.fixture(scope="module")
+def gen_definition(appliance):
+    """Generic object definition or class"""
+
+    with appliance.context.use(ViaREST):
+        definition = appliance.collections.generic_object_definitions.create(
+            name=fauxfactory.gen_numeric_string(17, start="gen_rest_class", separator="-"),
+            description="Generic Object Definition",
+            attributes={"addr01": "string"},
+            associations={"services": "Service"},
+            methods=["add_vm", "remove_vm"],
+        )
+        yield definition
+        definition.delete_if_exists()
+
+
+@pytest.fixture(scope="module")
+def generic_object(gen_definition, gen_rest_service, appliance):
+    """Generic object associated with service"""
+
+    myservice = MyService(appliance, name=gen_rest_service.name)
+    with appliance.context.use(ViaREST):
+        instance = appliance.collections.generic_objects.create(
+            name=fauxfactory.gen_numeric_string(20, start="gen_rest_instance", separator="-"),
+            definition=gen_definition,
+            attributes={"addr01": "Test Address"},
+            associations={"services": [myservice]},
+        )
+        instance.my_service = myservice
+        yield instance
+        instance.delete_if_exists()
+
+
+@pytest.fixture(scope="module")
+def add_generic_object_to_service(appliance, gen_service, generic_object):
+    """Add generic object as resource of service"""
+
+    with appliance.context.use(ViaREST):
+        gen_service.action.add_resource(
+            resource=appliance.rest_api.collections.generic_objects.find_by(
+                name=generic_object.name
+            )[0]._ref_repr()
+        )
+        assert_response(appliance)
+    return generic_object

--- a/cfme/fixtures/generic_object.py
+++ b/cfme/fixtures/generic_object.py
@@ -52,11 +52,11 @@ def generic_object(gen_definition, gen_rest_service, appliance):
 
 
 @pytest.fixture(scope="module")
-def add_generic_object_to_service(appliance, gen_service, generic_object):
+def add_generic_object_to_service(appliance, gen_rest_service, generic_object):
     """Add generic object as resource of service"""
 
     with appliance.context.use(ViaREST):
-        gen_service.action.add_resource(
+        gen_rest_service.action.add_resource(
             resource=appliance.rest_api.collections.generic_objects.find_by(
                 name=generic_object.name
             )[0]._ref_repr()

--- a/cfme/test_framework/pytest_plugin.py
+++ b/cfme/test_framework/pytest_plugin.py
@@ -113,6 +113,7 @@ pytest_plugins = (
     'cfme.fixtures.nuage',
     'cfme.fixtures.automate',
     'cfme.fixtures.multi_region',
+    'cfme.fixtures.generic_object',
 
     'cfme.metaplugins',
 )

--- a/cfme/tests/generic_objects/test_instances.py
+++ b/cfme/tests/generic_objects/test_instances.py
@@ -43,13 +43,13 @@ def tags(request, appliance, categories):
 
 
 @pytest.fixture(scope="module")
-def generic_object_button_group(appliance, gen_definition):
+def generic_object_button_group(appliance, generic_definition):
     def _generic_object_button_group(create_action=True):
         if create_action:
             with appliance.context.use(ViaUI):
                 group_name = "button_group_{}".format(fauxfactory.gen_alphanumeric())
                 group_desc = "Group_button_description_{}".format(fauxfactory.gen_alphanumeric())
-                groups_buttons = gen_definition.collections.generic_object_groups_buttons
+                groups_buttons = generic_definition.collections.generic_object_groups_buttons
                 generic_object_button_group = groups_buttons.create(
                     name=group_name, description=group_desc, image="fa-user"
                 )
@@ -61,11 +61,11 @@ def generic_object_button_group(appliance, gen_definition):
 
 
 @pytest.fixture(scope="module")
-def generic_object_button(appliance, generic_object_button_group, gen_definition):
+def generic_object_button(appliance, generic_object_button_group, generic_definition):
     def _generic_object_button(button_group):
         with appliance.context.use(ViaUI):
             button_parent = (
-                generic_object_button_group(button_group) if button_group else gen_definition
+                generic_object_button_group(button_group) if button_group else generic_definition
             )
             button_name = 'button_{}'.format(fauxfactory.gen_alphanumeric())
             button_desc = 'Button_description_{}'.format(fauxfactory.gen_alphanumeric())


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent

- Generic object creation is with `rest` OR `ruby` and hectic task
- we repetition of fixtures nearly common so moving to global so anyone can use this for setup.
- I need this for increasing coverage for custom button over generic definition/class. 

- **Note: Just moving fixture not changing implementation** 

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/generic_objects/test_instances.py cfme/tests/automate/custom_button/test_service_objects.py -sqvv}}

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].

Some examples are:

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
