### PR TITLE
[1LP][RFR]Set flag in advanced setting

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -48,7 +48,8 @@ def start_event_workers_for_osp(appliance, provider):
     provider_edit_view.save.click()
     # Test if workers are enabled and running
     worker_status = appliance.ssh_client.run_rake_command(
-        "evm:status | grep 'Openstack::Cloud::EventCatcher'").success
+        "evm:status | grep 'Openstack::Cloud::EventCatcher'")
+    assert "started" in worker_status.output
     if not worker_status:
         pytest.skip("Openstack Eventcatcher workers are not running")
 

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -18,6 +18,7 @@ from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
+from cfme.utils.blockers import BZ
 
 pytestmark = [
     test_requirements.v2v,
@@ -38,6 +39,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.meta(blockers=[BZ(1751900, forced_streams=['5.10'])])
 @pytest.mark.parametrize(
     "mapping_data_vm_obj_single_datastore",
     [

--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -16,7 +16,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for

--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -16,6 +16,7 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for


### PR DESCRIPTION
{{ pytest: cfme/tests/v2v/test_v2v_migrations.py --use-provider rhv43 --use-provider vsphere67-ims --provider-limit 2 -vvvv --long-running -k test_single_datastore_single_vm_migration[rhevm-4.3-virtualcenter-6.7-mapping_data_vm_obj_single_datastore0]}}

Added a method to set a flag in advanced setting for OSP required for V2V testing .
Tested this fixture locally . Flag is set to true.

Also added a method to start event catchers as a workaround.