### PR TITLE
[WIPTEST] Revert pytest-polarion-collect update, parallelizer broken

### DIFF
--- a/cfme/fixtures/parallelizer/remote.py
+++ b/cfme/fixtures/parallelizer/remote.py
@@ -121,6 +121,7 @@ class SlaveManager(object):
 
         """
         self.log.info("entering runtest loop")
+
         for item, nextitem in self._test_generator():
             if self.config.option.collectonly:
                 self.message('{}'.format(item.nodeid))
@@ -145,7 +146,10 @@ class SlaveManager(object):
 
     def _test_generator(self):
         node_iter = self._iter_nodes()
-        run_node = next(node_iter)
+        try:
+            run_node = next(node_iter)
+        except StopIteration:
+            return []
 
         for next_node in node_iter:
             yield run_node, next_node

--- a/cfme/utils/providers.py
+++ b/cfme/utils/providers.py
@@ -145,10 +145,10 @@ class ProviderFilter(object):
             allowed_flags = set(defined_flags) - set(excluded_flags)
 
             if set(test_flags) - allowed_flags:
-                logger.info("Filtering Provider %s out because it does not have the right flags, "
-                            "%s does not contain %s",
-                            provider.name, list(allowed_flags),
-                            list(set(test_flags) - allowed_flags))
+                logger.debug("Filtering Provider %s out because it does not have the right flags, "
+                             "%s does not contain %s",
+                             provider.name, list(allowed_flags),
+                             list(set(test_flags) - allowed_flags))
                 return False
         return True
 

--- a/requirements/frozen.py3.txt
+++ b/requirements/frozen.py3.txt
@@ -243,8 +243,8 @@ pyparsing==2.4.0
 pyperclip==1.7.0
 pytesseract==0.2.6
 pytest==3.4.1
-pytest-polarion-collect==0.19
-pytest-report-parameters==0.4.0
+pytest-polarion-collect==0.17.1
+#pytest-report-parameters==0.4.0
 python-box==3.2.4
 python-bugzilla==2.3.0
 python-cinderclient==4.1.0

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -239,8 +239,8 @@ pyparsing==2.4.0
 pyperclip==1.7.0
 pytesseract==0.2.6
 pytest==3.4.1
-pytest-polarion-collect==0.19
-pytest-report-parameters==0.4
+pytest-polarion-collect==0.17.1
+#pytest-report-parameters==0.4
 python-box==3.2.4
 python-bugzilla==2.2.0
 python-cinderclient==4.1.0


### PR DESCRIPTION
Collection in parallelizer remote slaves included manual tests
debug showing all options still passed, but update to pytest-polarion-collect 0.18 breaks collection with manual tests included

Not sure why the addition of a hookspec by pytest-polarion-collect is changing the markers in slave python processes