### PR TITLE
[1LP][RFR] Remove old blocker for action test

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -543,20 +543,14 @@ def test_action_power_on_audit(request, vm, vm_off, policy_for_testing):
 
 
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")
-@pytest.mark.meta(
-    blockers=[
-        BZ(
-            1549529,
-            forced_streams=["5.10", "upstream"],
-            unblock=lambda provider: provider.one_of(VMwareProvider),
-        )
-    ]
-)
 def test_action_create_snapshot_and_delete_last(appliance, request, vm, vm_on, policy_for_testing):
     """ This test tests actions 'Create a Snapshot' (custom) and 'Delete Most Recent Snapshot'.
 
     This test sets the policy that it makes snapshot of VM after it's powered off and when it is
     powered back on, it deletes the last snapshot.
+
+    Bugzilla:
+        1745065
 
     Metadata:
         test_flag: actions, provision
@@ -590,8 +584,6 @@ def test_action_create_snapshot_and_delete_last(appliance, request, vm, vm_on, p
         message="wait for snapshot appear",
         delay=5,
     )
-    assert vm.current_snapshot_description == "Created by EVM Policy Action"
-    assert vm.current_snapshot_name == snapshot_name
     # Snapshot created and validated, so let's delete it
     snapshots_before = vm.total_snapshots
     # Power on to invoke last snapshot deletion


### PR DESCRIPTION
The BZ removed was closed due to age. It still exists and I opened a new BZ https://bugzilla.redhat.com/show_bug.cgi?id=1745065, but really the action test is not relevant to this BZ, so I removed it as a blocker. 

{{ pytest: --use-provider rhv43 --long-running cfme/tests/control/test_actions.py::test_action_create_snapshot_and_delete_last }}

