### PR TITLE
[1LP][RFR][NOTEST] Add in an all() method ViaREST for generic-object and definitions

### DIFF
--- a/cfme/generic_objects/definition/__init__.py
+++ b/cfme/generic_objects/definition/__init__.py
@@ -46,6 +46,7 @@ class GenericObjectDefinitionCollection(BaseCollection, sentaku.modeling.Element
     ENTITY = GenericObjectDefinition
 
     create = sentaku.ContextualMethod()
+    all = sentaku.ContextualMethod()
 
 
 from cfme.generic_objects.definition import rest, ui  # NOQA last for import cycles

--- a/cfme/generic_objects/definition/rest.py
+++ b/cfme/generic_objects/definition/rest.py
@@ -7,6 +7,7 @@ from cfme.utils.rest import assert_response
 from cfme.utils.rest import create_resource
 
 
+# collection methods
 @MiqImplementationContext.external_for(GenericObjectDefinitionCollection.create, ViaREST)
 def create(self, name, description, attributes=None, associations=None, methods=None):
     body = {'name': name, 'description': description, 'properties': {}}
@@ -31,6 +32,18 @@ def create(self, name, description, attributes=None, associations=None, methods=
     return entity
 
 
+@MiqImplementationContext.external_for(GenericObjectDefinitionCollection.all, ViaREST)
+def all(self):
+    rest_generic_object_definitions = (
+        self.appliance.rest_api.collections.generic_object_definitions.all
+    )
+    return [
+        self.instantiate(name=gobj_def.name, description=gobj_def.description)
+        for gobj_def in rest_generic_object_definitions
+    ]
+
+
+# entity methods
 @MiqImplementationContext.external_for(GenericObjectDefinition.update, ViaREST)
 def update(self, updates):
     definition = self.appliance.rest_api.collections.generic_object_definitions.find_by(

--- a/cfme/generic_objects/definition/ui.py
+++ b/cfme/generic_objects/definition/ui.py
@@ -17,6 +17,7 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.appliance.implementations.ui import ViaUI
 
 
+# collection methods
 @MiqImplementationContext.external_for(GenericObjectDefinitionCollection.create, ViaUI)
 def create(self, name, description, attributes=None, associations=None, methods=None,
            custom_image_file_path=None, cancel=False):
@@ -57,6 +58,7 @@ def create(self, name, description, attributes=None, associations=None, methods=
     return entity
 
 
+# entity methods
 @MiqImplementationContext.external_for(GenericObjectDefinition.update, ViaUI)
 def update(self, updates, reset=False, cancel=False):
     """Update generic object definition
@@ -116,6 +118,7 @@ def instance_count(self):
     return int(view.summary("Relationships").get_text_of("Instances"))
 
 
+# navigator registers
 @navigator.register(GenericObjectDefinitionCollection)
 class All(CFMENavigateStep):
     VIEW = GenericObjectDefinitionAllView

--- a/cfme/generic_objects/instance/__init__.py
+++ b/cfme/generic_objects/instance/__init__.py
@@ -36,6 +36,7 @@ class GenericObjectInstanceCollection(BaseCollection, sentaku.modeling.ElementMi
     ENTITY = GenericObjectInstance
 
     create = sentaku.ContextualMethod()
+    all = sentaku.ContextualMethod()
 
 
 from cfme.generic_objects.instance import rest, ui  # NOQA last for import cycles

--- a/cfme/generic_objects/instance/rest.py
+++ b/cfme/generic_objects/instance/rest.py
@@ -21,6 +21,7 @@ def _get_associations_dict(appliance, associations, definition):
     return assoc_dict
 
 
+# collection methods
 @MiqImplementationContext.external_for(GenericObjectInstanceCollection.create, ViaREST)
 def create(self, name, definition, attributes=None, associations=None):
     definition_rest = self.appliance.rest_api.collections.generic_object_definitions.get(
@@ -44,6 +45,29 @@ def create(self, name, definition, attributes=None, associations=None):
     return entity
 
 
+@MiqImplementationContext.external_for(GenericObjectInstanceCollection.all, ViaREST)
+def all(self):
+    generic_objects = []
+    for rest_generic_object in self.appliance.rest_api.collections.generic_objects.all:
+        # get the generic_object_definition
+        rest_generic_definition = (
+            self.appliance.rest_api.collections.generic_object_definitions.find_by(
+                id=rest_generic_object.generic_object_definition_id
+            )[0]
+        )
+        generic_definition = self.appliance.collections.generic_object_definitions.instantiate(
+            name=rest_generic_definition.name,
+            description=rest_generic_definition.description
+        )
+        # instantiate the generic_object
+        generic_objects.append(self.instantiate(
+            name=rest_generic_object.name,
+            definition=generic_definition
+        ))
+    return generic_objects
+
+
+# entity methods
 @MiqImplementationContext.external_for(GenericObjectInstance.update, ViaREST)
 def update(self, updates):
     instance = self.appliance.rest_api.collections.generic_objects.find_by(

--- a/cfme/generic_objects/instance/ui.py
+++ b/cfme/generic_objects/instance/ui.py
@@ -23,6 +23,7 @@ from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import ParametrizedSummaryTable
 
 
+# views
 class GenericObjectInstanceToolbar(View):
     policy = Dropdown(text='Policy')
     download = Dropdown(text='Download')
@@ -85,6 +86,7 @@ class MyServiceGenericObjectInstanceView(BaseLoggedInPage):
         )
 
 
+# entity methods
 @MiqImplementationContext.external_for(GenericObjectInstance.exists.getter, ViaUI)
 def exists(self):
     if self.definition.instance_count > 0:
@@ -112,6 +114,7 @@ def get_tags(self, tenant="My Company Tags"):
     return Taggable.get_tags(self, tenant=tenant)
 
 
+# navigator registers
 @navigator.register(GenericObjectInstanceCollection, 'All')
 class All(CFMENavigateStep):
     VIEW = GenericObjectInstanceAllView


### PR DESCRIPTION
Adding in an `all()` method for generic_objects and generic_object_definitions. 