### PR TITLE
[1LP][RFR] fix custom menu test for test run

### DIFF
--- a/cfme/tests/automate/custom_button/test_custom_menu.py
+++ b/cfme/tests/automate/custom_button/test_custom_menu.py
@@ -91,7 +91,7 @@ def test_custom_menu_display(appliance, request):
     update_adv_setting_and_wait(appliance, ADVANCE_SETTING_CUSTOM_MENU)
     request.addfinalizer(lambda: update_adv_setting_and_wait(appliance, {"ui": "<<reset>>"}))
 
-    view = navigate_to(appliance.server, "LoggedIn")
+    view = navigate_to(appliance.server, "LoggedIn", force=True)
 
     for menu in ["RedHat", "ManageIQ"]:
         view.navigation.select(menu)


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- It was failing with `test runs`. update advance setting is with rest after evmserverd restart; we need force navigation.... locally and with single test run it was working properly. 

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/automate/custom_button/test_custom_menu.py -v}}