### PR TITLE
[1LP][RFR]Add test coverage for reports BZ

### DIFF
--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -279,7 +279,7 @@ def test_created_on_time_report_field():
         setup:
             1. Add a provider and provision a VM
         testSteps:
-            1. Create a report with `Created on Time` field.
+            1. Create a report based on 'VMs and Instances' with [Created on Time, Name] field.
         expectedResults:
             1. `Created on Time` field column must not be empty for the recently created VM.
     """
@@ -353,14 +353,14 @@ def test_optimization_reports():
     Polarion:
         assignee: pvala
         casecomponent: Reporting
-        caseimportance: high
         initialEstimate: 1/2h
-        setup:
-            1. Navigate to Overview > Optimization.
+        startsin: 5.11
         testSteps:
-            1. Queue all the 7 parametrized reports and check if it exists.
+            1. Navigate to Overview > Optimization.
+            2. Queue all the 7 parametrized reports and check if it exists.
         expectedResults:
-            1. Reports must exist.
+            1.
+            2. Reports must exist.
     """
     pass
 
@@ -378,8 +378,9 @@ def test_reports_timelines_tab():
     Polarion:
         assignee: pvala
         casecomponent: Reporting
-        caseimportance: high
+        caseimportance: low
         initialEstimate: 1/2h
+        startsin: 5.11
         testSteps:
             1. Copy a report based on timeline and check if the Timelines tab is visible.
         expectedResults:

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -260,3 +260,129 @@ def test_reports_online_vms():
         1504010
     """
     pass
+
+
+@test_requirements.report
+@pytest.mark.manual
+@pytest.mark.tier(2)
+@pytest.mark.meta(coverage=[1743579])
+def test_created_on_time_report_field():
+    """
+    Bugzilla:
+        1743579
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup:
+            1. Add a provider and provision a VM
+        testSteps:
+            1. Create a report with `Created on Time` field.
+        expectedResults:
+            1. `Created on Time` field column must not be empty for the recently created VM.
+    """
+    pass
+
+
+@test_requirements.report
+@pytest.mark.manual
+@pytest.mark.tier(2)
+@pytest.mark.meta(coverage=[1741588])
+def test_case_insensitive_report_filtering():
+    """
+    Bugzilla:
+        1741588
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup:
+            1. Queue a report based on VMs and Instances(make sure it is not empty).
+            2. Filter the report with `VM Name` - case exactly matching the subject VM name
+                and note the result.
+            3. Filter the report with `VM Name` - case not matching the subject VM name
+                and note the result.
+        testSteps:
+            1. Compare both the results.
+        expectedResults:
+            1. Both the results must be same.
+    """
+    pass
+
+
+@test_requirements.report
+@pytest.mark.manual
+@pytest.mark.tier(2)
+@pytest.mark.meta(coverage=[1725142])
+def test_reports_service_unavailable():
+    """
+    Bugzilla:
+        1725142
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: medium
+        initialEstimate: 1/2h
+        setup:
+            1. Load customer database on the appliance.
+        testSteps:
+            1. Navigate to Reports.
+            2. Navigate to `Details` page of the report with >31k rows.
+        expectedResults:
+            1. Reports must be accessible, there should be no 503 service unavailable error.
+            2. Details page must be accessible.
+    """
+    pass
+
+
+@pytest.mark.ignore_stream("5.10")
+@test_requirements.report
+@pytest.mark.manual
+@pytest.mark.tier(2)
+@pytest.mark.meta(coverage=[1714197])
+def test_optimization_reports():
+    """
+    Bugzilla:
+        1714197
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: high
+        initialEstimate: 1/2h
+        setup:
+            1. Navigate to Overview > Optimization.
+        testSteps:
+            1. Queue all the 7 parametrized reports and check if it exists.
+        expectedResults:
+            1. Reports must exist.
+    """
+    pass
+
+
+@pytest.mark.ignore_stream("5.10")
+@test_requirements.report
+@pytest.mark.manual
+@pytest.mark.tier(2)
+@pytest.mark.meta(coverage=[1743651])
+def test_reports_timelines_tab():
+    """
+    Bugzilla:
+        1743651
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: high
+        initialEstimate: 1/2h
+        testSteps:
+            1. Copy a report based on timeline and check if the Timelines tab is visible.
+        expectedResults:
+            1. Timelines tab must not be visible.
+    """
+    pass


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. `test_created_on_time_report_field` for [BZ 1743579](https://bugzilla.redhat.com/show_bug.cgi?id=1743579).
    2. `test_case_insensitive_report_filtering` for [BZ 1741588](https://bugzilla.redhat.com/show_bug.cgi?id=1741588)
    3. `test_reports_service_unavailable` for [BZ 1725142](https://bugzilla.redhat.com/show_bug.cgi?id=1725142)
    4. `test_optimization_reports` for [BZ 1714197](https://bugzilla.redhat.com/show_bug.cgi?id=1714197)
    5. `test_reports_timelines_tab` for [BZ 1743651](https://bugzilla.redhat.com/show_bug.cgi?id=1743651)