### PR TITLE
[1LP][RFR]Fix test: test_splitter.py for UtilizationCollection

### DIFF
--- a/cfme/tests/webui/test_splitter.py
+++ b/cfme/tests/webui/test_splitter.py
@@ -36,9 +36,7 @@ LOCATIONS = [
 
 
 pytestmark = [
-    pytest.mark.parametrize(
-        "model_object,destination", LOCATIONS
-    ),
+    pytest.mark.parametrize("model_object,destination", LOCATIONS),
     test_requirements.general_ui
 ]
 


### PR DESCRIPTION
## Purpose or Intent
- __Fixing__ `test_splitter.py` for UtilizationCollection which is failing because Utilization has been moved to Overview.
- __Enhance__ `UtilizationView` by adding `ManageIQTree()` which will be a useful widget for 5.11 and adding `tree.currently_selected` check in the `is_displayed`.
- __Extending__ `All` navigator of `UtilizationCollection` by adding a step to click a certain tree path if the appliance version > "5.11".

### PRT Run
{{ pytest: cfme/tests/webui/test_splitter.py -k "test_pull_splitter_persistence[UtilizationCollection-All" -vvv }}