### PR TITLE
[WIP] Blocked Reset power action on orphaned VM

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -700,7 +700,8 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
         logger.debug('Refreshing provider relationships')
         col = self.appliance.rest_api.collections.providers.find_by(name=self.name)
         try:
-            col[0].action.refresh()
+            if col[0].exists:
+                col[0].action.refresh()
         except IndexError:
             raise Exception("Provider collection empty")
 

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -672,14 +672,15 @@ def archive_orphan_vm(request, provider, testing_vm):
     yield request.param, testing_vm
 
 
-@pytest.mark.meta(automates=[1655477, 1686015])
-def test_power_options_on_archived_orphaned_vms_all_page(appliance, archive_orphan_vm):
+@pytest.mark.meta(automates=[1655477, 1686015, 1745915])
+def test_power_options_on_archived_orphaned_vms_all_page(provider, appliance, archive_orphan_vm):
     """This test case is to check Power option drop-down button is disabled on archived and orphaned
     VMs all page. Also it performs the power operations on vm and checked expected flash messages.
 
     Bugzilla:
         1655477
         1686015
+        1745915
 
     Polarion:
         assignee: ghubale
@@ -711,6 +712,13 @@ def test_power_options_on_archived_orphaned_vms_all_page(appliance, archive_orph
     # After selecting particular archived/orphaned vm; 'Power' drop down gets enabled.
     # Reading all the options available in 'power' drop down
     for action in view.toolbar.power.items:
+        if (
+                action == "Reset"
+                and state == "orphaned"
+                and BZ(1745915, forced_streams=["5.10"]).blocks
+                and provider.one_of(SCVMMProvider)
+        ):
+            continue
         # Performing power actions on archived/orphaned vm
         view.toolbar.power.item_select(action, handle_alert=True)
         if action == 'Power On':


### PR DESCRIPTION
## Purpose or Intent
- This PR blocks ```Reset``` power action on orphaned vms of scvmm2016 because of BZ(1745915)
- Fixes Error:
```
E           AssertionError: assert exact match of message: Reset action does not apply to selected items. 
E            Available messages: ['Reset initiated for 1 VM and Instance from the CFME Database']

/var/ci/cfme_venv3/lib64/python3.7/site-packages/widgetastic_patternfly/__init__.py:315: AssertionError
AssertionError
b"assert exact match of message: Reset action does not apply to selected items. \n Available messages: ['Reset initiated for 1 VM and Instance from the CFME Database']"

```

### PRT Run

{{ pytest: cfme/tests/infrastructure/test_vm_power_control.py::test_power_options_on_archived_orphaned_vms_all_page --use-provider=scvmm2016 --long-running -qsvvv }}