### PR TITLE
[1LP][RFR] Fix test: test_date_filtering AND test_datetime_filtering

### DIFF
--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -487,7 +487,7 @@ def test_datetime_filtering(appliance, provider):
     collection.reload()
     vms_num = len(collection)
     assert vms_num > 3
-    baseline_vm = collection[vms_num / 2]
+    baseline_vm = collection[vms_num // 2]
     baseline_datetime = baseline_vm._data['created_on']  # YYYY-MM-DDTHH:MM:SSZ
 
     def _get_filtered_resources(operator):
@@ -527,7 +527,7 @@ def test_date_filtering(appliance, provider):
     collection.reload()
     vms_num = len(collection)
     assert vms_num > 3
-    baseline_vm = collection[vms_num / 2]
+    baseline_vm = collection[vms_num // 2]
     baseline_date, _ = baseline_vm._data['created_on'].split('T')  # YYYY-MM-DD
 
     def _get_filtered_resources(operator):


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ test_date_filtering AND test_datetime_filtering.

### PRT Run

{{ pytest: cfme/tests/test_rest.py -k "test_date_filtering or test_datetime_filtering" -vvv }}