### PR TITLE
[1LP][RFR] Adding RHEL upgrade to Temporary Appliances for Interop Testing

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -58,6 +58,16 @@ def sprout_appliances(
         lease_time=lease_time,
         **kwargs
     )
+
+    if config.getoption("update_appliance"):
+        for app in apps:
+            logger.info("Initiating appliance update on temp appliance ...")
+            urls = config.getoption("update_urls")
+            app.update_rhel(*urls, reboot=True)
+            logger.info("Appliance update finished on temp appliance, waiting for UI ...")
+            app.wait_for_web_ui()
+            logger.info("Appliance update finished on temp appliance...")
+
     try:
         yield apps
     finally:


### PR DESCRIPTION
{{ pytest: cfme/tests/cli/test_appliance_console.py::test_appliance_console_scap --update-url http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/RHEL-7.8-20190912.3/compose/Server/x86_64/os/ --update-appliance }}