### PR TITLE
[1LP][RFR] Fix navigation for server

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -4,6 +4,7 @@ import attr
 import importscan
 import sentaku
 
+from cfme.exceptions import RestLookupError
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils import ParamClassName
@@ -47,6 +48,25 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
         return getattr(self.appliance._rest_api_server(), 'name', '')
 
     @property
+    def tree_path(self):
+        """Generate the path list for navigation purposes
+        list elements follow the tree path in the configuration accordion
+
+        Returns:
+            list of path elements for tree navigation
+        """
+        current = '' if self.is_slave else ' (current)'
+        # replace two spaces with one, formatting tweak when name is empty
+        name_string = f' {self.name} '.replace('  ', ' ')
+        path = [
+            self.zone.region.settings_string,
+            "Zones",
+            f"Zone: {self.rest_api_entity.zone.description} (current)",
+            f"Server:{name_string}[{self.sid}]{current}"  # variables have needed spaces
+        ]
+        return path
+
+    @property
     def settings(self):
         from cfme.configure.configuration.server_settings import ServerInformation
         setting = ServerInformation(appliance=self.appliance)
@@ -65,12 +85,13 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
 
     @property
     def zone(self):
-        server_res = self.appliance.rest_api.collections.servers.find_by(id=self.sid)
-        server, = server_res
+        server, = self.appliance.rest_api.collections.servers.find_by(id=self.sid)
         server.reload(attributes=['zone'])
         zone = server.zone
         zone_obj = self.appliance.collections.zones.instantiate(
-            name=zone['name'], description=zone['description'], id=zone['id']
+            name=zone['name'],
+            description=zone['description'],
+            id=zone['id']
         )
         return zone_obj
 
@@ -79,10 +100,21 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
         return self.zone.collections.servers.filter({'slave': True}).all()
 
     @property
+    def is_slave(self):
+        return self in self.slave_servers
+
+    @property
     def _api_settings_url(self):
         return '/'.join(
             [self.appliance.rest_api.collections.servers._href, str(self.sid), 'settings']
         )
+
+    @property
+    def rest_api_entity(self):
+        try:
+            return self.appliance.rest_api.collections.servers.get(id=self.sid)
+        except ValueError:
+            raise RestLookupError
 
     @property
     def advanced_settings(self):

--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -85,15 +85,13 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
 
     @property
     def zone(self):
-        server, = self.appliance.rest_api.collections.servers.find_by(id=self.sid)
-        server.reload(attributes=['zone'])
-        zone = server.zone
-        zone_obj = self.appliance.collections.zones.instantiate(
-            name=zone['name'],
-            description=zone['description'],
-            id=zone['id']
+        entity = self.rest_api_entity
+        entity.reload(attributes=['zone'])
+        return self.appliance.collections.zones.instantiate(
+            name=entity.zone['name'],
+            description=entity.zone['description'],
+            id=entity.zone['id']
         )
-        return zone_obj
 
     @property
     def slave_servers(self):
@@ -114,7 +112,7 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
         try:
             return self.appliance.rest_api.collections.servers.get(id=self.sid)
         except ValueError:
-            raise RestLookupError
+            raise RestLookupError(f'No server rest entity found matching ID {self.sid}')
 
     @property
     def advanced_settings(self):

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -548,17 +548,7 @@ class ServerView(ConfigurationView):
             return False
 
         # check that tree contains all expected entities
-        expected_list = [
-            self.context['object'].zone.region.settings_string,
-            "Zones",
-            "Zone: {} (current)".format(self.context['object'].zone.description),
-            "Server: {name} [{sid}]{current}".format(
-                name=self.context['object'].name,
-                sid=self.context['object'].sid,
-                current='' if self.context['object'] in self.context['object'].slave_servers
-                else ' (current)')]
-
-        return (self.accordions.settings.tree.currently_selected == expected_list)
+        return self.accordions.settings.tree.currently_selected == self.context['object'].tree_path
 
 
 @navigator.register(Server, 'Details')
@@ -567,15 +557,7 @@ class Details(CFMENavigateStep):
     prerequisite = NavigateToSibling('Configuration')
 
     def step(self, *args, **kwargs):
-        path = (
-            self.obj.zone.region.settings_string,
-            "Zones",
-            "Zone: {} (current)".format(self.obj.appliance.server.zone.description),
-            "Server: {name} [{sid}]{current}".format(
-                name=self.obj.appliance.server.name,
-                sid=self.obj.sid,
-                current='' if self.obj in self.obj.slave_servers else ' (current)'))
-        self.prerequisite_view.accordions.settings.tree.click_path(*path)
+        self.prerequisite_view.accordions.settings.tree.click_path(*self.obj.tree_path)
 
 
 @navigator.register(Server, 'Server')
@@ -816,14 +798,9 @@ class ServerDiagnosticsView(ConfigurationView):
 
     @property
     def is_displayed(self):
-        expected_list = [self.context['object'].zone.region.settings_string,
-            "Zone: {} (current)".format(self.context['object'].zone.description),
-            "Server: {name} [{sid}]{current}".format(
-            name=self.context['object'].name,
-            sid=self.context['object'].sid,
-            current='' if self.context['object'] in self.context['object'].slave_servers
-            else ' (current)')]
-        return (self.accordions.diagnostics.tree.currently_selected == expected_list)
+        expected_tree = self.context['object'].tree_path
+        expected_tree.remove('Zones')  # second item isn't included here
+        return (self.accordions.diagnostics.tree.currently_selected == expected_tree)
 
 
 class ServerDiagnosticsCollectLogsView(ServerDiagnosticsView):
@@ -838,14 +815,9 @@ class Diagnostics(CFMENavigateStep):
     prerequisite = NavigateToSibling('Configuration')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.accordions.diagnostics.tree.click_path(
-            self.obj.zone.region.settings_string,
-            "Zone: {} (current)".format(self.obj.zone.description),
-            "Server: {name} [{sid}]{current}".format(
-                name=self.obj.appliance.server.name,
-                sid=self.obj.sid,
-                current='' if self.obj in self.obj.slave_servers
-                else ' (current)'))
+        tree_path = self.obj.tree_path
+        tree_path.remove('Zones')
+        self.prerequisite_view.accordions.diagnostics.tree.click_path(*tree_path)
 
 
 @navigator.register(Server)

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -20,6 +20,7 @@ from cfme.exceptions import AddProviderError
 from cfme.exceptions import HostStatsNotContains
 from cfme.exceptions import ProviderHasNoKey
 from cfme.exceptions import ProviderHasNoProperty
+from cfme.exceptions import RestLookupError
 from cfme.modeling.base import BaseEntity
 from cfme.utils import conf
 from cfme.utils import ParamClassName
@@ -151,7 +152,10 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
 
     @property
     def rest_api_entity(self):
-        return self.appliance.rest_api.collections.providers.get(name=self.name)
+        try:
+            return self.appliance.rest_api.collections.providers.get(name=self.name)
+        except ValueError:
+            raise RestLookupError(f'No provider rest entity found matching name {self.name}')
 
     @property
     def id(self):

--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -277,6 +277,10 @@ class NeedleNotFoundInLog(CFMEException):
     """Raised when log doesnt't contain needle"""
 
 
+class RestLookupError(CFMEException):
+    """raised when lookup of a rest entity fails"""
+
+
 @property
 def displayed_not_implemented(cls):
     raise NotImplementedError("This view has no unique markers for is_displayed check")

--- a/cfme/fixtures/base.py
+++ b/cfme/fixtures/base.py
@@ -58,3 +58,19 @@ def fix_missing_hostname(appliance):
 
             if ssh_client.run_command('grep $(hostname) /etc/hosts').failed:
                 logger.error('Failed to mangle /etc/hosts')
+
+
+@pytest.fixture(scope="session", autouse=True)
+def fix_missing_appliance_name(appliance):
+    """Fix for an empty appliance server name"""
+    if isinstance(appliance, DummyAppliance) or appliance.is_dev:
+        return
+    logger.info('Checking appliance server name is set')
+    if appliance.server.name == '':
+        appliance.update_advanced_settings(
+            {
+                'server': {
+                    'name': getattr(appliance, '_default_name', 'EVM')
+                }
+            }
+        )

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -24,6 +24,7 @@ from cfme.common.host_views import HostsView
 from cfme.common.host_views import HostTimelinesView
 from cfme.common.host_views import ProviderAllHostsView
 from cfme.exceptions import ItemNotFound
+from cfme.exceptions import RestLookupError
 from cfme.infrastructure.datastore import HostAllDatastoresView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -457,7 +458,10 @@ class Host(
 
     @property
     def rest_api_entity(self):
-        return self.appliance.rest_api.collections.hosts.get(name=self.name)
+        try:
+            return self.appliance.rest_api.collections.hosts.get(name=self.name)
+        except ValueError:
+            raise RestLookupError(f'No host rest entity found matching name {self.name}')
 
 
 @attr.s

--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -2,6 +2,7 @@ import importscan
 import sentaku
 
 from cfme.common import Taggable
+from cfme.exceptions import RestLookupError
 from cfme.utils.appliance import Navigatable
 from cfme.utils.update import Updateable
 
@@ -37,7 +38,10 @@ class MyService(Updateable, Navigatable, Taggable, sentaku.modeling.ElementMixin
 
     @property
     def rest_api_entity(self):
-        return self.appliance.rest_api.collections.services.find_by(name=self.name)[0]
+        try:
+            return self.appliance.rest_api.collections.services.get(name=self.name)[0]
+        except IndexError:
+            raise RestLookupError(f'No service rest entity found matching name {self.name}')
 
 
 from cfme.services.myservice import ui, ssui, rest  # NOQA last for import cycles

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -105,6 +105,7 @@ def user_obj(appliance, auth_user, user_type):
         fullname=auth_user.fullname or auth_user.username)  # fullname could be empty
     yield user
 
+    appliance.browser.widgetastic.refresh()
     appliance.server.login_admin()
     if user.exists:
         user.delete()
@@ -134,7 +135,7 @@ def test_login_evm_group(appliance, auth_user, user_obj, soft_assert):
     evm_group_names = [group for group in auth_user.groups if 'evmgroup' in group.lower()]
     with user_obj:
         logger.info('Logging in as user %s, member of groups %s', user_obj, evm_group_names)
-        view = navigate_to(appliance.server, 'LoggedIn')
+        view = navigate_to(appliance.server, 'Dashboard')
         assert view.is_displayed, 'user {} failed login'.format(user_obj)
         soft_assert(user_obj.name == view.current_fullname,
                     'user {} is not in view fullname'.format(user_obj))


### PR DESCRIPTION
create tree_path property for Server
Use it in navigation/views where this tree path is built from server attributes
add base session fixture to set appliance name

There are some other failures going on in PRT, but I don't really want this PR scope creeping too far beyond the changes here related to server configuration navigation/view assertions.

{{ pytest: cfme/tests/integration/test_cfme_auth.py::test_login_evm_group --long-running }}