### PR TITLE
[1LP][RFR] Add ONE_PER_VERSION selector to test_host module

### DIFF
--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -30,8 +30,7 @@ pytestmark = [
     pytest.mark.provider([InfraProvider],
                          required_fields=['hosts'], scope='module',
                          selector=ONE_PER_VERSION,
-                        ),
-
+                         ),
 ]
 
 VIEWS = ('Grid View', 'Tile View', 'List View')

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -16,6 +16,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE
+from cfme.markers.env_markers.provider import ONE_PER_VERSION
 from cfme.tests.networks.test_sdn_downloads import handle_extra_tabs
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -26,7 +27,11 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.tier(3),
-    pytest.mark.provider([InfraProvider], required_fields=['hosts'], scope='module'),
+    pytest.mark.provider([InfraProvider],
+                         required_fields=['hosts'], scope='module',
+                         selector=ONE_PER_VERSION,
+                        ),
+
 ]
 
 VIEWS = ('Grid View', 'Tile View', 'List View')


### PR DESCRIPTION
## Purpose or Intent
- __Updating tests__ in test_host module to use the ONE_PER_VERSION selector.

{{ pytest: --long-running --use-provider vsphere6-nested cfme/tests/infrastructure/test_host.py }}