### PR TITLE
[1LP][RFR] Remove old bz 1549529, allow tests to run

### DIFF
--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -595,8 +595,10 @@ def test_action_create_snapshot_and_delete_last(appliance, request, vm, vm_on, p
     )
 
 
-@pytest.mark.meta(blockers=[BZ(1748410, forced_streams=["5.10"])], automates=[1748410])
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")
+@pytest.mark.meta(blockers=[BZ(1748410, forced_streams=["5.10"])],
+                  automates=[1748410],
+                  unblock=lambda provider: provider.one_of(VMwareProvider))
 def test_action_create_snapshots_and_delete_them(request, appliance, vm, vm_on, policy_for_testing):
     """ This test tests actions 'Create a Snapshot' (custom) and 'Delete all Snapshots'.
 

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -28,7 +28,6 @@ from cfme.tests.control import wait_for_ssa_enabled
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
-from cfme.utils.log import logger
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.update import update
 from cfme.utils.wait import TimedOutError
@@ -597,21 +596,15 @@ def test_action_create_snapshot_and_delete_last(appliance, request, vm, vm_on, p
 
 
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")
-@pytest.mark.meta(
-    blockers=[
-        BZ(
-            1549529,
-            forced_streams=["5.10", "upstream"],
-            unblock=lambda provider: provider.one_of(VMwareProvider),
-        )
-    ]
-)
 def test_action_create_snapshots_and_delete_them(request, appliance, vm, vm_on, policy_for_testing):
     """ This test tests actions 'Create a Snapshot' (custom) and 'Delete all Snapshots'.
 
     This test sets the policy that it makes snapshot of VM after it's powered off and then it cycles
     several time that it generates a couple of snapshots. Then the 'Delete all Snapshots' is
     assigned to power on event, VM is powered on and it waits for all snapshots to disappear.
+
+    Bugzilla:
+        1745065
 
     Metadata:
         test_flag: actions, provision
@@ -649,9 +642,6 @@ def test_action_create_snapshots_and_delete_them(request, appliance, vm, vm_on, 
             message="wait for snapshot %d to appear" % (n + 1),
             delay=5,
         )
-        current_snapshot = vm.current_snapshot_name
-        logger.debug("Current Snapshot Name: {}".format(current_snapshot))
-        assert current_snapshot == snapshot_name
         vm.mgmt.ensure_state(VmState.RUNNING)
 
     for i in range(4):

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -595,6 +595,7 @@ def test_action_create_snapshot_and_delete_last(appliance, request, vm, vm_on, p
     )
 
 
+@pytest.mark.meta(blockers=[BZ(1748410, forced_streams=["5.10"])], automates=[1748410])
 @pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module")
 def test_action_create_snapshots_and_delete_them(request, appliance, vm, vm_on, policy_for_testing):
     """ This test tests actions 'Create a Snapshot' (custom) and 'Delete all Snapshots'.
@@ -606,6 +607,7 @@ def test_action_create_snapshots_and_delete_them(request, appliance, vm, vm_on, 
     Bugzilla:
         1549529
         1745065
+        1748410
 
     Metadata:
         test_flag: actions, provision

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -604,6 +604,7 @@ def test_action_create_snapshots_and_delete_them(request, appliance, vm, vm_on, 
     assigned to power on event, VM is powered on and it waits for all snapshots to disappear.
 
     Bugzilla:
+        1549529
         1745065
 
     Metadata:


### PR DESCRIPTION
This should have been included in #9248, but I missed it. Essentially it is doing the same thing as that PR, but for a slightly different test case. 

{{ pytest: --use-provider rhv43 --long-running cfme/tests/control/test_actions.py::test_action_create_snapshots_and_delete_them }}

