### PR TITLE
[RFR] Update BootstrapSelect to ReactSelect for 5.11

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -526,7 +526,10 @@ class ManagementEngineView(BaseLoggedInPage):
 
     @View.nested
     class form(View):  # noqa
-        server = BootstrapSelect('server_id')
+        server = VersionPicker({
+            "5.11": ReactSelect('serverId'),
+            LOWEST: BootstrapSelect('server_id')
+        })
         save_button = Button('Save')
         reset_button = Button('Reset')
         cancel_button = Button('Cancel')


### PR DESCRIPTION
This select was updated to a react select in 5.11, which is breaking some timelines tests. 

{{ pytest: --use-provider rhv42 cfme/tests/infrastructure/test_timelines.py::test_infra_timeline_diagnostic }}