### PR TITLE
[1LP][WIPTEST] Add test_compare_hosts_from_provider_allhosts to test_host.py

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -309,7 +309,9 @@ class HostsCompareView(ComputeInfrastructureHostsView):
     def is_displayed(self):
         title = "Compare Host / Node"
         return (self.logged_in_as_current_user and
-                self.title.text == title)
+                self.title.text == title and
+                self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Hosts']
+                )
 
 
 class ProviderAllHostsView(HostsView):

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -302,6 +302,18 @@ class HostsEditView(HostEditView):
         return self.in_compute_infrastructure_hosts and self.title.text == 'Credentials/Settings'
 
 
+class HostsCompareView(ComputeInfrastructureHostsView):
+    """Compare Host / Node page."""
+
+    @property
+    def is_displayed(self):
+        title = "Compare Host / Node"
+        return (self.logged_in_as_current_user and
+                # self.navigation.currently_selected == ['Compute', 'Infrastructure',
+                #                                       'Hosts', 'Compare Host / Node'] and
+                self.title.text == title)
+
+
 class ProviderAllHostsView(HostsView):
     """
     This view is used in Provider and HostCollection contexts

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -309,8 +309,6 @@ class HostsCompareView(ComputeInfrastructureHostsView):
     def is_displayed(self):
         title = "Compare Host / Node"
         return (self.logged_in_as_current_user and
-                # self.navigation.currently_selected == ['Compute', 'Infrastructure',
-                #                                       'Hosts', 'Compare Host / Node'] and
                 self.title.text == title)
 
 

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -7,8 +7,8 @@ from wait_for import TimedOutError
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
-from cfme.common.host_views import HostsEditView
 from cfme.common.host_views import HostsCompareView
+from cfme.common.host_views import HostsEditView
 from cfme.common.provider_views import InfraProviderDetailsView
 from cfme.common.provider_views import ProviderNodesView
 from cfme.fixtures.provider import setup_or_skip

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -454,10 +454,11 @@ def test_compare_hosts_from_provider_allhosts(appliance, setup_provider_min_host
 
     """
     hosts_view = navigate_to(provider.collections.hosts, "All")
-    num_hosts = len(hosts_view.entities.get_all())
+    ent_slice = slice(0,2,None)
+    num_hosts = hosts_view.entities.paginator.items_amount
     if num_hosts < 2:
         pytest.skip('not enough hosts in appliance UI to run test')
-    for h in hosts_view.entities.get_all():
+    for h in hosts_view.entities.get_all(slice=ent_slice):
         h.check()
     hosts_view.toolbar.configuration.item_select('Compare Selected items',
                                                  handle_alert=True)

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -8,6 +8,7 @@ from wait_for import TimedOutError
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.host_views import HostsEditView
+from cfme.common.host_views import HostsCompareView
 from cfme.common.provider_views import InfraProviderDetailsView
 from cfme.common.provider_views import ProviderNodesView
 from cfme.fixtures.provider import setup_or_skip
@@ -25,6 +26,7 @@ from cfme.utils.conf import credentials
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for
 
+from cfme.common.host_views import ComputeInfrastructureHostsView
 
 pytestmark = [
     pytest.mark.tier(3),
@@ -438,3 +440,28 @@ def test_infrastructure_hosts_navigation_after_download(
         assert provider_view.is_displayed
     elif hosts_collection == "appliance":
         assert hosts_view.is_displayed
+
+
+@test_requirements.infra_hosts
+#@pytest.mark.meta(blockers=[BZ(1746214, forced_streams=["5.10"])], automates=[1746214])
+def test_compare_hosts_from_provider_allhosts(appliance, setup_provider_min_hosts, provider):
+    """
+    Polarion:
+        assignee: prichard
+        casecomponent: Infra
+        caseimportance: high
+        initialEstimate: 1/6h
+    Bugzilla:
+        1746214
+
+    """
+    hosts_view = navigate_to(provider.collections.hosts, "All")
+    num_hosts = len(hosts_view.entities.get_all())
+    if num_hosts < 2:
+        pytest.skip('not enough hosts in appliance UI to run test')
+    for h in hosts_view.entities.get_all():
+        h.check()
+    hosts_view.toolbar.configuration.item_select('Compare Selected items',
+                                                 handle_alert=True)
+    compare_hosts_view = provider.create_view(HostsCompareView)
+    assert compare_hosts_view.is_displayed

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -454,7 +454,7 @@ def test_compare_hosts_from_provider_allhosts(appliance, setup_provider_min_host
 
     """
     hosts_view = navigate_to(provider.collections.hosts, "All")
-    ent_slice = slice(0,2,None)
+    ent_slice = slice(0, 2, None)
     num_hosts = hosts_view.entities.paginator.items_amount
     if num_hosts < 2:
         pytest.skip('not enough hosts in appliance UI to run test')

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -26,8 +26,6 @@ from cfme.utils.conf import credentials
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for
 
-from cfme.common.host_views import ComputeInfrastructureHostsView
-
 pytestmark = [
     pytest.mark.tier(3),
     pytest.mark.provider([InfraProvider],
@@ -443,7 +441,7 @@ def test_infrastructure_hosts_navigation_after_download(
 
 
 @test_requirements.infra_hosts
-#@pytest.mark.meta(blockers=[BZ(1746214, forced_streams=["5.10"])], automates=[1746214])
+@pytest.mark.meta(blockers=[BZ(1746214, forced_streams=["5.10"])], automates=[1746214])
 def test_compare_hosts_from_provider_allhosts(appliance, setup_provider_min_hosts, provider):
     """
     Polarion:


### PR DESCRIPTION
## Purpose or Intent

- __Adding test__ for BZ 1746214, opened in 5.10.9. Fix is slated for 5.11.1.


### PRT Run
{{ pytest: --use-provider complete --long-running cfme/tests/infrastructure/test_host.py::test_compare_hosts_from_provider_allhosts }}