### PR TITLE
[1LP][RFR]New Test: test_reset_report_menus AND remove unnecessary tests

### DIFF
--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -35,24 +35,6 @@ def test_validate_landing_pages_for_rbac():
 
 
 @pytest.mark.manual
-@test_requirements.settings
-@pytest.mark.tier(1)
-def test_my_settings_default_views_alignment():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Settings
-        caseimportance: medium
-        initialEstimate: 1/20h
-        testSteps:
-            1. Go to My Settings -> Default Views
-        expectedResults:
-            1. All icons are aligned correctly
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.configuration
 @pytest.mark.tier(1)
 def test_configure_icons_roles_by_server():

--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -226,3 +226,36 @@ def test_reports_menu_with_duplicate_reports(appliance, request, group, report_m
     ).copy()
     request.addfinalizer(custom_report_2.delete_if_exists)
     assert not expected_report.exists
+
+
+@pytest.mark.parametrize("group", GROUPS)
+def test_reset_report_menus(appliance, get_custom_report, group, report_menus):
+    """
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: low
+        initialEstimate: 1/12h
+        setup:
+            1. Create a custom report.
+        testSteps:
+            1. Select the custom report and move it to a different menu.
+            2. Reset it.
+            3. Check if the report is available under the selected menu.
+    """
+    folder, subfolder = "Tenants", "Tenant Quotas"
+    # move the report
+    report_menus.move_reports(group, folder, subfolder, get_custom_report.menu_name)
+
+    # assert the report exists in the moved menu
+    assert appliance.collections.reports.instantiate(
+        type=folder, subtype=subfolder, menu_name=get_custom_report.menu_name
+    ).exists
+
+    # reset the report menu
+    report_menus.reset_to_default(group)
+
+    # assert the report does not exist in the moved menu
+    assert not appliance.collections.reports.instantiate(
+        type=folder, subtype=subfolder, menu_name=get_custom_report.menu_name
+    ).exists

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -65,60 +65,6 @@ def test_date_should_be_change_in_editing_reports_scheduled():
 
 @pytest.mark.manual
 @test_requirements.report
-@pytest.mark.tier(1)
-def test_reports_manage_report_menu_accordion_with_users():
-    """
-    Bugzilla:
-        1535023
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.8
-        setup:
-            1. Create a new report called report01
-            2. Create a new user under EvmGroup-super_administrator called
-            testuser
-            3. "Edit Report Menus" and add the report01 under EvmGroup-
-            super_administrator"s Provisioning -> Activities
-            4. Login using testuser and navigate to Reports
-        testSteps:
-            1. Check if the report01 is present under Provisioning -> Activities
-        expectedResults:
-            1. The report01 must be present under Provisioning -> Activities
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
-def test_report_menus_moving_reports():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: low
-        initialEstimate: 1/12h
-        setup:
-            1. Navigate to  Cloud Intel -> Reports -> Edit reports menu
-            2. Select EvmGroupAdministrator -> Configuration Management -> Virtual Machines
-        testSteps:
-            1. Select 5 Reports and move them to the left.
-            2. Reset it.
-            3. Select all reports and move them to the left
-        expectedResults:
-            1. All 5 reports should be moved.
-            2. All settings must be reset.
-            3. All reports should be moved.
-
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
 @pytest.mark.tier(2)
 @pytest.mark.parametrize(
     "report_type", ["hosts", "vm_operation", "policy_events", "custom"]


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ `test_reset_report_menus` to test resetting reports menu.
- __Removing tests__ 
    1. `test_my_settings_default_views_alignment` - no longer required.
    2.  `test_reports_manage_report_menu_accordion_with_users` and `test_report_menus_moving_reports` which are already covered by other tests.


### PRT Run
{{ pytest : cfme/tests/intelligence/reports/test_menus.py::test_reset_report_menus -vvv }}
