### PR TITLE
[1LP][RFR] Automate: test_refresh_with_empty_iot_hub_azure

### DIFF
--- a/cfme/tests/cloud/test_azure_manual.py
+++ b/cfme/tests/cloud/test_azure_manual.py
@@ -44,7 +44,7 @@ def test_refresh_with_empty_iot_hub_azure():
     Bugzilla:
         1495318
     """
-    pass
+    pass  # :)
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/cloud/test_azure_manual.py
+++ b/cfme/tests/cloud/test_azure_manual.py
@@ -26,27 +26,6 @@ def test_refresh_azure_provider_with_empty_ipv6_config_on_vm():
     pass
 
 
-@pytest.mark.tier(1)
-def test_refresh_with_empty_iot_hub_azure():
-    """
-    Polarion:
-        assignee: anikifor
-        casecomponent: Cloud
-        caseimportance: low
-        initialEstimate: 1/6h
-        setup: prepare env
-               create an IoT Hub in Azure (using free tier pricing is good enough):
-               $ az iot hub create --name rmanes-iothub --resource-group iot_rg
-        testSteps:
-            1. refresh azure provider
-        expectedResults:
-            1. no errors found in logs
-    Bugzilla:
-        1495318
-    """
-    pass  # :)
-
-
 @pytest.mark.tier(2)
 def test_regions_gov_azure():
     """

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -27,6 +27,7 @@ from cfme.utils import appliance
 from cfme.utils import conf
 from cfme.utils import ssh
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log_validator import LogValidator
@@ -542,7 +543,7 @@ def test_azure_multiple_subscription(appliance, request, soft_assert):
 
 @pytest.mark.tier(3)
 @test_requirements.azure
-@pytest.mark.meta(automates=[1495318])
+@pytest.mark.meta(automates=[1495318], blockers=[BZ(1756984)])
 @pytest.mark.provider([AzureProvider], scope="function", override=True, selector=ONE)
 def test_refresh_with_empty_iot_hub_azure(request, provider, setup_provider):
     """
@@ -567,7 +568,7 @@ def test_refresh_with_empty_iot_hub_azure(request, provider, setup_provider):
     if not azure.has_iothub():
         azure.create_iothub("potatoiothub")
         request.addfinalizer(lambda: azure.delete_iothub("potatoiothub"))
-    assert azure.has_iothub()
+        assert azure.has_iothub()
     provider.refresh_provider_relationships()
     wait_for(provider.is_refreshed, func_kwargs={'refresh_delta': 10}, timeout=600)
     assert result.validate(wait="60s")

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -566,8 +566,9 @@ def test_refresh_with_empty_iot_hub_azure(request, provider, setup_provider):
     result.start_monitoring()
     azure = provider.mgmt
     if not azure.has_iothub():
-        azure.create_iothub("potatoiothub")
-        request.addfinalizer(lambda: azure.delete_iothub("potatoiothub"))
+        iothub_name = f"potatoiothub_{fauxfactory.gen_alpha()}"
+        azure.create_iothub(iothub_name)
+        request.addfinalizer(lambda: azure.delete_iothub(iothub_name))
         assert azure.has_iothub()
     provider.refresh_provider_relationships()
     wait_for(provider.is_refreshed, func_kwargs={'refresh_delta': 10}, timeout=600)

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -334,7 +334,7 @@ Werkzeug==0.16.0
 widgetastic.core==0.40
 widgetastic.patternfly==1.1.0
 widgetsnbextension==3.4.2
-wrapanapi==3.4.0
+wrapanapi==3.4.1
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0


### PR DESCRIPTION
:heavy_check_mark:  requires https://github.com/ManageIQ/wrapanapi/pull/419
:stop_sign:  5.10.11 blocker found by test run https://bugzilla.redhat.com/show_bug.cgi?id=1756984 

{{ pytest: cfme/tests/cloud/test_providers.py::test_refresh_with_empty_iot_hub_azure -v --use-provider azure }}