### PR TITLE
[1LP][RFR] Add sidebar accordion to Compute Infrastructure pages AND automate test: test_infrastructure_provider_left_panel_titles

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -93,17 +93,35 @@ class HostNetworkDetailsView(View):
         "{} (Network)".format(self.context["object"].name) == self.breadcrumb.active_location)
 
 
+class HostDetailsAccordionView(View):
+
+    @View.nested
+    class properties(Accordion):  # noqa
+        ACCORDION_NAME = "Properties"
+        tree = BootstrapNav(locator='//div[@id="host_prop"]//ul')
+
+    @View.nested
+    class relationships(Accordion):  # noqa
+        ACCORDION_NAME = "Relationships"
+        tree = BootstrapNav(locator='//div[@id="host_rel"]//ul')
+
+    @View.nested
+    class security(Accordion):  # noqa
+        ACCORDION_NAME = "Security"
+        tree = BootstrapNav(locator='//div[@id="host_sec"]//ul')
+
+    @View.nested
+    class configuration(Accordion):  # noqa
+        ACCORDION_NAME = "Configuration"
+        tree = BootstrapNav(locator='//div[@id="host_config"]//ul')
+
+
 class HostDetailsView(ComputeInfrastructureHostsView):
     """Main Host details page."""
     breadcrumb = BreadCrumb(locator='.//ol[@class="breadcrumb"]')
     toolbar = View.nested(HostDetailsToolbar)
     entities = View.nested(HostDetailsEntities)
-
-    @View.nested
-    class security_accordion(Accordion):  # noqa
-        ACCORDION_NAME = "Security"
-
-        navigation = BootstrapNav('.//div/ul')
+    sidebar = View.nested(HostDetailsAccordionView)
 
     @property
     def is_displayed(self):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -58,6 +58,19 @@ class ProviderDetailsToolBar(View):
     view_selector = View.nested(DetailsToolBarViewSelector)
 
 
+class SummaryAccordionView(View):
+
+    @View.nested
+    class properties(Accordion):    # noqa
+        ACCORDION_NAME = "Properties"
+        tree = BootstrapNav(locator='//div[@id="ems_prop"]//ul')
+
+    @View.nested
+    class relationships(Accordion):    # noqa
+        ACCORDION_NAME = "Relationships"
+        tree = BootstrapNav(locator='//div[@id="ems_rel"]//ul')
+
+
 class ProviderDetailsView(BaseLoggedInPage):
     """
      main Details page
@@ -75,6 +88,7 @@ class ProviderDetailsView(BaseLoggedInPage):
         represents Details page when it is switched to Summary aka Tables view
         """
         summary = ParametrizedSummaryTable()
+        sidebar = View.nested(SummaryAccordionView)
 
     @entities.register('Dashboard View')
     class ProviderDetailsDashboardView(View):

--- a/cfme/infrastructure/cluster.py
+++ b/cfme/infrastructure/cluster.py
@@ -15,6 +15,7 @@ from cfme.common import CustomButtonEventsMixin
 from cfme.common import Taggable
 from cfme.common import TimelinesView
 from cfme.common.candu_views import ClusterInfraUtilizationView
+from cfme.common.provider_views import SummaryAccordionView
 from cfme.exceptions import ItemNotFound
 from cfme.infrastructure.virtual_machines import VmsTemplatesAllView
 from cfme.modeling.base import BaseCollection
@@ -55,21 +56,6 @@ class ClusterDetailsToolbar(View):
     policy = Dropdown('Policy')
     monitoring = Dropdown('Monitoring')
     download = Button('Print or export summary')
-
-
-class ClusterDetailsAccordion(View):
-    """The accordion on the details page"""
-    @View.nested
-    class cluster(Accordion):           # noqa
-        pass
-
-    @View.nested
-    class properties(Accordion):        # noqa
-        tree = ManageIQTree()
-
-    @View.nested
-    class relationships(Accordion):     # noqa
-        tree = ManageIQTree()
 
 
 class ClusterDetailsEntities(View):
@@ -140,7 +126,7 @@ class ClusterDetailsView(ClusterView):
         )
 
     toolbar = View.nested(ClusterDetailsToolbar)
-    sidebar = View.nested(ClusterDetailsAccordion)
+    sidebar = View.nested(SummaryAccordionView)
     entities = View.nested(ClusterDetailsEntities)
 
 

--- a/cfme/infrastructure/resource_pool.py
+++ b/cfme/infrastructure/resource_pool.py
@@ -45,11 +45,11 @@ class ResourcePoolDetailsAccordion(View):
     """The accordian on the details page"""
     @View.nested
     class properties(Accordion):  # noqa
-        tree = ManageIQTree()
+        tree = BootstrapNav(locator='//div[@id="resource_pool_prop"]//ul')
 
     @View.nested
     class relationships(Accordion):  # noqa
-        tree = ManageIQTree()
+        tree = BootstrapNav(locator='//div[@id="resource_pool_rel"]//ul')
 
 
 class ResourcePoolDetailsEntities(View):

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -101,7 +101,7 @@ def test_run_host_analysis(setup_provider_modscope, provider, host_type, host_na
     elif host_type in ('esx', 'esxi'):
         soft_assert(view.entities.summary('Configuration').get_text_of('Advanced Settings') != '0',
                     'No advanced settings found in host detail')
-        view.security_accordion.navigation.select(partial_match('Firewall Rules'))
+        view.sidebar.security.tree.select(partial_match('Firewall Rules'))
         # Page get updated if rules value is not 0, and title is update
         soft_assert("(Firewall Rules)" in view.title.text, (
             "No firewall rules found in host detail"))

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -15,8 +15,8 @@ from cfme.common.provider_views import ProviderDetailsView
 from cfme.common.provider_views import ProviderTimelinesView
 from cfme.infrastructure.config_management.ansible_tower import AnsibleTowerProvider
 from cfme.infrastructure.config_management.satellite import SatelliteProvider
-from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.datastore import ProviderAllDatastoresView
+from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider import ProviderClustersView
 from cfme.infrastructure.provider import ProviderTemplatesView
 from cfme.infrastructure.provider import ProviderVmsView
@@ -27,8 +27,8 @@ from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
-from cfme.utils.log_validator import LogValidator
 from cfme.utils.log import logger
+from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for
 
 
@@ -530,7 +530,7 @@ def test_provider_details_page_refresh_after_clear_cookies(
 
 
 @pytest.mark.tier(1)
-@pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE)
+@pytest.mark.provider([InfraProvider], selector=ONE_PER_CATEGORY)
 @pytest.mark.parametrize("option", ALL_OPTIONS)
 def test_infrastructure_provider_left_panel_titles(
     setup_provider, provider, option, soft_assert
@@ -570,7 +570,7 @@ def test_infrastructure_provider_left_panel_titles(
         )
         if not accordion.tree.is_disabled(partial_match(panel)):
             accordion.tree.select(partial_match(panel))
-            test_view = provider.create_view(ALL_OPTIONS[option][panel], wait="40s")
+            test_view = provider.create_view(ALL_OPTIONS[option][panel], wait="60s")
             soft_assert(test_view.is_displayed, f"{test_view} not displayed.")
         else:
             logger.info(f"'{panel}' was not tested, it did not enable.")

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -570,7 +570,7 @@ def test_infrastructure_provider_left_panel_titles(
         )
         if not accordion.tree.is_disabled(partial_match(panel)):
             accordion.tree.select(partial_match(panel))
-            test_view = provider.create_view(ALL_OPTIONS[option][panel], wait="20s")
+            test_view = provider.create_view(ALL_OPTIONS[option][panel], wait="40s")
             soft_assert(test_view.is_displayed, f"{test_view} not displayed.")
         else:
             logger.info(f"'{panel}' was not tested, it did not enable.")

--- a/cfme/tests/webui/test_general_ui_manual.py
+++ b/cfme/tests/webui/test_general_ui_manual.py
@@ -58,38 +58,14 @@ def test_notification_window_can_be_closed_by_clicking_x():
     pass
 
 
-@pytest.mark.manual("manualonly")
-@pytest.mark.tier(1)
-def test_infrastructure_provider_left_panel_titles():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Infra
-        caseimportance: low
-        initialEstimate: 1/18h
-        testSteps:
-            1. Add an infrastructure provider and navigate to it's Details page.
-            2. Select Properties on the panel and check all items, whether they have their titles.
-            3. Select Relationships on the panel and check all items,
-                whether they have their titles.
-        expectedResults:
-            1.
-            2. Properties panel must have all items and clicking on each item should display
-                the correct page.
-            3. Relationships panel must have all items and clicking on each item should display
-                the correct page.
-    """
-    pass
-
-
-@pytest.mark.manual("manualonly")
+@pytest.mark.manual
 @pytest.mark.tier(1)
 @pytest.mark.meta(coverage=[1651194, 1503213])
 @test_requirements.general_ui
 @pytest.mark.provider([InfraProvider, CloudProvider], selector=ONE)
 def test_pdf_summary_provider(provider):
     """
-    Polarion:
+q    Polarion:
         assignee: pvala
         casecomponent: WebUI
         caseimportance: medium

--- a/cfme/tests/webui/test_general_ui_manual.py
+++ b/cfme/tests/webui/test_general_ui_manual.py
@@ -65,7 +65,7 @@ def test_notification_window_can_be_closed_by_clicking_x():
 @pytest.mark.provider([InfraProvider, CloudProvider], selector=ONE)
 def test_pdf_summary_provider(provider):
     """
-q    Polarion:
+    Polarion:
         assignee: pvala
         casecomponent: WebUI
         caseimportance: medium

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -337,7 +337,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.16.0
 widgetastic.core==0.51
-widgetastic.patternfly==1.2.0
+widgetastic.patternfly==1.2.2
 widgetsnbextension==3.4.2
 wrapanapi==3.5.2
 wrapt==1.11.1


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ `test_infrastructure_provider_left_panel_titles`
- __Updating tests__ `test_run_host_analysis` which uses host details sidebar.
- __Enhancement__ Add sidebar accordions to the following pages
    1. Infrastructure > Providers
    2. Infrastructure > Clusters
    3. Infrastructure > Hosts
    4. Infrastructure > Resource Pools

Note: Dependent on : https://github.com/RedHatQE/widgetastic.patternfly/pull/114

### PRT Run
{{ pytest : cfme/tests/webui/test_general_ui.py::test_infrastructure_provider_left_panel_titles cfme/tests/infrastructure/test_host_analysis.py::test_run_host_analysis -vvv }}