### PR TITLE
[WIPTEST] Fixed discover vm issue on provider

### DIFF
--- a/cfme/tests/cloud_infra_common/test_discovery_and_support.py
+++ b/cfme/tests/cloud_infra_common/test_discovery_and_support.py
@@ -14,14 +14,9 @@ from cfme.utils.wait import wait_for
 
 
 @pytest.fixture(scope="module")
-def vm_name():
-    return random_vm_name("dscvry")
-
-
-@pytest.fixture(scope="module")
-def vm_crud(vm_name, provider):
+def vm_crud(provider):
     collection = provider.appliance.provider_based_collection(provider)
-    return collection.instantiate(vm_name, provider)
+    return collection.instantiate(random_vm_name("dscvry"), provider)
 
 
 @pytest.mark.rhv2
@@ -75,6 +70,7 @@ def test_vm_discovery(request, setup_provider, provider, vm_crud):
         num_sec=600,
         delay=10,
         handle_exception=True,
+        fail_func=vm_crud.refresh_relationships(),
         message='Waiting for archived state'
     )
 


### PR DESCRIPTION
## Purpose or Intent
- This PR fixes the issue of vm/instance discovery on provider. 
- This issue needs to be fixed by adding **vm refresh relationships which is required to update vm relationships data to get updated power state.**

### PRT Run
{{ pytest: cfme/tests/cloud_infra_common/test_discovery_and_support.py -k 'test_vm_discovery' --use-template-cache -qsvvv --use-provider=complete --long-running }}