### PR TITLE
[1LP][RFR] Fixed instace type issue of rhos provider

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -933,7 +933,7 @@ def test_retire_vm_automate():
 
 @pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1672007])
-def test_invoke_custom_automation():
+def test_action_invoke_custom_automation():
     """
     Bugzilla:
         1672007

--- a/cfme/tests/cloud/test_quota_tagging.py
+++ b/cfme/tests/cloud/test_quota_tagging.py
@@ -130,21 +130,14 @@ def entities(appliance, request, max_quota_test_instance):
 
 @pytest.fixture(scope='function')
 def set_entity_quota_tag(request, entities, appliance):
-    tag_name, value = request.param
+    tag, value = request.param
     tag = appliance.collections.categories.instantiate(
-        display_name=tag_name).collections.tags.instantiate(
+        display_name=tag).collections.tags.instantiate(
         display_name=value)
     entities.add_tag(tag)
     yield
     # will refresh page as navigation to configuration is blocked if alert are on requests page
     appliance.server.browser.refresh()
-    # Tag assignment for groups and users is changed in 5.11. Now entities.remove_tag(tag) doesn't
-    # work because of change in title of assigned tags. Hence I updated tag instantiation with
-    # tag_name only as per title.
-    if appliance.version > '5.11':
-        tag = appliance.collections.categories.instantiate(
-            display_name=tag_name.strip(' *')).collections.tags.instantiate(
-            display_name=tag_name.strip(' *'))
     entities.remove_tag(tag)
 
 


### PR DESCRIPTION
## Purpose or Intent
-  Instance type ```m1.large``` is not available. Hence checking with existing type -  ```m1.small```
### PRT Run
{{ pytest: cfme/tests/cloud/test_quota_tagging.py --long-running --use-template-cache -qsvvv --use-provider=rhos13 }}