### PR TITLE
[WIPTEST] test_advanced_search -  doctrings get lost when transforming function to method

### DIFF
--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -177,6 +177,7 @@ def methodized(metafunc):
 
     def func(self, param, appliance):
         return metafunc(param, appliance)
+    func.__doc__ = metafunc.__doc__
     return func
 
 


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
Make Polarion great again :sunglasses: 

Added quick fix that copies docstring of test function that is being wrapped up.

_Needs to be verified if Polarion can work with these tests now._
<!-- Please provide some information related to PR. Some examples are:


- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].

Some examples are:
- {{pytest: cfme/tests/test_foo_file.py -v}}
- {{pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}}
- {{pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}}
- {{pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}}
- {{pytest: cfme/tests/test_foo_file.py --long-running -v}}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
