### PR TITLE
[RFR] Add support for 5.11's zip files for creating appliance on SCVMM

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2590,7 +2590,7 @@ class Appliance(IPAppliance):
                     return False
             vm_ip, _ = wait_for(is_ip_available,
                               delay=5,
-                              num_sec=600)
+                              num_sec=1200)
             app_kwargs['hostname'] = str(vm_ip)
 
         if isinstance(provider_mgmt, OpenShiftSystem):


### PR DESCRIPTION
CFME is now zipped for hyperv images in 5.11, here we are fixing our test case to deal with the zipped file. 

Depends on:
~~https://github.com/ManageIQ/wrapanapi/pull/411~~
~~https://github.com/ManageIQ/wrapanapi/pull/418~~
#9716 


{{ pytest: --use-provider scvmm --long-running cfme/tests/infrastructure/test_scvmm_specific.py::test_create_appliance_on_scvmm_using_the_vhd_image }}