### PR TITLE
[1LP][RFR] fix locator for Catalog Multibox widget

### DIFF
--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -2,6 +2,8 @@ import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
 from widgetastic.utils import Parameter
+from widgetastic.utils import ParametrizedLocator
+from widgetastic.widget import Select
 from widgetastic.widget import Text
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
@@ -19,6 +21,12 @@ from widgetastic_manageiq import MultiBoxSelect
 
 
 class CatalogsMultiBoxSelect(MultiBoxSelect):
+    available_options = Select(
+        locator=ParametrizedLocator(".//div[contains(text(), {@available_items|quote})]/select")
+    )
+    chosen_options = Select(
+        locator=ParametrizedLocator(".//div[contains(text(), {@chosen_items|quote})]/select")
+    )
     move_into_button = Button(title=Parameter("@move_into"))
     move_from_button = Button(title=Parameter("@move_from"))
 
@@ -31,8 +39,8 @@ class CatalogForm(ServicesCatalogView):
     assign_catalog_items = CatalogsMultiBoxSelect(
         move_into="Move Selected buttons right",
         move_from="Move Selected buttons left",
-        available_items="available_fields",
-        chosen_items="selected_fields"
+        available_items="Unassigned",
+        chosen_items="Selected"
     )
 
     save_button = Button('Save')


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>
Co-authored-by: Satyajit Bulage <sbulage@redhat.com>

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- 22 test are failing due to this locator changes with error `Could not find an element './/select[@id="selected_fields"]'`

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
trying to cover some tests

{{pytest: cfme/tests/ -k "test_service_catalog_crud_ui or test_service_ansible_verbosity or test_embed_tower_exec_play_against or test_service_ansible_playbook_order_credentials or test_service_ansible_playbook_order_retire or test_service_ansible_playbook_pass_extra_varstest_service_ansible_playbook_pass_extra_vars or test_service_ansible_execution_ttltest_service_ansible_execution_ttl or test_custom_button_ansible_credential_list" --long-running -sqv}}

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
