### PR TITLE
[1LP][RFR] New Test: Testing embedded method is visible after selection

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -255,7 +255,6 @@ class MethodAddView(AutomateExplorerView):
     playbook_input_parameters = PlaybookInputParameters()
 
     # Add embedded method
-    # TODO(ghubale@redhat.com): Make use of this table once this BZ(1718495) got fixed
     embedded_method_table = Table('//*[@id="embedded_methods_div"]/table')
     embedded_method = EntryPoint(locator='//*[@id="automate-inline-method-select"]//button',
                                  tree_id="treeview-entrypoint_selection")
@@ -299,7 +298,6 @@ class MethodEditView(AutomateExplorerView):
     playbook_input_parameters = PlaybookInputParameters()
 
     # Edit embedded method
-    # TODO(ghubale@redhat.com): Make use of this table once this BZ(1718495) got fixed
     embedded_method_table = Table('//*[@id="embedded_methods_div"]/table')
     embedded_method = EntryPoint(locator='//*[@id="automate-inline-method-select"]//button',
                                  tree_id="treeview-entrypoint_selection")

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -502,25 +502,6 @@ def test_automate_restrict_domain_crud():
 
 
 @pytest.mark.tier(3)
-def test_automate_embedded_method():
-    """
-    For a "new" method when adding Embedded Methods the UI hangs in the
-    tree view when the method is selected
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: high
-        initialEstimate: 1/12h
-        tags: automate
-
-    Bugzilla:
-        1523379
-    """
-    pass
-
-
-@pytest.mark.tier(3)
 def test_automate_git_verify_ssl():
     """
     Polarion:
@@ -578,36 +559,6 @@ def test_list_of_diff_vm_storages_via_rails():
 
     Bugzilla:
         1574444
-    """
-    pass
-
-
-@pytest.mark.tier(1)
-def test_method_for_log_and_notify():
-    """
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/8h
-        caseimportance: high
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.9
-        casecomponent: Automate
-        tags: automate
-        testSteps:
-            1. Create an Automate domain or use an existing writeable Automate domain
-            2. Create a new Automate Method
-            3. In the Automate Method screen embed ManageIQ/System/CommonMethods/Utils/log_object
-               you can pick this
-               method from the UI tree picker
-            4. In your method add a line akin to
-               ManageIQ::Automate::System::CommonMethods::Utils::LogObject.log_and_notify
-               (:info, "Hello Testing Log & Notify", $evm.root['vm'], $evm)
-            5. Check the logs
-            6. In your UI session you should see a notification
-
-    PR:
-        https://github.com/ManageIQ/manageiq-content/pull/423
     """
     pass
 

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -479,7 +479,7 @@ def test_automate_service_quota_runs_only_once(appliance, generic_catalog_item):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1718495, forced_streams=['5.10'])], automate=[1718495, 1523379])
+@pytest.mark.meta(blockers=[BZ(1718495, forced_streams=['5.10'])], automates=[1718495, 1523379])
 def test_embedded_method_selection(klass):
     """
     Bugzilla:
@@ -500,7 +500,7 @@ def test_embedded_method_selection(klass):
     path = ("Datastore", "ManageIQ (Locked)", "System", "CommonMethods", "Utils", "log_object")
     view = navigate_to(klass.methods, "Add")
     view.fill({'location': "Inline", "embedded_method": path})
-    assert view.embedded_method_table.read()[0]['Path'] == "/" + "/".join(path[2:])
+    assert view.embedded_method_table.read()[0]['Path'] == f"/{'/'.join(path[2:])}"
 
 
 @pytest.mark.tier(1)

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -479,9 +479,13 @@ def test_automate_service_quota_runs_only_once(appliance, generic_catalog_item):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1718495])
-def test_embedded_method_selection():
+@pytest.mark.meta(blockers=[BZ(1718495, forced_streams=['5.10'])], automate=[1718495, 1523379])
+def test_embedded_method_selection(klass):
     """
+    Bugzilla:
+        1718495
+        1523379
+
     Polarion:
         assignee: ghubale
         initialEstimate: 1/8h
@@ -492,11 +496,11 @@ def test_embedded_method_selection():
         expectedResults:
             1.
             2. Selected embedded method should be visible
-
-    Bugzilla:
-        1718495
     """
-    pass
+    path = ("Datastore", "ManageIQ (Locked)", "System", "CommonMethods", "Utils", "log_object")
+    view = navigate_to(klass.methods, "Add")
+    view.fill({'location': "Inline", "embedded_method": path})
+    assert view.embedded_method_table.read()[0]['Path'] == "/" + "/".join(path[2:])
 
 
 @pytest.mark.tier(1)


### PR DESCRIPTION
## Purpose or Intent
- This PR tests embedded method is visible after selection in ```inline``` type of automate method
- Removed ```test_method_for_log_and_notify``` as this test case  is already automated.

### PRT Run
{{ pytest: cfme/tests/automate/test_method.py::test_embedded_method_selection --use-template-cache -qsvv}}