### PR TITLE
[1LP][RFR] Add bz metadata for timelines tests

### DIFF
--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -323,9 +323,7 @@ def test_infra_timeline_create_event(new_vm, soft_assert):
     """
     event = 'create'
     vm_event = VMEvent(new_vm, event)
-    if BZ(1670550).blocks:
-        targets = (new_vm, )
-    elif BZ(1747132).blocks:
+    if BZ(1747132).blocks:
         targets = (new_vm, new_vm.cluster, new_vm.provider)
     else:
         targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
@@ -352,10 +350,7 @@ def test_infra_timeline_policy_event(new_vm, control_policy, soft_assert):
     """
 
     event = 'policy'
-    if BZ(1670550).blocks:
-        targets = (new_vm,)
-    else:
-        targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
+    targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     vm_event = VMEvent(new_vm, event)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)
     wait_for(vm_event.emit, timeout='7m', message='Event {} did timeout'.format(event))
@@ -378,10 +373,7 @@ def test_infra_timeline_stop_event(new_vm, soft_assert):
         casecomponent: Events
     """
     event = 'stop'
-    if BZ(1670550).blocks:
-        targets = (new_vm,)
-    else:
-        targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
+    targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     vm_event = VMEvent(new_vm, event)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)
     wait_for(vm_event.emit, timeout='7m', message='Event {} failed'.format(event))
@@ -404,10 +396,7 @@ def test_infra_timeline_start_event(new_vm, soft_assert):
         casecomponent: Events
     """
     event = 'start'
-    if BZ(1670550).blocks:
-        targets = (new_vm,)
-    else:
-        targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
+    targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     vm_event = VMEvent(new_vm, event)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)
     wait_for(vm_event.emit, timeout='7m', message='Event {} failed'.format(event))
@@ -430,10 +419,7 @@ def test_infra_timeline_suspend_event(new_vm, soft_assert):
         casecomponent: Events
     """
     event = 'suspend'
-    if BZ(1670550).blocks:
-        targets = (new_vm,)
-    else:
-        targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
+    targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     vm_event = VMEvent(new_vm, event)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)
     wait_for(vm_event.emit, timeout='7m', message='Event {} failed'.format(event))
@@ -479,10 +465,7 @@ def test_infra_timeline_clone_event(new_vm, soft_assert):
     """
     event = 'clone'
     vm_event = VMEvent(new_vm, event)
-    if BZ(1670550).blocks:
-        targets = (new_vm,)
-    else:
-        targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
+    targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)
     wait_for(vm_event.emit, timeout='7m', message='Event {evt} failed'.format(evt=event))
     vm_event.catch_in_timelines(soft_assert, targets)
@@ -505,10 +488,7 @@ def test_infra_timeline_migrate_event(new_vm, soft_assert):
     """
     event = 'migrate'
     vm_event = VMEvent(new_vm, event)
-    if BZ(1670550).blocks:
-        targets = (new_vm,)
-    else:
-        targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
+    targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)
     wait_for(vm_event.emit, timeout='7m', message='Event {evt} failed'.format(evt=event))
     vm_event.catch_in_timelines(soft_assert, targets)
@@ -533,15 +513,13 @@ def test_infra_timeline_rename_event(new_vm, soft_assert):
     """
     event = 'rename'
     vm_event = VMEvent(new_vm, event)
-    if BZ(1670550).blocks:
-        targets = (new_vm,)
-    else:
-        targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
+    targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)
     wait_for(vm_event.emit, timeout='7m', message='Event {evt} failed'.format(evt=event))
     vm_event.catch_in_timelines(soft_assert, targets)
 
 
+@pytest.mark.meta(automates=[1747132])
 def test_infra_timeline_delete_event(new_vm, soft_assert):
     """Test that the event delete is visible on the  management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
@@ -552,6 +530,7 @@ def test_infra_timeline_delete_event(new_vm, soft_assert):
     Bugzilla:
         1550488
         1670550
+        1747132
 
     Polarion:
         assignee: jdupuy
@@ -560,8 +539,8 @@ def test_infra_timeline_delete_event(new_vm, soft_assert):
     """
     event = 'delete'
     vm_event = VMEvent(new_vm, event)
-    if BZ(1670550).blocks:
-        targets = (new_vm,)
+    if BZ(1747132).blocks:
+        targets = (new_vm, new_vm.cluster, new_vm.provider)
     else:
         targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)

--- a/cfme/tests/infrastructure/test_timelines.py
+++ b/cfme/tests/infrastructure/test_timelines.py
@@ -304,12 +304,17 @@ class VMEvent(object):
             raise ValueError('Targets must not be empty')
 
 
+@pytest.mark.meta(automates=[1747132])
 def test_infra_timeline_create_event(new_vm, soft_assert):
     """Test that the event create is visible on the management event timeline of the Vm,
     Vm's cluster,  VM's host, VM's provider.
 
     Metadata:
         test_flag: events, provision, timelines
+
+    Bugzilla:
+        1670550
+        1747132
 
     Polarion:
         assignee: jdupuy
@@ -320,6 +325,8 @@ def test_infra_timeline_create_event(new_vm, soft_assert):
     vm_event = VMEvent(new_vm, event)
     if BZ(1670550).blocks:
         targets = (new_vm, )
+    elif BZ(1747132).blocks:
+        targets = (new_vm, new_vm.cluster, new_vm.provider)
     else:
         targets = (new_vm, new_vm.cluster, new_vm.host, new_vm.provider)
     logger.info('Will generate event %r on machine %r', event, new_vm.name)
@@ -334,6 +341,9 @@ def test_infra_timeline_policy_event(new_vm, control_policy, soft_assert):
 
     Metadata:
         test_flag: events, provision, timelines
+
+    Bugzilla:
+        1670550
 
     Polarion:
         assignee: jdupuy
@@ -359,6 +369,9 @@ def test_infra_timeline_stop_event(new_vm, soft_assert):
     Metadata:
         test_flag: events, provision, timelines
 
+    Bugzilla:
+        1670550
+
     Polarion:
         assignee: jdupuy
         initialEstimate: 1/4h
@@ -382,6 +395,9 @@ def test_infra_timeline_start_event(new_vm, soft_assert):
     Metadata:
         test_flag: events, provision, timelines
 
+    Bugzilla:
+        1670550
+
     Polarion:
         assignee: jdupuy
         initialEstimate: 1/4h
@@ -404,6 +420,9 @@ def test_infra_timeline_suspend_event(new_vm, soft_assert):
 
     Metadata:
         test_flag: events, provision, timelines
+
+    Bugzilla:
+        1670550
 
     Polarion:
         assignee: jdupuy
@@ -451,6 +470,7 @@ def test_infra_timeline_clone_event(new_vm, soft_assert):
 
     Bugzilla:
         1622952
+        1670550
 
     Polarion:
         assignee: jdupuy
@@ -474,6 +494,9 @@ def test_infra_timeline_migrate_event(new_vm, soft_assert):
 
     Metadata:
         test_flag: events, provision, timelines
+
+    Bugzilla:
+        1670550
 
     Polarion:
         assignee: jdupuy
@@ -500,6 +523,9 @@ def test_infra_timeline_rename_event(new_vm, soft_assert):
     Metadata:
         test_flag: events, provision, timelines
 
+    Bugzilla:
+        1670550
+
     Polarion:
         assignee: jdupuy
         initialEstimate: 1/4h
@@ -525,6 +551,7 @@ def test_infra_timeline_delete_event(new_vm, soft_assert):
 
     Bugzilla:
         1550488
+        1670550
 
     Polarion:
         assignee: jdupuy


### PR DESCRIPTION
Adding a `blocks` statement for BZ https://bugzilla.redhat.com/show_bug.cgi?id=1747132 and adding metadata throughout `test_timelines.py`

{{ pytest: --use-provider rhv43 cfme/tests/infrastructure/test_timelines.py::test_infra_timeline_create_event }}
