### PR TITLE
[RFR]Fixing test failure by adding required_fields

### DIFF
--- a/cfme/tests/infrastructure/test_publish_vm_to_template.py
+++ b/cfme/tests/infrastructure/test_publish_vm_to_template.py
@@ -12,7 +12,10 @@ from cfme.utils.virtual_machines import deploy_template
 
 pytestmark = [
     pytest.mark.provider([InfraProvider],
-    required_fields=[['templates', 'small_template']]),
+    required_fields=[['templates', 'small_template'],
+                    ['provisioning', 'template'],
+                    ['provisioning', 'host'],
+                    ['provisioning', 'datastore']]),
     test_requirements.vmware,
     test_requirements.rhev
 ]


### PR DESCRIPTION

## Purpose or Intent

- __Fixing__ this test by adding required_fields as it was picking wrong vmware provider and failing. 


![image](https://user-images.githubusercontent.com/8180469/63977316-80159200-ca81-11e9-9d53-dd7eeeab5dfc.png)

### PRT Run


- {{pytest: cfme/tests/infrastructure/test_publish_vm_to_template.py -k "test_publish_vm_to_template" -v}}
