### PR TITLE
[WIPTEST] Don't rewrite the pg_hba.conf when loosening it.

### DIFF
--- a/scripts/data/enable-internal-db.rbt
+++ b/scripts/data/enable-internal-db.rbt
@@ -28,7 +28,7 @@ config.post_activation
 # assumes sdb, update disk device as needed
 systemctl stop evmserverd
 /etc/init.d/${postgres_svcname} stop
-umount ${postgres_prefix}/var/lib/pgsql/data/
+umount ${postgres_prefix}/data/
 lvremove -f vg_data/lv_pg
 vgremove vg_data
 pvremove /dev/sdb1


### PR DESCRIPTION
In commit 2950ae43d73c8 I was changing paths that is used by the DB permsissions "loosening" code. The path used on CFME 5.10 is wrong though and the DB "loosening" was not effective there (we didn't know about that as the command failed silently).

We were rewriting the pg_hba.conf in the "loosening" DB permissions step (in case 5.11)
in such a way that it results in actually disallowing the replication. The
vanilla state of the pg_hba.conf allows replication. Allowance of db replication is required for db backup opertaions to work. This made restore tests not working on 5.11 but working on 5.10.

This PR is fixing the path on 5.10 and also changing the code from doing complete rewrite to just adding to the pg_hba.conf, but from the fact that we haven't had the loosening in effect on 5.10 for some time, the question to ask is: *Do we really need to modify the pg_hba.conf at all? *