### PR TITLE
[1LP][RFR] Adding rhel_testing markers back on test_appliance_console_scap

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -521,6 +521,7 @@ def test_appliance_console_external_auth_all(configured_appliance):
     assert evm_tail.validate(wait="30s")
 
 
+@pytest.mark.rhel_testing
 @pytest.mark.tier(2)
 def test_appliance_console_scap(temp_appliance_preconfig, soft_assert):
     """ Commands:


### PR DESCRIPTION
Adding `rhel_testing` marker back on to `test_appliance_console_scap`. Orginally removed because it was using temp appliance but  https://github.com/ManageIQ/integration_tests/pull/9403 should handle the upgrade