### PR TITLE
[1LP][RFR]Fix failing tests and add ignore_stream wherever required

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -22,7 +22,6 @@ from cfme.common.provider_views import CloudProviderAddView
 from cfme.common.provider_views import CloudProvidersView
 from cfme.fixtures.provider import enable_provider_regions
 from cfme.markers.env_markers.provider import ONE
-from cfme.rest.gen_data import arbitration_profiles as _arbitration_profiles
 from cfme.utils import appliance
 from cfme.utils import conf
 from cfme.utils import ssh
@@ -700,16 +699,6 @@ def test_display_network_topology(appliance, openstack_provider):
 
 
 class TestProvidersRESTAPI(object):
-    @pytest.fixture(scope="function")
-    def arbitration_profiles(self, request, appliance, cloud_provider):
-        num_profiles = 2
-        response = _arbitration_profiles(
-            request, appliance, cloud_provider, num=num_profiles)
-        assert_response(appliance)
-        assert len(response) == num_profiles
-
-        return response
-
     @pytest.mark.tier(3)
     @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
     def test_cloud_networks_query(self, cloud_provider, appliance, from_detail, setup_provider):

--- a/cfme/tests/intelligence/test_reports_with_timelines.py
+++ b/cfme/tests/intelligence/test_reports_with_timelines.py
@@ -11,6 +11,7 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE),
     pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.ignore_stream("5.11")
 ]
 
 IDS = [

--- a/cfme/tests/intelligence/test_rss.py
+++ b/cfme/tests/intelligence/test_rss.py
@@ -4,6 +4,8 @@ import requests
 
 from cfme.utils.appliance.implementations.ui import navigate_to
 
+pytestmark = [pytest.mark.ignore_stream("5.11")]
+
 
 @pytest.mark.tier(3)
 def test_verify_rss_links(appliance):


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ tests:
    1. `test_check_vm_retirement_requester` - test was failing due to a change in the request description, which is now fixed by using `find_by` instead of `get` action.
    2. Add ignore_stream("5.11") to test_rss.py and test_reports_with_timeline.py, since they have been removed from 5.11.
    3. Remove unnecessary code related to arbitration_profiles from cfme/tests/cloud/test_providers.py

### PRT Run
{{ pytest: cfme/tests/infrastructure/test_vm_retirement_rest.py::test_check_vm_retirement_requester  -vvv }}