### PR TITLE
[1LP][RFR] Fix test_provision_stack

### DIFF
--- a/cfme/services/catalogs/orchestration_template.py
+++ b/cfme/services/catalogs/orchestration_template.py
@@ -20,6 +20,7 @@ from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
 from cfme.utils.version import LOWEST
 from cfme.utils.version import VersionPicker
+from cfme.utils.wait import wait_for
 from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import ReactCodeMirror
 from widgetastic_manageiq import ReactSelect
@@ -137,8 +138,10 @@ class TemplateTypeView(ServicesCatalogView):
 
 class DialogForm(ServicesCatalogView):
     title = Text('#explorer_title_text')
-
-    name = Input(name='dialog_name')
+    name = VersionPicker({
+        "5.11": Input(name='label'),
+        LOWEST: Input(name='dialog_name')
+    })
 
 
 class AddDialogView(DialogForm):
@@ -206,6 +209,7 @@ class OrchestrationTemplate(BaseEntity, Updateable, Pretty, Taggable):
     def create_service_dialog_from_template(self, dialog_name):
         view = navigate_to(self, 'AddDialog')
         view.fill({'name': dialog_name})
+        wait_for(lambda: view.add_button.is_enabled, num_sec=5)
         view.add_button.click()
         view.flash.assert_no_error()
         service_dialog = self.parent.parent.collections.service_dialogs.instantiate(

--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -29,8 +29,13 @@ class MyService(Updateable, Navigatable, Taggable, sentaku.modeling.ElementMixin
     service_power = sentaku.ContextualMethod()
     add_resource_generic_object = sentaku.ContextualMethod()
 
-    def __init__(self, appliance, name=None, description=None, vm_name=None):
+    def __init__(self, appliance, name=None, name_base=None, description=None, vm_name=None):
         self.appliance = appliance
+        #TODO(jehnner) remove?
+        #if name_base:
+        #    self.name, = (s.name for s in self.appliance.rest_api.collections.services.all if name_base in s.name)
+        #else:
+        #    self.name = name
         self.name = name
         self.description = description
         self.vm_name = vm_name

--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -31,11 +31,6 @@ class MyService(Updateable, Navigatable, Taggable, sentaku.modeling.ElementMixin
 
     def __init__(self, appliance, name=None, name_base=None, description=None, vm_name=None):
         self.appliance = appliance
-        #TODO(jehnner) remove?
-        #if name_base:
-        #    self.name, = (s.name for s in self.appliance.rest_api.collections.services.all if name_base in s.name)
-        #else:
-        #    self.name = name
         self.name = name
         self.description = description
         self.vm_name = vm_name

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -371,10 +371,6 @@ class MyServiceAll(CFMENavigateStep):
 
     def resetter(self, *args, **kwargs):
         self.view.myservice.tree.click_path('Active Services')
-        if self.obj.rest_api_entity.retired:
-            self.view.myservice.tree.click_path('Retired Services')
-        else:
-            self.view.myservice.tree.click_path('Active Services')
 
 
 @navigator.register(MyService, 'Details')
@@ -384,6 +380,10 @@ class MyServiceDetails(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
+        if self.obj.rest_api_entity.retired:
+            self.view.myservice.tree.click_path('Retired Services')
+        else:
+            self.view.myservice.tree.click_path('Active Services')
         self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).click()
 
 

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -263,7 +263,7 @@ def retire(self):
             num_sec=10 * 60, delay=3,
             message='Service Retirement wait')
     else:
-        request_descr = "Provisioning Service [{0}] from [{0}]".format(self.name)
+        request_descr = f"Service Retire for: {self.name}"
         service_request = self.appliance.collections.requests.instantiate(
             description=request_descr)
         service_request.wait_for_request()
@@ -354,6 +354,7 @@ def download_file(self, extension):
 def reconfigure_service(self):
     # TODO refactor this method - it does nothing at the moment. Bug 1575935
     view = navigate_to(self, 'Reconfigure')
+    wait_for(lambda: view.submit_button.is_displayed, num_sec=5)
     view.submit_button.click()
     view.flash.assert_no_error()
     self.create_view(MyServiceDetailView, wait='5s')

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -371,6 +371,10 @@ class MyServiceAll(CFMENavigateStep):
 
     def resetter(self, *args, **kwargs):
         self.view.myservice.tree.click_path('Active Services')
+        if self.obj.rest_api_entity.retired:
+            self.view.myservice.tree.click_path('Retired Services')
+        else:
+            self.view.myservice.tree.click_path('Active Services')
 
 
 @navigator.register(MyService, 'Details')

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -354,7 +354,7 @@ def download_file(self, extension):
 def reconfigure_service(self):
     # TODO refactor this method - it does nothing at the moment. Bug 1575935
     view = navigate_to(self, 'Reconfigure')
-    wait_for(lambda: view.submit_button.is_displayed, num_sec=5)
+    view.submit_button.wait_displayed('5s')
     view.submit_button.click()
     view.flash.assert_no_error()
     self.create_view(MyServiceDetailView, wait='5s')

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -42,6 +42,7 @@ class Request(BaseEntity):
     REQUEST_FINISHED_STATES = {'Migrated', 'Finished'}
 
     description = attr.ib(default=None)
+    message = attr.ib(default=None)
     partial_check = attr.ib(default=False)
     cells = attr.ib(default=None)
     row = attr.ib(default=None, init=False)
@@ -84,6 +85,7 @@ class Request(BaseEntity):
         else:
             matching_requests = self.appliance.rest_api.collections.requests.find_by(
                 description=self.cells['Description'])
+
         if len(matching_requests) > 1:
             raise RequestException(
                 'Multiple requests with matching \"{}\" '
@@ -94,7 +96,6 @@ class Request(BaseEntity):
                 'Nothing matching "{}" with partial_check={} was found'.format(
                     self.cells['Description'], self.partial_check))
         else:
-            self.description = matching_requests[0].description
             return matching_requests[0]
 
     def get_request_row_from_ui(self):
@@ -140,6 +141,7 @@ class Request(BaseEntity):
         """
         self.rest.reload()
         self.description = self.rest.description
+        self.message = self.rest.message
         self.cells = {'Description': self.description}
 
     @update.variant('ui')

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -166,6 +166,7 @@ def _cleanup(appliance=None, provision_request=None, service=None):
         myservice = service
     if myservice.exists:
         myservice.retire()
+        myservice.delete()
 
 
 @pytest.mark.meta(blockers=[BZ(1754543)])


### PR DESCRIPTION
Fix `test_provision_stack`, `test_retire_stack` and `test_reconfigure_service`

The stack creation was failing
 * Changed name of the input field from dialog_name to label on 5.11.
 * Need to select correct network for the stack.
 * On 5.11, there is a bug BZ 1754543 making fill method silently fail
   to fill the orchestration template content (it fills only first
   character).  The template then doesn't contain parameter which then
   "surprises" the test as it has no options to fill when ordering the
   stack.
 * Wait for Submit button to get displayed.

The stack was also not properly cleaned-up after I got it created. When
the stack was created using a service, we need to retire the service to
get the stack deleted by CFME.

When we are deleting the stack on EC2, the stack remains in
DELETE_COMPLETE state for a bit, so Stack.exists property needed to be
modified to consider these stacks as non-existent.

{{pytest: cfme/tests/services/test_provision_stack.py -v}}