### PR TITLE
[1LP][RFR] Add `wait_for_power_state_change_rest` to BaseVM

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -253,9 +253,6 @@ class Instance(VM):
             navigate_to(self, 'Details')
             return True
 
-    def get_collection_via_rest(self):
-        return self.appliance.rest_api.collections.instances
-
     def wait_for_instance_state_change(self, desired_state, timeout=900):
         """Wait for an instance to come to desired state.
 

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -253,15 +253,6 @@ class Instance(VM):
             navigate_to(self, 'Details')
             return True
 
-    def get_vm_via_rest(self):
-        # Try except block, because instances collection isn't available on 5.4
-        try:
-            instance = self.appliance.rest_api.collections.instances.get(name=self.name)
-        except AttributeError:
-            raise Exception("Collection instances isn't available")
-        else:
-            return instance
-
     def get_collection_via_rest(self):
         return self.appliance.rest_api.collections.instances
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -506,7 +506,7 @@ class BaseVM(
             & Q("ems_id", "=", self.provider.rest_api_entity.id)
         ).resources[0]
 
-    def wait_for_power_state_change_rest(self, desired_state, timeout=1200):
+    def wait_for_power_state_change_rest(self, desired_state, timeout=1200, delay=45):
         """Wait for a VM/Instance power state to change to a desired state.
 
         Args:
@@ -517,7 +517,7 @@ class BaseVM(
             lambda: self.rest_api_entity.power_state == desired_state,
             fail_func=self.rest_api_entity.reload,
             num_sec=timeout,
-            delay=45,
+            delay=delay,
             handle_exception=True,
             message=f"Waiting for VM/Instance power state to change to {desired_state}"
         ).out

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -938,9 +938,6 @@ class InfraVm(VM):
     def genealogy(self):
         return Genealogy(self)
 
-    def get_collection_via_rest(self):
-        return self.appliance.rest_api.collections.vms
-
     @property
     def cluster_id(self):
         """returns id of cluster current vm belongs to"""

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -938,17 +938,13 @@ class InfraVm(VM):
     def genealogy(self):
         return Genealogy(self)
 
-    def get_vm_via_rest(self):
-        return self.appliance.rest_api.collections.vms.get(name=self.name)
-
     def get_collection_via_rest(self):
         return self.appliance.rest_api.collections.vms
 
     @property
     def cluster_id(self):
         """returns id of cluster current vm belongs to"""
-        vm = self.get_vm_via_rest()
-        return int(vm.ems_cluster_id)
+        return int(self.rest_api_entity.ems_cluster_id)
 
     @attr.s
     class CfmeRelationship(object):

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -73,7 +73,7 @@ def control_policy(appliance, new_instance):
 
 @pytest.fixture(scope='function')
 def azone(new_instance, appliance):
-    zone_id = new_instance.get_vm_via_rest().availability_zone_id
+    zone_id = new_instance.rest_api_entity.availability_zone_id
     rest_zones = new_instance.appliance.rest_api.collections.availability_zones
     zone_name = next(zone.name for zone in rest_zones if zone.id == zone_id)
     inst_zone = appliance.collections.cloud_av_zones.instantiate(name=zone_name,

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -95,7 +95,7 @@ def wait_for_ui_state_refresh(instance, provider, state_change_time, timeout=900
 
 def wait_for_pwr_state_change(instance, state_change_time, timeout=720):
     def _wait_for():
-        vm = instance.get_vm_via_rest()
+        vm = instance.rest_api_entity
         if vm.state_changed_on != state_change_time:
             return True
 
@@ -557,7 +557,7 @@ class TestInstanceRESTAPI(object):
             initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
-        vm = testing_instance.get_vm_via_rest()
+        vm = testing_instance.rest_api_entity
         if from_detail:
             vm.action.stop()
         else:
@@ -581,7 +581,7 @@ class TestInstanceRESTAPI(object):
         """
         testing_instance.wait_for_instance_state_change(
             desired_state=testing_instance.STATE_OFF, timeout=1200)
-        vm = testing_instance.get_vm_via_rest()
+        vm = testing_instance.rest_api_entity
         if from_detail:
             vm.action.start()
         else:
@@ -604,7 +604,7 @@ class TestInstanceRESTAPI(object):
             initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
-        vm = testing_instance.get_vm_via_rest()
+        vm = testing_instance.rest_api_entity
         state_change_time = vm.state_changed_on
         if from_detail:
             vm.action.reboot_guest()
@@ -616,7 +616,7 @@ class TestInstanceRESTAPI(object):
         # We may also miss a quick reboot during the wait_for.
         # Just check for when the state last changed
         wait_for_pwr_state_change(testing_instance, state_change_time)
-        state_change_time = testing_instance.get_vm_via_rest().state_changed_on
+        state_change_time = testing_instance.rest_api_entity.state_changed_on
         # If the VM is not on after this state change, wait for another
         if vm.power_state != testing_instance.STATE_ON:
             wait_for_pwr_state_change(testing_instance, state_change_time)
@@ -639,7 +639,7 @@ class TestInstanceRESTAPI(object):
             initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
-        vm = testing_instance.get_vm_via_rest()
+        vm = testing_instance.rest_api_entity
         if from_detail:
             vm.action.reset()
         else:
@@ -666,7 +666,7 @@ class TestInstanceRESTAPI(object):
             initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
-        vm = testing_instance.get_vm_via_rest()
+        vm = testing_instance.rest_api_entity
 
         if from_detail:
             vm.action.suspend()
@@ -699,7 +699,7 @@ class TestInstanceRESTAPI(object):
             initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
-        vm = testing_instance.get_vm_via_rest()
+        vm = testing_instance.rest_api_entity
 
         if from_detail:
             vm.action.pause()
@@ -730,7 +730,7 @@ class TestInstanceRESTAPI(object):
             initialEstimate: 1/4h
         """
         testing_instance.wait_for_instance_state_change(desired_state=testing_instance.STATE_ON)
-        vm = testing_instance.get_vm_via_rest()
+        vm = testing_instance.rest_api_entity
         if from_detail:
             vm.action.terminate()
         else:

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -37,18 +37,11 @@ def vm_obj(provider, setup_provider, small_template, vm_name):
 
 
 def wait_for_vm_state_change(vm_obj, state):
-    vm = vm_obj.rest_api_entity
     if vm_obj.provider.one_of(GCEProvider, EC2Provider, SCVMMProvider):
         num_sec = 4000  # extra time for slow providers
     else:
         num_sec = 1200
-
-    def _state_changed():
-        vm.reload()
-        return vm.power_state == state
-    wait_for(_state_changed, num_sec=num_sec, delay=45, silent_failure=True,
-        message="Wait for VM state `{}` (current state: {})".format(state, vm.power_state),
-        fail_func=vm_obj.refresh_relationships)
+    vm_obj.wait_for_power_state_change_rest(desired_state=state, timeout=num_sec)
 
 
 def verify_vm_power_state(vm, state):

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -37,7 +37,7 @@ def vm_obj(provider, setup_provider, small_template, vm_name):
 
 
 def wait_for_vm_state_change(vm_obj, state):
-    vm = vm_obj.get_vm_via_rest()
+    vm = vm_obj.rest_api_entity
     if vm_obj.provider.one_of(GCEProvider, EC2Provider, SCVMMProvider):
         num_sec = 4000  # extra time for slow providers
     else:


### PR DESCRIPTION
## Purpose or Intent

- __Enhancement__
    1. Add `rest_api_entity` property to `BaseVM` which returns a VM/Instance's REST entity based on the VM/Instance name and provider.
    2. Add `wait_for_power_state_change_rest` method to `BaseVM` which waits until the VM/Instance reaches the desired state.
    3. Remove `get_vm_via_rest` since we now have `rest_api_entity`.
    4. Remove `get_collection_via_rest` since it's not used anywhere.

- __Updating tests__ 
    1. `cloud/test_cloud_timelines.py`, `cloud/test_instance_power_control.py`, `cloud_infra_common/test_power_control_rest.py`to use `rest_api_entity` instead of `get_vm_via_rest`.
    2. `cloud_infra_common/test_power_control_rest.py`  to use `wait_for_power_state_change_rest`.

### PRT Run

{{ pytest: cfme/tests/cloud/test_instance_power_control.py cfme/tests/cloud_infra_common/test_power_control_rest.py --long-running -vvvv }}