### PR TITLE
[1LP][RFR] New Test: Testing state machine variables

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -457,9 +457,7 @@ class MethodCollection(BaseCollection):
 
         add_page = navigate_to(self, 'Add')
 
-        if self.browser.product_version < '5.11':
-            location = location
-        else:
+        if self.browser.product_version > '5.11' and location.islower():
             location = location.capitalize()
 
         add_page.fill({'location': location})

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -168,35 +168,6 @@ def test_automate_git_domain_import_with_no_connection():
     pass
 
 
-@pytest.mark.tier(1)
-def test_automate_retry_onexit_increases():
-    """
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/8h
-        tags: automate
-        testSteps:
-            1. Import the attached file, it will create a domain called OnExitRetry
-            2. Enable the domain
-            3. Go to Automate / Simulation
-            4. Simulate Request with instance OnExitRetry, execute methods
-            5. Click submit, open the tree on right and expand ae_state_retries
-        expectedResults:
-            1.
-            2.
-            3.
-            4.
-            5. It should be 1 by now and subsequent clicks on Retry should raise the
-               number if it works properly.
-
-    Bugzilla:
-        1365442
-    """
-    pass
-
-
 @pytest.mark.tier(3)
 def test_automate_simulation_result_has_hash_data():
     """
@@ -249,25 +220,6 @@ def test_automate_git_import_without_master():
 
     Bugzilla:
         1508881
-    """
-    pass
-
-
-@pytest.mark.tier(1)
-def test_state_machine_variable():
-    """
-    Test whether storing the state machine variable works and the value is
-    available in another state.
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/4h
-        tags: automate
-        testSteps:
-            1. Test whether storing the state machine variable works and the value is available in
-               another state.
     """
     pass
 


### PR DESCRIPTION
  ## Purpose or Intent
- This PR includes testing of state machines variables by executing ```inline``` automate methods in state schema
- Removed test case - ```test_automate_retry_onexit_increases```. It is already automated test case - ```test_automate_schema_field_without_type```
### PRT Run
{{ pytest: cfme/tests/automate/test_class.py::test_state_machine_variable --use-template-cache -qsvvv }}