### PR TITLE
[RFR] Uncollect RHV provider for cloning test

### DIFF
--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -441,6 +441,7 @@ def test_infra_timeline_diagnostic(new_vm, soft_assert, mark_vm_as_appliance):
 
 
 @pytest.mark.meta(blockers=[BZ(1622952)])
+@pytest.mark.provider([VMwareProvider], override=True)
 def test_infra_timeline_clone_event(new_vm, soft_assert):
     """Test that the event clone is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.


### PR DESCRIPTION
Cloning is unsupported for RHV providers. 

source: https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/pdf/support_matrix/Red_Hat_CloudForms-4.7-Support_Matrix-en-US.pdf

{{ pytest: --use-provider rhv43 --long-running cfme/tests/infrastructure/test_timelines.py::test_infra_timeline_clone_event }}