### PR TITLE
[1LP][RFR] Fix problem with None being passed as service unit name on 5.9

### DIFF
--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -12,6 +12,7 @@ from cfme.utils.appliance.plugin import AppliancePlugin
 from cfme.utils.appliance.plugin import AppliancePluginException
 from cfme.utils.conf import credentials
 from cfme.utils.path import scripts_path
+from cfme.utils.version import LOWEST
 from cfme.utils.version import VersionPicker
 from cfme.utils.wait import wait_for
 
@@ -29,7 +30,7 @@ class ApplianceDB(AppliancePlugin):
     @cached_property
     def service_name(self):
         return VersionPicker({
-            '5.10': 'rh-postgresql95-postgresql',
+            LOWEST: 'rh-postgresql95-postgresql',
             '5.11': 'postgresql'}).pick(self.appliance.version)
 
     @property


### PR DESCRIPTION
When running the test_upgrade_single_inplace, None was passed as service
unit name because VersionPicker didn't have definition for the 5.9. This
happened on testing upgrade from 5.9 to 5.10.

```
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

appliance_preupdate = IPAppliance.from_json('{"is_dev": false, "db_host": null, "ui_protocol": "https", "browser_steal": false, "hostname": ...196.157", "openshift_creds": {}, "ui_port": 443, "project": null, "container": null, "db_port": 5432, "ssh_port": 22}')
appliance = IPAppliance.from_json('{"is_dev": false, "db_host": null, "ui_protocol": "https", "browser_steal": false, "hostname": ...198.129", "openshift_creds": {}, "ui_port": 443, "project": null, "container": null, "db_port": 5432, "ssh_port": 22}')

    @pytest.mark.ignore_stream("5.11")
    @pytest.mark.tier(2)
    def test_upgrade_single_inplace(appliance_preupdate, appliance):
        """Tests appliance upgrade between streams

        Polarion:
            assignee: jhenner
            casecomponent: Appliance
            caseimportance: critical
            initialEstimate: 1/3h
            testtype: upgrade
        """
        appliance_preupdate.evmserverd.stop()
        result = appliance_preupdate.ssh_client.run_command('yum update -y', timeout=3600)
        assert result.success, "update failed {}".format(result.output)
        appliance_preupdate.db.migrate()
        appliance_preupdate.db.automate_reset()
>       appliance_preupdate.db_service.restart()

cfme/tests/test_db_migrate.py:209:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
cfme/utils/appliance/services.py:74: in restart
    log_callback=log_callback
cfme/utils/log.py:177: in newfunc
    return func(*args, **kwargs)
cfme/utils/appliance/services.py:40: in _run_service_command
    cmd = 'systemctl {} {}'.format(quote(command), quote(unit))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (None,)

    def quote(*args):
        """Combine the arguments into a single string and escape any and
        all shell special characters or (reserved) words.  The shortest
        possible string (correctly quoted suited to pass to a bash shell)
        is returned.
        """
>       s = "".join(args)
E       TypeError: sequence item 0: expected str instance, NoneType found
```
{{ py.test: -v cfme/tests/test_db_migrate.py::test_upgrade_single_inplace }}