### PR TITLE
[1LP][RFR] Increase timeout for creating the db

### DIFF
--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -181,7 +181,7 @@ def test_cpu_total(appliance):
     assert int(result.output) >= 4
 
 
-@pytest.mark.meta(blockers=[BZ(1712929, forced_streams=['5.11'])])  # against RHEL
+@pytest.mark.meta(blockers=[BZ(1712929, forced_streams=['5.10', '5.11'])])  # against RHEL
 @pytest.mark.ignore_stream("upstream")
 def test_certificates_present(appliance, soft_assert):
     """Test whether the required product certificates are present.

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -121,7 +121,7 @@ def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
         assert result.success, "Couldn't start evmserverd: {}".format(result.output)
     app.wait_for_web_ui(timeout=600)
     app.db.reset_user_pass()
-    wait_for(lambda: navigate_to(app.server, 'LoginScreen'), handle_exception=True)
+    wait_for(navigate_to, (app.server, 'LoginScreen'), handle_exception=True, timeout='5m')
     app.server.login(app.user)
 
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -233,7 +233,7 @@ class ApplianceConsoleCli(object):
         self._run("--region {region} --internal --hostname {dbhostname} --username {username}"
             " --password {password} --dbname {dbname} --verbose --dbdisk {dbdisk}".format(
                 region=region, dbhostname=dbhostname, username=username, password=password,
-                dbname=dbname, dbdisk=dbdisk), timeout=4 * 60)
+                dbname=dbname, dbdisk=dbdisk), timeout=5 * 60)
 
     def configure_appliance_internal_fetch_key(self, region, dbhostname,
             username, password, dbname, dbdisk, fetch_key, sshlogin, sshpass):

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -232,7 +232,7 @@ class SSHClient(paramiko.SSHClient):
 
         if not self.connected:
             self._connect_kwargs.update(kwargs)
-            wait_for(self._check_port, timeout='2m', delay=5)
+            wait_for(self._check_port, handle_exception=True, timeout='2m', delay=5)
             try:
                 conn = super(SSHClient, self).connect(**self._connect_kwargs)
             except paramiko.ssh_exception.BadHostKeyException:


### PR DESCRIPTION
It seems that creating the db takes ~4 minutes to complete. It seems
that when our systems are more loaded, we are getting slightly over
4 minutes and many migration tests fail.

I tested
```
time appliance_conosle_cli --region {region} --internal \
                      --hostname localhost \
                      --username {username} --password {password} \
                      --dbname {dbname} --verbose --dbdisk {dbdisk}
```
with some configurations with these results:
```
	       CFME version
region	5.11.0.23 	5.11.0.24
---------------------------------
0	3m53.328s	4m16.664s
50	3m58.793s	3m40.494s
99	4m16.768s	3m49.669s
```

To make the test passing I also had to:
1) handle the exception risen from the connection checking code that happened when the machine was till refusing the connection attempts as there was no service listening yet.

1) increase timeout for waiting for LoginPage from default value of 120s.

    The failed tests on PRT seem to be failed because of sprout issues like for example destroyed modscope-fixture created VM.

1) add 5.10 to ignore streams to make smoke tests pass.

{{pytest: cfme/tests/test_db_migrate.py -v}}