### PR TITLE
[RFR] Fixed vm reconfigure quota test case

### DIFF
--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -318,8 +318,8 @@ def test_quota_vm_reconfigure(
         )
     provision_request = appliance.collections.requests.instantiate(request_description)
     provision_request.wait_for_request(method="ui")
-    assert small_vm.configuration != original_config
     assert provision_request.row.reason.text == "Quota Exceeded"
+    assert small_vm.configuration == original_config
 
 
 @pytest.mark.parametrize('context', [ViaSSUI, ViaUI])


### PR DESCRIPTION
## Purpose or Intent
- This test case needs to updated because in this test case we are checked if quota is getting  exceeded or not while reconfiguring vm above quota
- Here vm is not getting reconfigured because of quota exceeded. So removing assertion.

### PRT Run
{{ pytest: cfme/tests/infrastructure/test_quota_tagging.py::test_quota_vm_reconfigure --use-template-cache -qsvvv --use-provider=complete --long-running }}