### PR TITLE
[1LP][WIP] Test Ansible Tower job status

### DIFF
--- a/cfme/ansible_tower/jobs.py
+++ b/cfme/ansible_tower/jobs.py
@@ -90,7 +90,7 @@ class TowerJob(BaseEntity):
         view.flash.assert_no_error()
 
     def is_job_successful(self):
-        return True if self.status == "successful" else False
+        return self.status == "successful"
 
     def wait_for_completion(self, num_sec=1200, delay=10):
         def last_status():

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -139,7 +139,10 @@ def test_check_tower_job_status(appliance, catalog_item, request, config_manager
         caseimportance: medium
         initialEstimate: 1/4h
     """
-    template = config_manager_obj.yaml_data['provisioning_data'][job_type]
+    try:
+        template = config_manager_obj.yaml_data['provisioning_data'][job_type]
+    except KeyError:
+        pytest.skip("No Ansible job template was found in the yaml file.")
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', catalog_item.name)
@@ -152,5 +155,4 @@ def test_check_tower_job_status(appliance, catalog_item, request, config_manager
     tower_job = appliance.collections.ansible_tower_jobs.instantiate(template_name=template)
     request.addfinalizer(tower_job.delete_if_exists)
     tower_job.wait_for_completion()
-    msg = "Ansible Tower Job failed"
-    assert tower_job.is_job_successful(), msg
+    assert tower_job.is_job_successful(), 'Ansible Tower Job failed'


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
1)Updated TowerJobs and TowerJobsCollection on the Tower Jobs page .
2)Added a test to check the status of Tower Jobs

### PRT Run
{{py.test: cfme/tests/services/test_config_provider_servicecatalogs.py -k "status"}}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
PRT results:
510 - PASS
511 - PASS