### PR TITLE
[1LP][RFR]Automate test: test_edit_provider_request_task

### DIFF
--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -58,34 +58,6 @@ def test_automation_request_task():
 
 @pytest.mark.manual
 @test_requirements.rest
-def test_edit_provider_request_task():
-    """
-    Polarion:
-        assignee: pvala
-        caseimportance: medium
-        initialEstimate: 1/4h
-        casecomponent: Rest
-        testSteps:
-            1. Create a provision request.
-            2. Edit the provision request task:
-                POST /api/provision_requests/:id/request_tasks/:request_task_id
-                {
-                "action" : "edit",
-                "resource" : {
-                    "options" : {
-                    "request_param_a" : "value_a",
-                    "request_param_b" : "value_b"
-                    }
-                }
-        expectedResults:
-            1.
-            2. Task must be edited successfully.
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.rest
 def test_provider_specific_vm():
     """
     Polarion:


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__
    1. Automating manual test - `test_edit_provider_request_task`

### PRT Run

{{ pytest: cfme/tests/infrastructure/test_provisioning_rest.py -k "test_edit_provider_request_task" -vvv }}