### PR TITLE
[1LP][RFR] Fix TypeError and is_displayed Containers in 5.11

### DIFF
--- a/cfme/containers/container.py
+++ b/cfme/containers/container.py
@@ -17,6 +17,8 @@ from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.providers import get_crud_by_name
+from cfme.utils.version import LOWEST
+from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import Table
@@ -42,7 +44,9 @@ class ContainerAllView(ContainerView):
 
     @View.nested
     class Filters(Accordion):  # noqa
-        ACCORDION_NAME = "Filters"
+        ACCORDION_NAME = VersionPicker({
+            LOWEST: "Filters",
+            '5.11': "Global Filters"})
 
         @View.nested
         class Navigation(VerticalNavigation):

--- a/cfme/tests/containers/test_search_bar.py
+++ b/cfme/tests/containers/test_search_bar.py
@@ -46,7 +46,7 @@ def test_search_bar(provider, appliance, soft_assert):
             '***': None,
             exist_member_str: exist_member_str,
             '$$$': None,
-            exist_member_str[:len(exist_member_str) / 2]: exist_member_str
+            exist_member_str[:len(exist_member_str) // 2]: exist_member_str
         }
 
         try:


### PR DESCRIPTION
Fixes:

```
TypeError
b'slice indices must be integers or None or have an __index__ method'
```

{{ pytest: cfme/tests/containers/test_search_bar.py  --use-provider ocp-39-hawk }}