### PR TITLE
[1LP][RFR] Removed ignore stream and updated global fixture

### DIFF
--- a/cfme/fixtures/automate.py
+++ b/cfme/fixtures/automate.py
@@ -61,11 +61,11 @@ def custom_instance(request_cls):
     type of automate method."""
     def method(ruby_code):
         meth = request_cls.methods.create(
-            name=fauxfactory.gen_alphanumeric(start="meth_", length=6), script=ruby_code
+            name=fauxfactory.gen_alphanumeric(start="meth_", length=10), script=ruby_code
         )
 
         instance = request_cls.instances.create(
-            name=fauxfactory.gen_alphanumeric(start="inst_", length=6),
+            name=fauxfactory.gen_alphanumeric(start="inst_", length=10),
             fields={"meth1": {"value": meth.name}},
         )
         return instance

--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -188,12 +188,13 @@ def test_miq_password_decrypt(klass):
 
 
 @pytest.mark.tier(1)
+@pytest.mark.customer_scenario
 @pytest.mark.meta(automates=[1700524])
-@pytest.mark.ignore_stream("5.10")
 def test_service_retirement_from_automate_method(request, generic_catalog_item, custom_instance):
     """
     Bugzilla:
         1700524
+        1753669
 
     Polarion:
         assignee: ghubale


### PR DESCRIPTION
## Purpose or Intent
- BZ(1700524) is fixed for 5.10.11.0. So need to remove ```ignore_stream```.
- Improved length of the instance and method names created in custom instance global fixture.
### PRT Run
{{ pytest: cfme/tests/automate/test_common_methods.py::test_service_retirement_from_automate_method --use-template-cache -qsvvv }}