### PR TITLE
[1LP][RFR] Update pytest-polarion-collect, add pytest-report-parameters

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,6 +1,4 @@
 azure-storage-common==1.4.0
-dump2polarion==0.40.0
 pdfminer.six==20181108
-pytest-polarion-collect==0.17.1
 pytest<=3.4.1
 websocket-client<=0.40.2,>=0.32.0

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -114,7 +114,7 @@ cmd2==0.9.11
 colorama==0.4.1
 cryptography==2.6.1
 cycler==0.10.0
-dateparser==0.7.1
+dateparser==0.7.2
 debtcollector==1.22.0
 decorator==4.4.0
 dectate==0.13
@@ -128,7 +128,7 @@ docker-py==1.10.6
 docker-pycreds==0.4.0
 docutils==0.15.2
 dogpile.cache==0.7.1
-dump2polarion==0.40.0
+dump2polarion==0.45.0
 entrypoints==0.3
 fauxfactory==3.0.6
 flake8==3.7.8
@@ -255,7 +255,8 @@ pyparsing==2.4.0
 pyperclip==1.7.0
 pytesseract==0.3.0
 pytest==3.4.1
-pytest-polarion-collect==0.17.1
+pytest-polarion-collect==0.21.0
+pytest-report-parameters==0.5.0
 python-box==3.2.4
 python-bugzilla==2.3.0
 python-cinderclient==4.1.0
@@ -322,7 +323,7 @@ tornado==6.0.2
 traitlets==4.3.2
 tzlocal==2.0.0
 uritemplate==3.0.0
-urllib3==1.25.3
+urllib3==1.25.6
 virtualenv==16.4.3
 vspk==5.3.2
 wait-for==1.1.0
@@ -330,7 +331,7 @@ warlock==1.3.0
 wcwidth==0.1.7
 webencodings==0.5.1
 websocket-client==0.40.0
-Werkzeug==0.15.6
+Werkzeug==0.16.0
 widgetastic.core==0.39
 widgetastic.patternfly==1.1.0
 widgetsnbextension==3.4.2

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -270,7 +270,7 @@ wait-for==1.1.0
 warlock==1.3.0
 wcwidth==0.1.7
 websocket-client==0.40.0
-Werkzeug==0.15.2
+Werkzeug==0.16.0
 widgetastic.core==0.39
 widgetastic.patternfly==1.0.0
 widgetsnbextension==3.4.2

--- a/requirements/template_non_imported.txt
+++ b/requirements/template_non_imported.txt
@@ -7,5 +7,7 @@ dump2polarion
 flake8
 pdfminer.six
 polarion-docstrings
+polarion-tools-common
 pre-commit
 pytest-polarion-collect
+pytest-report-parameters


### PR DESCRIPTION
Bump Werkzeug for docs to get rid of security alert as well.

Issues with parallelizer remote collection have been resolved in pytest-polarion-collect 0.21, tested locally.