### PR TITLE
[RFR] fixed the expected path for ansible logs in the collected logs

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -22,8 +22,7 @@ from cfme.utils.ftp import FTPClient
 from cfme.utils.ssh import SSHClient
 from cfme.utils.update import update
 
-pytestmark = [pytest.mark.long_running, test_requirements.log_depot,
-              pytest.mark.meta(blockers=[BZ(1706903)])]
+pytestmark = [pytest.mark.long_running, test_requirements.log_depot]
 
 
 class LogDepotType(object):
@@ -166,9 +165,7 @@ def check_ftp(appliance, ftp, server_name, server_zone_id, check_ansible_logs=Fa
         try:
             date_from = datetime.strptime(date_from, "%Y%m%d%H%M%S")
             date_to = datetime.strptime(date_to, "%Y%m%d%H%M%S")
-            # if the file is correct, check ansible logs (~/ROOT/var/log/tower/setup-*) are there
-            logs_ansible = "ROOT/var/log/tower/setup" if zip_file.name.startswith("Current") \
-                else "log/ansible_tower"
+            logs_ansible = "log/ansible_tower"
             if ftp.login != 'anonymous' and check_ansible_logs:  # can't login as anon using SSH
                 with SSHClient(hostname=ftp.host,
                                username=ftp.login,


### PR DESCRIPTION
## Purpose or Intent
Log collection tests failed on checking ansible logs. Before there was a workaroud and now it seems to work the same for all archives.

### PRT Run

{{ pytest: -v cfme/tests/configure/test_log_depot_operation.py::test_collect_log_depot  --long-running }}
