### PR TITLE
[1LP][RFR]: Make playbook lowercase in create method

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -473,7 +473,7 @@ class MethodCollection(BaseCollection):
                 'inputs': inputs,
                 'embedded_method': embedded_method
             })
-        if location == 'playbook':
+        if location.lower() == 'playbook':
             add_page.fill({
                 'playbook_name': name,
                 'playbook_display_name': display_name,

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -116,7 +116,8 @@ def management_event_instance(management_event_class, management_event_method):
     return management_event_class.instances.create(
         name=fauxfactory.gen_alphanumeric(),
         description=fauxfactory.gen_alphanumeric(),
-        fields={"meth1": {"value": management_event_method.name}})
+        fields={"meth1": {"value": management_event_method.name}}
+    )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
In 5.11 "Playbook" is uppercase, so we must make the condition use `lower()` for this to evaluated properly. 

{{ pytest: --use-provider vsphere65-nested --long-running cfme/tests/ansible/test_embedded_ansible_automate.py::test_alert_run_ansible_playbook }}