### PR TITLE
[1LP][RFR] fix test_provision_vm_with_2_nics

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -423,6 +423,7 @@ def test_provision_vm_with_2_nics(provisioner, provisioning, prov_data, vm_name)
     """
     template_name = provisioning.get('template_2_nics', None)
     prov_data['catalog']['vm_name'] = vm_name
+    prov_data['network']['vlan'] = '<Use template nics>'
 
     vm = provisioner(template_name, prov_data)
 


### PR DESCRIPTION
Test was failing because the selected option overridden the template.

{{pytest: cfme/tests/infrastructure/test_provisioning_dialog.py::test_provision_vm_with_2_nics -v --long-running --use-provider complete }}