### PR TITLE
[1LP][RFR] Test to create service dialog using Tower Workflow

### DIFF
--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -193,8 +193,9 @@ class AnsibleTowerJobTemplatesCollection(BaseCollection, TaggableCollection):
         """Return entities for all items in Ansible Job templates collection"""
         view = navigate_to(self, "All")
         job_type = self.filters.get('job_type')
-        all_jobs = [self.instantiate(name=e.name,
-            job_type=e.data["type"]) for e in view.entities.get_all()]
+        all_jobs = [
+            self.instantiate(name=e.name, job_type=e.data["type"]) for e in view.entities.get_all()
+        ]
         return [j for j in all_jobs if j.job_type == job_type] if job_type else all_jobs
 
 

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -127,8 +127,10 @@ class TowerExplorerJobTemplateDetailsView(TowerExplorerView):
     def is_displayed(self):
         return (
             self.in_tower_explorer
-            and self.title.text
-            == 'Job Template (Ansible Tower) "{}"'.format(self.context["object"].name)
+            and self.title.text in {
+                'Job Template (Ansible Tower) "{}"'.format(self.context["object"].name),
+                'Workflow Template (Ansible Tower) "{}"'.format(self.context["object"].name)
+            }
             and self.sidebar.job_templates.is_opened
         )
 
@@ -171,6 +173,7 @@ class AnsibleTowerSystemsCollection(BaseCollection):
 @attr.s
 class AnsibleTowerJobTemplate(BaseEntity, Taggable):
     name = attr.ib()
+    job_type = attr.ib(None)
 
     def create_service_dailog(self, name):
         view = navigate_to(self, "CreateServiceDialog")
@@ -189,10 +192,10 @@ class AnsibleTowerJobTemplatesCollection(BaseCollection, TaggableCollection):
     def all(self):
         """Return entities for all items in Ansible Job templates collection"""
         view = navigate_to(self, "All")
-        for row in view.entities.elements:
-            if 'Job Template' in row.type.text:
-                return self.instantiate(template_name=row.name.text)
-        # return [self.instantiate(e) for e in view.entities.all_entity_names]
+        job_type = self.filters.get('job_type')
+        all_jobs = [self.instantiate(name=e.name,
+            job_type=e.data["type"]) for e in view.entities.get_all()]
+        return [j for j in all_jobs if j.job_type == job_type] if job_type else all_jobs
 
 
 @navigator.register(Server, "AnsibleTowerExplorer")

--- a/cfme/ansible_tower/explorer.py
+++ b/cfme/ansible_tower/explorer.py
@@ -189,7 +189,10 @@ class AnsibleTowerJobTemplatesCollection(BaseCollection, TaggableCollection):
     def all(self):
         """Return entities for all items in Ansible Job templates collection"""
         view = navigate_to(self, "All")
-        return [self.instantiate(e) for e in view.entities.all_entity_names]
+        for row in view.entities.elements:
+            if 'Job Template' in row.type.text:
+                return self.instantiate(template_name=row.name.text)
+        # return [self.instantiate(e) for e in view.entities.all_entity_names]
 
 
 @navigator.register(Server, "AnsibleTowerExplorer")

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -160,7 +160,11 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag):
 
 @pytest.mark.tier(3)
 @pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type != "Ansible Tower")
-def test_ansible_tower_service_dialog_creation_from_template(request, config_manager, appliance):
+@pytest.mark.parametrize('template_type', ['Job Template (Ansible Tower)',
+    'Workflow Template (Ansible Tower)'], ids=['job', 'workflow'],
+    scope='module')
+def test_ansible_tower_service_dialog_creation_from_template(request, config_manager, appliance,
+        template_type):
     """
     Polarion:
         assignee: nachandr
@@ -170,7 +174,8 @@ def test_ansible_tower_service_dialog_creation_from_template(request, config_man
 
     """
     try:
-        job_template = config_manager.appliance.collections.ansible_tower_job_templates.all()[0]
+        job_template = config_manager.appliance.collections.ansible_tower_job_templates.filter(
+            {"job_type": template_type}).all()[0]
     except IndexError:
         pytest.skip("No job template was found")
     dialog_label = fauxfactory.gen_alpha(8)

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -11,6 +11,11 @@ from cfme.utils.update import update
 pytest_generate_tests = generate(gen_func=config_managers)
 pytestmark = [pytest.mark.meta(blockers=[1491704])]
 
+TEMPLATE_TYPE = {
+    "job": "Job Template (Ansible Tower)",
+    "workflow": "Workflow Template (Ansible Tower)",
+}
+
 
 @pytest.fixture
 def config_manager(config_manager_obj):
@@ -160,9 +165,7 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag):
 
 @pytest.mark.tier(3)
 @pytest.mark.uncollectif(lambda config_manager_obj: config_manager_obj.type != "Ansible Tower")
-@pytest.mark.parametrize('template_type', ['Job Template (Ansible Tower)',
-    'Workflow Template (Ansible Tower)'], ids=['job', 'workflow'],
-    scope='module')
+@pytest.mark.parametrize('template_type', TEMPLATE_TYPE.values(), ids=list(TEMPLATE_TYPE.keys()))
 def test_ansible_tower_service_dialog_creation_from_template(request, config_manager, appliance,
         template_type):
     """


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
1.Updated AnsibleTowerJobTemplatesCollection so that it can be filtered on Ansible job type.
2.Updated TowerExplorerJobTemplateDetailsView to cover workflow template details page as well.
3.Added test to create service dialog using Tower Workflow

### PRT Run
{{py.test: cfme/tests/infrastructure/test_config_management.py -k "dialog"}}

### PRT Results:
All tests except for the test_config_system_tag[satellite_62]  test passed on both 510 and 511. The failure is not related to the code changes made through this PR.
