### PR TITLE
[RFR] Add/Remove rhel_testing marker on tests

### DIFF
--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -169,7 +169,6 @@ def no_ipa_config(configured_appliance):
     configured_appliance.appliance_console_cli.uninstall_ipa_client()
 
 
-@pytest.mark.rhel_testing
 def test_appliance_console_cli_ipa(ipa_crud, configured_appliance, no_ipa_config):
     """
     Polarion:

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -417,7 +417,6 @@ def test_appliance_console_extend_storage(unconfigured_appliance):
     wait_for(is_storage_extended)
 
 
-@pytest.mark.rhel_testing
 def test_appliance_console_ipa(ipa_crud, configured_appliance):
     """ Commands:
     1. 'ap' launches appliance_console,
@@ -522,7 +521,6 @@ def test_appliance_console_external_auth_all(configured_appliance):
     assert evm_tail.validate(wait="30s")
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.tier(2)
 def test_appliance_console_scap(temp_appliance_preconfig, soft_assert):
     """ Commands:

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -263,7 +263,6 @@ def test_stop(appliance, provider, testing_instance, ensure_vm_running, soft_ass
     wait_for_instance_state(soft_assert, testing_instance, state="stopped")
 
 
-@pytest.mark.rhel_testing
 def test_start(appliance, provider, testing_instance, ensure_vm_stopped, soft_assert):
     """ Tests instance start
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -254,7 +254,6 @@ def test_cloud_provider_add_with_bad_credentials(request, provider, enable_regio
         provider.create(validate_credentials=True)
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.tier(1)
 @pytest.mark.smoke
 @pytest.mark.usefixtures('has_no_cloud_providers')

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -88,7 +88,6 @@ def provisioned_instance(provider, instance_args, appliance):
                        .format(ex.message))
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.parametrize('instance_args', [True, False], ids=["Auto", "Manual"], indirect=True)
 def test_provision_from_template(provider, provisioned_instance):
     """ Tests instance provision from template via CFME UI

--- a/cfme/tests/configure/test_email.py
+++ b/cfme/tests/configure/test_email.py
@@ -5,11 +5,12 @@ from cfme.utils.wait import wait_for
 
 
 pytestmark = [
-    test_requirements.configuration
+    test_requirements.configuration,
+    pytest.mark.rhel_testing,
+    pytest.mark.tier(3)
 ]
 
 
-@pytest.mark.tier(3)
 def test_send_test_email(smtp_test, random_string, appliance):
     """ This test checks whether the mail sent for testing really arrives.
 

--- a/cfme/tests/configure/test_ntp_server.py
+++ b/cfme/tests/configure/test_ntp_server.py
@@ -11,7 +11,8 @@ from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 
-pytestmark = [test_requirements.configuration]
+pytestmark = [test_requirements.configuration,
+              pytest.mark.rhel_testing]
 
 
 @pytest.fixture

--- a/cfme/tests/configure/test_workers.py
+++ b/cfme/tests/configure/test_workers.py
@@ -6,6 +6,8 @@ import pytest
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
 
+pytestmark = [pytest.mark.rhel_testing]
+
 Dropdown = namedtuple('Dropdown', 'dropdown id')
 
 DROPDOWNS = [

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -180,7 +180,6 @@ def vm_off(vm):
     return
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider], scope="module"
 )

--- a/cfme/tests/infrastructure/test_child_tenant.py
+++ b/cfme/tests/infrastructure/test_child_tenant.py
@@ -100,7 +100,6 @@ def new_user(appliance, new_group, new_credential):
         user.delete()
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.rhv3
 @pytest.mark.meta(blockers=[GH('ManageIQ/integration_tests:7385',
     unblock=lambda provider, appliance_version:

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -221,7 +221,6 @@ def test_disk_format_select(provisioner, disk_format, provider, prov_data, vm_na
         assert thin != 'true', "The disk format should not be Thin"
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.rhv3
 @pytest.mark.parametrize("started", [True, False])
 def test_power_on_or_off_after_provision(provisioner, prov_data, provider, started, vm_name):

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -116,7 +116,6 @@ def enable_hot_plugin(provider, full_vm, ensure_vm_stopped):
         vm.memory_hot_plug = True
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.rhv1
 @pytest.mark.parametrize('change_type', ['cores_per_socket', 'sockets', 'memory'])
 def test_vm_reconfig_add_remove_hw_cold(provider, full_vm, ensure_vm_stopped, change_type):

--- a/cfme/tests/networks/test_network_providers.py
+++ b/cfme/tests/networks/test_network_providers.py
@@ -15,7 +15,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.rhel_testing
 def test_add_cancelled_validation(request, appliance):
     """Tests that the flash message is correct when add is cancelled.
 

--- a/cfme/tests/networks/test_sdn_crud.py
+++ b/cfme/tests/networks/test_sdn_crud.py
@@ -13,7 +13,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.tier(1)
 def test_sdn_crud(provider, appliance):
     """ Test for functional addition of network manager with cloud provider

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -33,7 +33,6 @@ pytestmark = [
 ]
 
 
-@pytest.mark.rhel_testing
 @pytest.mark.rhv1
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_myservice_crud(appliance, setup_provider, context, order_service):


### PR DESCRIPTION
PR covers two things:
1) Removing rhel_testing marker on tests that don't need to be run after an upgrade
2) Adding rhel_testing marker on test that should be executed after an upgrade