### PR TITLE
[1LP][RFR] Workaround bz 1667064

### DIFF
--- a/cfme/intelligence/reports/__init__.py
+++ b/cfme/intelligence/reports/__init__.py
@@ -31,7 +31,7 @@ class CloudIntelReportsView(BaseLoggedInPage):
         return self.in_intel_reports and self.configuration.is_displayed
 
     def correct_tree_item_selected(self):
-        # The bug is currently targetted only to 5.10, but we have the
+        # The bug is currently targeted only to 5.10, but we have the
         # problem on 5.11 as well, so we probably need to use
         # forced_streams.
         if BZ(1667064, forced_streams=['5.11']).blocks:

--- a/cfme/intelligence/reports/__init__.py
+++ b/cfme/intelligence/reports/__init__.py
@@ -10,6 +10,7 @@ from cfme.base import Server
 from cfme.base.login import BaseLoggedInPage
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.blockers import BZ
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import MultiBoxSelect
 
@@ -28,6 +29,20 @@ class CloudIntelReportsView(BaseLoggedInPage):
     @property
     def is_displayed(self):
         return self.in_intel_reports and self.configuration.is_displayed
+
+    def correct_tree_item_selected(self):
+        # The bug is currently targetted only to 5.10, but we have the
+        # problem on 5.11 as well, so we probably need to use
+        # forced_streams.
+        if BZ(1667064, forced_streams=['5.11']).blocks:
+            return True
+
+        return self.dashboards.tree.currently_selected == [
+            "All Dashboards",
+            "All Groups",
+            self.context["object"].group,
+            self.context["object"].name
+        ]
 
     @View.nested
     class saved_reports(Accordion):  # noqa

--- a/cfme/intelligence/reports/dashboards.py
+++ b/cfme/intelligence/reports/dashboards.py
@@ -75,13 +75,7 @@ class EditDashboardView(DashboardFormCommon):
         return (
             self.in_intel_reports and
             self.title.text == 'Editing Dashboard "{}"'.format(self.context["object"].name) and
-            self.dashboards.is_opened and
-            self.dashboards.tree.currently_selected == [
-                "All Dashboards",
-                "All Groups",
-                self.context["object"].group,
-                self.context["object"].name
-            ]
+            self.dashboards.is_opened and self.correct_tree_item_selected()
         )
 
 
@@ -122,13 +116,7 @@ class DashboardDetailsView(CloudIntelReportsView):
                 self.context["object"].title,
                 self.context["object"].name
             ) and
-            self.dashboards.is_opened and
-            self.dashboards.tree.currently_selected == [
-                "All Dashboards",
-                "All Groups",
-                self.context["object"].group,
-                self.context["object"].name
-            ]
+            self.dashboards.is_opened and self.correct_tree_item_selected()
         )
 
 

--- a/cfme/intelligence/reports/widgets/__init__.py
+++ b/cfme/intelligence/reports/widgets/__init__.py
@@ -15,6 +15,7 @@ from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.blockers import BZ
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
 from cfme.utils.wait import wait_for
@@ -182,6 +183,19 @@ class DashboardWidgetsView(CloudIntelReportsView):
     def is_displayed(self):
         return self.in_dashboard_widgets
 
+    def correct_tree_menu_item_selected(self):
+        # The bug is currently targetted only to 5.10, but we have the
+        # problem on 5.11 as well, so we probably need to use
+        # forced_streams.
+        if BZ(1667064, forced_streams=['5.11']).blocks:
+            return True
+
+        return self.dashboard_widgets.tree.currently_selected == [
+            "All Widgets",
+            self.context["object"].TYPE,
+            self.context["object"].title
+        ]
+
 
 class AllDashboardWidgetsView(DashboardWidgetsView):
     title = Text("#explorer_title_text")
@@ -211,11 +225,7 @@ class DashboardWidgetDetailsView(DashboardWidgetsView):
             self.in_dashboard_widgets and
             self.title.text == '{} Widget "{}"'.format(
                 self.context["object"].TITLE, self.context["object"].title) and
-            self.dashboard_widgets.tree.currently_selected == [
-                "All Widgets",
-                self.context["object"].TYPE,
-                self.context["object"].title
-            ]
+            self.correct_tree_menu_item_selected()
         )
 
 
@@ -256,11 +266,7 @@ class BaseEditDashboardWidgetView(DashboardWidgetsView):
         return (
             self.in_dashboard_widgets and
             self.title.text == 'Editing Widget "{}"'.format(self.context["object"].title) and
-            self.dashboard_widgets.tree.currently_selected == [
-                "All Widgets",
-                self.context["object"].TYPE,
-                self.context["object"].title
-            ]
+            self.correct_tree_menu_item_selected()
         )
 
 

--- a/cfme/intelligence/reports/widgets/__init__.py
+++ b/cfme/intelligence/reports/widgets/__init__.py
@@ -184,7 +184,7 @@ class DashboardWidgetsView(CloudIntelReportsView):
         return self.in_dashboard_widgets
 
     def correct_tree_menu_item_selected(self):
-        # The bug is currently targetted only to 5.10, but we have the
+        # The bug is currently targeted only to 5.10, but we have the
         # problem on 5.11 as well, so we probably need to use
         # forced_streams.
         if BZ(1667064, forced_streams=['5.11']).blocks:

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -9,7 +9,6 @@ from cfme import test_requirements
 from cfme.intelligence.reports.schedules import ScheduleDetailsView
 from cfme.intelligence.reports.widgets import AllDashboardWidgetsView
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.path import data_path
 from cfme.utils.rest import assert_response
 from cfme.utils.update import update
@@ -135,7 +134,6 @@ def test_reports_schedule_crud(schedule_data, appliance, request):
 
 @pytest.mark.sauce
 @pytest.mark.tier(3)
-@pytest.mark.meta(blockers=[BZ(1667064)])
 def test_menuwidget_crud(appliance, request):
     """
     Bugzilla:
@@ -170,7 +168,6 @@ def test_menuwidget_crud(appliance, request):
 
 @pytest.mark.sauce
 @pytest.mark.tier(3)
-@pytest.mark.meta(blockers=[BZ(1667064)])
 def test_reportwidget_crud(appliance, request):
     """
     Bugzilla:
@@ -204,7 +201,6 @@ def test_reportwidget_crud(appliance, request):
 
 @pytest.mark.sauce
 @pytest.mark.tier(3)
-@pytest.mark.meta(blockers=[BZ(1653796), BZ(1667064)])
 def test_chartwidget_crud(appliance, request):
     """
     Polarion:
@@ -232,7 +228,7 @@ def test_chartwidget_crud(appliance, request):
 
 @pytest.mark.sauce
 @pytest.mark.tier(3)
-@pytest.mark.meta(blockers=[BZ(1653796), BZ(1667064)])
+@pytest.mark.ignore_stream("5.11", "upstream")  # BZ 1728328
 def test_rssfeedwidget_crud(appliance, request):
     """
     Polarion:
@@ -271,7 +267,6 @@ def test_rssfeedwidget_crud(appliance, request):
 @pytest.mark.rhel_testing
 @pytest.mark.sauce
 @pytest.mark.tier(3)
-@pytest.mark.meta(blockers=[BZ(1667064)])
 def test_dashboard_crud(appliance, request):
     """
     Polarion:


### PR DESCRIPTION
Make reports tests running.
    
There were some bugs regarding the report tests but they may be worked around and tests may start running.

 * Workaround BZ 1667064
 * remove blocker BZ 1653796 because it was resolved
 * remove test_rssfeedwidget_crud from CFME 5.11 runs as per BZ 1728328


Some examples are:
- {{pytest:  cfme/tests/intelligence/reports/test_crud.py -v}}
