### PR TITLE
[WIP] Fix ServerDetails and CustomLogos navigation exceptions

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -583,12 +583,6 @@ class ServerDetails(CFMENavigateStep):
     VIEW = ServerInformationView
     prerequisite = NavigateToSibling('Details')
 
-    def am_i_here(self):
-        return (
-            self.view.is_displayed and
-            self.view.server.is_active
-        )
-
     def step(self, *args, **kwargs):
         self.prerequisite_view.server.select()
 
@@ -623,8 +617,8 @@ class CustomLogos(CFMENavigateStep):
 
     def am_i_here(self):
         return (
-            self.view.is_displayed and self.view.custom_logos.is_displayed and
-            self.view.custom_logos.is_active())
+            self.view.is_displayed and self.view.customlogos.is_displayed and
+            self.view.customlogos.is_active())
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.customlogos.select()


### PR DESCRIPTION
Navigation to the Server/Server (ServerDetails class) and Server/CustomLogos (CustomLogos class) destinations logs exceptions when running the associated am_i_here() methods. The navigation eventually succeeds, because it falls back to their associated prerequisites:

****
2019-08-21 12:39:08,103 [I] [cfme] ------------------ test_server_roles_changing[default_candu] ------------------- (cfme/fixtures/log.py:27)
2019-08-21 12:39:08,436 [I] [cfme] [UI-NAV/Server/Server]: Beginning Navigation... (cfme/utils/appliance/implementations/ui.py:527)
2019-08-21 12:39:08,818 [E] [cfme] [UI-NAV/Server/Server]: Exception raised ['ServerInformationView' object has no attribute 'server'] whilst checking if already here (cfme/utils/appliance/implementations/ui.py:527)
2019-08-21 12:39:08,818 [I] [cfme] [UI-NAV/Server/Details]: Beginning Navigation... (cfme/utils/appliance/implementations/ui.py:527)
2019-08-21 12:39:15,149 [I] [cfme] [UI-NAV/Server/Details]: Already Here/Resetter Used/View Returned/Waited on View/Navigation Not Forced (elapsed 3385ms) (cfme/utils/appliance/implementations/ui.py:527)
2019-08-21 12:39:15,641 [I] [cfme] [UI-NAV/Server/Server]: Needed Navigation/Resetter Used/View Returned/Waited on View/Navigation Not Forced (elapsed 7107ms) (cfme/utils/appliance/implementations/ui.py:527)
****
****
2019-08-21 12:31:10,195 [I] [cfme] --------------- test_paginator_config_pages[servers_customlogos] --------------- (cfme/fixtures/log.py:27)
2019-08-21 12:31:10,493 [I] [cfme] [UI-NAV/Server/CustomLogos]: Beginning Navigation... (cfme/utils/appliance/implementations/ui.py:527)
2019-08-21 12:31:13,960 [E] [cfme] [UI-NAV/Server/CustomLogos]: Exception raised ['ServerView' object has no attribute 'custom_logos'] whilst checking if already here (cfme/utils/appliance/implementations/ui.py:527)
2019-08-21 12:31:13,960 [I] [cfme] [UI-NAV/Server/Details]: Beginning Navigation... (cfme/utils/appliance/implementations/ui.py:527)
2019-08-21 12:31:20,580 [I] [cfme] [UI-NAV/Server/Details]: Already Here/Resetter Used/View Returned/Waited on View/Navigation Not Forced (elapsed 3632ms) (cfme/utils/appliance/implementations/ui.py:527)
2019-08-21 12:31:21,031 [I] [cfme] [ServerView/customlogos]: opened the tab Custom Logos (.cfme_venv/lib64/python3.7/site-packages/widgetastic_patternfly/__init__.py:764)
2019-08-21 12:31:24,311 [I] [cfme] [UI-NAV/Server/CustomLogos]: Needed Navigation/Resetter Used/View Returned/Waited on View/Navigation Not Forced (elapsed 10933ms) (cfme/utils/appliance/implementations/ui.py:527)
****
This PR fixes those two classes:

1.) ServerDetails.am_i_here() makes an invalid reference to self.view.server:

    def am_i_here(self):
        return (
            self.view.is_displayed and
            self.view.server.is_active
        )

. ServerInformationView has no nested 'server' class. Because the only other statement is self.view.is_displayed, which is the default behavior if am_i_here is absent, I've removed this method altogether.

2.) CustomLogos.am_i_here() references self.view.custom_logos instead of self.view.customlogos.

{{ pytest: cfme/tests/configure/test_paginator.py::test_paginator_config_pages[servers_customlogos] 
cfme/tests/configure/test_ntp_server.py::test_clear_ntp_settings -v }}