### PR TITLE
[1LP][RFR] Automate test case for BZ 1650559

### DIFF
--- a/cfme/generic_objects/definition/__init__.py
+++ b/cfme/generic_objects/definition/__init__.py
@@ -29,6 +29,7 @@ class GenericObjectDefinition(BaseEntity, Updateable, sentaku.modeling.ElementMi
     add_button = sentaku.ContextualMethod()
     add_button_group = sentaku.ContextualMethod()
     generic_objects = sentaku.ContextualProperty()
+    generic_object_buttons = sentaku.ContextualProperty()
     instance_count = sentaku.ContextualProperty()
 
     name = attr.ib()

--- a/cfme/generic_objects/definition/button_groups.py
+++ b/cfme/generic_objects/definition/button_groups.py
@@ -25,8 +25,8 @@ class GenericObjectButton(BaseEntity, Updateable):
 
     name = attr.ib()
     description = attr.ib()
-    image = attr.ib()
     request = attr.ib()
+    image = attr.ib(default='fa-home')
     button_type = attr.ib(default='Default')
     display = attr.ib(default=True)
     dialog = attr.ib(default=None)
@@ -37,6 +37,11 @@ class GenericObjectButton(BaseEntity, Updateable):
     attributes = attr.ib(default=None)
     role = attr.ib(default=None)
     button_group = attr.ib(default=None)
+
+    # extra fields for ansible playbook type buttons
+    playbook_cat_item = attr.ib(default=None)
+    inventory = attr.ib(default=None)
+    hosts = attr.ib(default=None)
 
     def delete(self, cancel=False):
         """Delete generic object button
@@ -66,9 +71,10 @@ class GenericObjectButtonsCollection(BaseCollection):
 
     ENTITY = GenericObjectButton
 
-    def create(self, name, description, request, image, button_type='Default',
+    def create(self, name, description, request, image='fa-home', button_type='Default',
                display=True, dialog=None, open_url=None, display_for=None, submit_version=None,
-               system_message=None, attributes=None, role=None, cancel=False):
+               system_message=None, attributes=None, role=None, cancel=False, inventory=None,
+               playbook_cat_item=None, hosts=None):
         """Add button to generic object definition or button group
 
             Args:
@@ -86,13 +92,20 @@ class GenericObjectButtonsCollection(BaseCollection):
                 attributes(dict): button attributes ex. {'address': 'string'}
                 role: role used for button
                 cancel(bool): cancel button creation, default if False
+                inventory(str): Name of inventory (Localhost, Target Machine, Specific Hosts)
+                playbook_cat_item(str): catalog item name for ansible playbook
+                hosts(str): if inventory is Specific Hosts, enter hosts here
 
             Returns: button object
 
         """
         view = navigate_to(self, 'Add')
+
         view.fill({
             'button_type': button_type,
+            'form': {
+                'playbook_cat_item': playbook_cat_item, 'inventory': inventory, 'hosts': hosts
+            },
             'name': name,
             'description': description,
             'display': display,
@@ -121,7 +134,8 @@ class GenericObjectButtonsCollection(BaseCollection):
                                 button_type=button_type, display=display, dialog=dialog,
                                 open_url=open_url, display_for=display_for,
                                 submit_version=submit_version, system_message=system_message,
-                                attributes=attributes, role=role)
+                                attributes=attributes, role=role, inventory=inventory,
+                                playbook_cat_item=playbook_cat_item, hosts=hosts)
 
     def all(self):
         """All existing buttons

--- a/cfme/generic_objects/definition/definition_views.py
+++ b/cfme/generic_objects/definition/definition_views.py
@@ -1,5 +1,6 @@
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import ParametrizedString
+from widgetastic.widget import ConditionalSwitchableView
 from widgetastic.widget import ParametrizedLocator
 from widgetastic.widget import Text
 from widgetastic.widget import View
@@ -10,6 +11,7 @@ from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import Input
 
 from cfme.base.login import BaseLoggedInPage
+from widgetastic_manageiq import AutomateRadioGroup
 from widgetastic_manageiq import BaseEntitiesView
 from widgetastic_manageiq import BootstrapSwitch
 from widgetastic_manageiq import FileInput
@@ -192,6 +194,7 @@ class ButtonParameterForm(ParametersForm):
 
 class GenericObjectAddEditButtonView(GenericObjectDefinitionView):
     title = Text('#explorer_title_text')
+    form = ConditionalSwitchableView(reference="button_type")
 
     button_type = BootstrapSelect(name='button_type')
     name = Input(name='name')
@@ -208,6 +211,17 @@ class GenericObjectAddEditButtonView(GenericObjectDefinitionView):
     add_attribute_value_key = Button('Add Attribute/Value Pair')
     attributes = ButtonParameterForm(param_type="Attribute")
     cancel = Button('Cancel')
+
+    @form.register("Default")
+    class DefaultButtonFieldView(View):
+        pass
+
+    # the following are necessary for ansible playbook buttons in 5.11
+    @form.register("Ansible Playbook")
+    class AnsibleButtonFieldView(View):  # noqa
+        playbook_cat_item = BootstrapSelect(name='playbook_catalog_item')
+        inventory = AutomateRadioGroup(locator=".//input[@name='inventory']/..")
+        hosts = Input(locator=".//input[contains(@ng-model, 'hosts')]")
 
 
 class GenericObjectAddButtonView(GenericObjectAddEditButtonView):

--- a/cfme/generic_objects/definition/ui.py
+++ b/cfme/generic_objects/definition/ui.py
@@ -112,10 +112,20 @@ def generic_objects(self):
     return self.collections.generic_objects
 
 
+@MiqImplementationContext.external_for(GenericObjectDefinition.generic_object_buttons.getter, ViaUI)
+def generic_object_buttons(self):
+    return self.collections.generic_object_buttons
+
+
 @MiqImplementationContext.external_for(GenericObjectDefinition.instance_count.getter, ViaUI)
 def instance_count(self):
     view = navigate_to(self, "Details")
     return int(view.summary("Relationships").get_text_of("Instances"))
+
+
+@MiqImplementationContext.external_for(GenericObjectDefinition.add_button, ViaUI)
+def add_button(self, name, description, request, **kwargs):
+    return self.generic_object_buttons.create(name, description, request, **kwargs)
 
 
 # navigator registers


### PR DESCRIPTION
Automating test case for https://bugzilla.redhat.com/show_bug.cgi?id=1650559

Note that this test case doesn't require you to create the Ansible Playbook type generic object button, just that the fields are valid. A future test case will create these buttons.

This test case required some framework enhancements to allow for different types of generic object buttons. 

{{ pytest: --long-running cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py::test_ansible_playbook_generic_object_button }}