### PR TITLE
[1LP][RFR] fixed collection for service multi-region tests

### DIFF
--- a/cfme/tests/cloud_infra_common/test_power_control_manual.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_manual.py
@@ -249,7 +249,6 @@ def test_power_operations_from_global_region(provider, context):
         startsin: 5.6
         casecomponent: Control
         tags: power
-        title:test power operations from global region
         testSteps:
             1. Take two or more appliances
             2. Configure DB manually

--- a/cfme/tests/pod/test_appliance_crud.py
+++ b/cfme/tests/pod/test_appliance_crud.py
@@ -191,7 +191,7 @@ def temp_pod_appliance(appliance, provider, appliance_data, pytestconfig):
             provider_type='openshift',
             provider=provider.key,
             template_type='openshift_pod',
-            wait_time='1800'
+            wait_time=1800
     ) as appliances:
         with appliances[0] as appliance:
             appliance.openshift_creds = appliance_data['openshift_creds']

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -7,8 +7,6 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.services.workloads import VmsInstances
-from cfme.utils.appliance import ViaREST
-from cfme.utils.appliance import ViaUI
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.rest import assert_response
@@ -545,24 +543,5 @@ def test_generic_object_details_displayed_from_a_service_do_not_include_associat
         tags: service
     Bugzilla:
         1576828
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-@test_requirements.multi_region
-@test_requirements.service
-@pytest.mark.parametrize('context', [ViaREST, ViaUI])
-@pytest.mark.parametrize('catalog_location', ['global', 'remote'])
-@pytest.mark.parametrize('item_type', ['AMAZON', 'ANSIBLE', 'TOWER', 'AZURE', 'GENERIC',
-                                       'OPENSTACK', 'ORCHESTRATION', 'RHV', 'SCVMM', 'VMWARE'])
-def test_service_provision_retire_from_global_region(item_type, catalog_location, context):
-    """
-    Polarion:
-        assignee: izapolsk
-        caseimportance: high
-        casecomponent: Services
-        initialEstimate: 1/3h
     """
     pass

--- a/cfme/tests/services/test_service_catalogs_multi_region.py
+++ b/cfme/tests/services/test_service_catalogs_multi_region.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+from cfme import test_requirements
+from cfme.utils.appliance import ViaREST
+from cfme.utils.appliance import ViaUI
+
+
+pytestmark = [
+    pytest.mark.meta(server_roles="+automate"),
+    pytest.mark.long_running,
+]
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+@test_requirements.multi_region
+@test_requirements.service
+@pytest.mark.parametrize('context', [ViaREST, ViaUI])
+@pytest.mark.parametrize('catalog_location', ['global', 'remote'])
+@pytest.mark.parametrize('item_type', ['AMAZON', 'ANSIBLE', 'TOWER', 'AZURE', 'GENERIC',
+                                       'OPENSTACK', 'ORCHESTRATION', 'RHV', 'SCVMM', 'VMWARE',
+                                       'BUNDLE'])
+@pytest.mark.uncollectif(lambda catalog_location: catalog_location == 'global',
+                         reason="isn't supported yet")
+def test_service_provision_retire_from_global_region(item_type, catalog_location, context):
+    """
+    Polarion:
+        assignee: izapolsk
+        caseimportance: high
+        casecomponent: Services
+        initialEstimate: 1/3h
+    """
+    pass

--- a/cfme/tests/services/test_service_catalogs_multi_region.py
+++ b/cfme/tests/services/test_service_catalogs_multi_region.py
@@ -30,5 +30,26 @@ def test_service_provision_retire_from_global_region(item_type, catalog_location
         caseimportance: high
         casecomponent: Services
         initialEstimate: 1/3h
+        testSteps:
+            1. Take two or more appliances
+            2. Configure DB manually
+            3. Make one appliance as Global region and second are Remote
+            4. Add appropriate provider to remote region appliance
+            5. Create Dialog
+            6. Create Catalog
+            7. Create Catalog Item of above provider type in remote appliance
+            8. Order appearing service catalog in global appliance
+            9. Retire provisioned service in global appliance
+
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6.
+            7.
+            8. service catalog has been successfully provisioned
+            9. service has been successfully retired
     """
     pass


### PR DESCRIPTION
- Existing service catalogs tests file covers only limited range of catalog items due to provider == InfraProvider filter.

In my case I need to override this marker to have provider == None, provider marker doesn't support this. 
So, I just moved my manual tests to another file in order to turn off provider parametrization. 

- fixed wait_for value str->int.
- added Bundle option to service tests
- fixed power on/off tests in global region because collection of these tests has been broken



