### PR TITLE
[1LP][RFR] automated manual test for unconfigured log depot

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -303,6 +303,9 @@ def test_collect_unconfigured(appliance):
     server_log_depot.clear()
     # check button is disable after removing log depot
     assert not view.toolbar.collect.is_displayed
+    # check it's also disabled on zone level
+    view_zone = navigate_to(appliance.server.zone.collect_logs, 'DiagnosticsCollectLogs')
+    assert not view_zone.toolbar.collect.is_displayed
 
 
 @pytest.mark.parametrize('from_slave', [True, False], ids=['from_slave', 'from_master'])

--- a/cfme/tests/configure/test_log_depot_operation_manual.py
+++ b/cfme/tests/configure/test_log_depot_operation_manual.py
@@ -140,38 +140,6 @@ def test_log_multiple_servers_unconfigured():
     pass
 
 
-@pytest.mark.tier(1)
-def test_log_collect_all_zone_unconfigured():
-    """
-    check collect all logs under zone when both levels are unconfigured.
-    Expected result - all buttons are disabled
-
-    Polarion:
-        assignee: anikifor
-        casecomponent: Configuration
-        caseimportance: low
-        caseposneg: negative
-        initialEstimate: 1/2h
-    """
-    pass
-
-
-@pytest.mark.tier(1)
-def test_log_collect_current_zone_all_unconfigured():
-    """
-    check collect logs under zone when both levels are unconfigured.
-    Expected result - all buttons are disabled
-
-    Polarion:
-        assignee: anikifor
-        casecomponent: Configuration
-        caseimportance: low
-        caseposneg: negative
-        initialEstimate: 1/2h
-    """
-    pass
-
-
 @pytest.mark.manual
 @pytest.mark.tier(2)
 def test_log_collection_via_ftp_over_ipv6():


### PR DESCRIPTION
## Purpose or Intent
Added 1 more check to cover `test_log_collect_all_zone_unconfigured` and `test_log_collect_current_zone_all_unconfigured`

### PRT Run

{{ pytest: -v cfme/tests/configure/test_log_depot_operation.py::test_collect_unconfigured  --long-running }}