### PR TITLE
[1LP][RFR]Ignoring load balancers in 5.11 because of deprecation

### DIFF
--- a/cfme/tests/cloud/test_targeted_refresh.py
+++ b/cfme/tests/cloud/test_targeted_refresh.py
@@ -161,6 +161,7 @@ def test_ec2_targeted_refresh_subnet():
 
 
 @pytest.mark.manual
+@pytest.mark.ignore_stream('5.11')
 def test_ec2_targeted_refresh_load_balancer():
     """
     AWS naming is ELB

--- a/cfme/tests/configure/test_landing_page.py
+++ b/cfme/tests/configure/test_landing_page.py
@@ -145,6 +145,7 @@ PAGES_NOT_IN_511 = [
     "Cloud Intel / Reports",
     "Cloud Intel / Timelines",
     "Monitor / Alerts / Most Recent Alerts",
+    "Networks / Load Balancers",
     "Optimize / Bottlenecks",
     "Optimize / Planning",
     "Optimize / Utilization",

--- a/cfme/tests/networks/test_sdn_crud.py
+++ b/cfme/tests/networks/test_sdn_crud.py
@@ -36,7 +36,9 @@ def test_sdn_crud(provider, appliance):
     assert parent_name == provider.name
 
     testing_list = ["Cloud Networks", "Cloud Subnets", "Network Routers",
-                    "Security Groups", "Floating IPs", "Network Ports", "Load Balancers"]
+                    "Security Groups", "Floating IPs", "Network Ports"]
+    if appliance.version < '5.11':
+        testing_list.append("Load Balancers")
     for testing_name in testing_list:
         view = navigate_to(network_provider, 'Details')
         view.entities.relationships.click_at(testing_name)

--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -54,6 +54,10 @@ def handle_extra_tabs(view):
 
 @pytest.mark.parametrize("filetype", list(extensions_mapping.keys()))
 @pytest.mark.parametrize("collection_type", OBJECTCOLLECTIONS)
+@pytest.mark.uncollectif(
+    lambda collection_type, appliance:
+    "balancers" in collection_type and appliance.version > "5.11",
+    reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
 def test_download_lists_base(filetype, collection_type, appliance):
     """ Download the items from base lists.
 
@@ -70,6 +74,10 @@ def test_download_lists_base(filetype, collection_type, appliance):
     download(collection, filetype)
 
 
+@pytest.mark.uncollectif(
+    lambda collection_type, appliance:
+    "balancers" in collection_type and appliance.version > "5.11",
+    reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
 @pytest.mark.parametrize("collection_type", OBJECTCOLLECTIONS)
 def test_download_pdf_summary(appliance, collection_type, provider):
     """ Download the summary details of specific object

--- a/cfme/tests/networks/test_sdn_inventory_collection.py
+++ b/cfme/tests/networks/test_sdn_inventory_collection.py
@@ -108,6 +108,7 @@ def test_sdn_api_inventory_security_groups(provider, appliance):
     'cfme list: {cfme}'.format(sec=prov_sec_gp, cfme=cfme_sec_gp)
 
 
+@pytest.mark.ignore_stream('5.11')  # Load Balancers are deprecated in 5.11
 @pytest.mark.provider([EC2Provider, AzureProvider], override=True, scope='function')
 def test_sdn_api_inventory_loadbalancers(provider, appliance):
     """Pulls the list of loadbalancers from the Provider API and from the appliance. Compare the 2

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -15,6 +15,9 @@ pytestmark = [
 
 @pytest.mark.parametrize("tested_part", ["Cloud Subnets", "Cloud Networks", "Network Routers",
                          "Security Groups", "Network Ports", "Load Balancers"])
+@pytest.mark.uncollectif(
+    lambda tested_part, appliance: "Load Balancers" in tested_part and appliance.version > "5.11",
+    reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
 def test_sdn_provider_relationships_navigation(provider, tested_part, appliance):
     """
     Metadata:

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -160,7 +160,7 @@ COLLECTIONS_ALL = {
 }
 
 COLLECTIONS_NOT_IN_510 = {"customization_templates", "pxe_images", "pxe_servers"}
-COLLECTIONS_NOT_IN_511 = {"container_deployments"}
+COLLECTIONS_NOT_IN_511 = {"container_deployments", "load_balancers"}
 
 COLLECTIONS_IN_510 = COLLECTIONS_ALL - COLLECTIONS_NOT_IN_510
 COLLECTIONS_IN_511 = COLLECTIONS_ALL - COLLECTIONS_NOT_IN_511


### PR DESCRIPTION
There are multiple tests running with loadbalancers parameter in 5.11.
There are loadbalancer tests running in 5.11.
Purpose of this PR is to ignore_stream for load balancers tests or uncollect loadbalancer parameter for 5.11.
