### PR TITLE
[1LP][RFR] New Test: Testing automate domain import via rake command

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -355,25 +355,6 @@ def test_automate_git_credentials_changed():
     pass
 
 
-@pytest.mark.tier(1)
-def test_automate_git_import_case_insensitive():
-    """
-    bin/rake evm:automate:import PREVIEW=false
-    GIT_URL=https://github.com/mkanoor/SimpleDomain REF=test2branch
-    This should not cause an error (the actual name of the branch is
-    Test2Branch).
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/8h
-        tags: automate
-        startsin: 5.7
-    """
-    pass
-
-
 @pytest.mark.tier(3)
 def test_automate_import_namespace_attributes_updated():
     """

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -358,9 +358,9 @@ def test_domain_import_git_rest(appliance, request):
 def test_automate_git_import_case_insensitive(request, appliance):
     """
     bin/rake evm:automate:import PREVIEW=false
-    GIT_URL=https://github.com/mkanoor/SimpleDomain REF=test2branch
+    GIT_URL=https://github.com/RedHatQE/ManageIQ-automate-git REF=TestBranch
     This should not cause an error (the actual name of the branch is
-    Test2Branch).
+    TestBranch).
 
     Polarion:
         assignee: ghubale
@@ -371,9 +371,9 @@ def test_automate_git_import_case_insensitive(request, appliance):
         startsin: 5.7
     """
     appliance.ssh_client.run_rake_command(
-        "evm:automate:import PREVIEW=false GIT_URL=https://github.com/ganeshhubale/SimpleDomain "
-        "REF=test2branch"
+        "evm:automate:import PREVIEW=false "
+        "GIT_URL=https://github.com/RedHatQE/ManageIQ-automate-git REF=TestBranch"
     )
-    domain = appliance.collections.domains.instantiate(name="SimpleDomain")
+    domain = appliance.collections.domains.instantiate(name="testdomain")
     request.addfinalizer(domain.delete_if_exists)
     assert domain.exists

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -352,3 +352,28 @@ def test_domain_import_git_rest(appliance, request):
         domain.delete_if_exists()
 
     assert automate_domain.exists
+
+
+@pytest.mark.tier(1)
+def test_automate_git_import_case_insensitive(request, appliance):
+    """
+    bin/rake evm:automate:import PREVIEW=false
+    GIT_URL=https://github.com/mkanoor/SimpleDomain REF=test2branch
+    This should not cause an error (the actual name of the branch is
+    Test2Branch).
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: Automate
+        caseimportance: medium
+        initialEstimate: 1/8h
+        tags: automate
+        startsin: 5.7
+    """
+    appliance.ssh_client.run_rake_command(
+        "evm:automate:import PREVIEW=false GIT_URL=https://github.com/ganeshhubale/SimpleDomain "
+        "REF=test2branch"
+    )
+    domain = appliance.collections.domains.instantiate(name="SimpleDomain")
+    request.addfinalizer(domain.delete_if_exists)
+    assert domain.exists


### PR DESCRIPTION
## Purpose or Intent
- This PR automates the scenario of importing automate domain via rake command using git repo and checking via UI if imported domain is exists without any error.

### PRT Run
{{ pytest: cfme/tests/automate/test_git_import.py::test_automate_git_import_case_insensitive --use-template-cache -qsvvv }}