### PR TITLE
Downgrade cfme-testcases to 0.12, conf loading broken

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,4 +1,6 @@
 azure-storage-common==1.4.0
+cfme-testcases==0.12
+dump2polarion==0.44
 pdfminer.six==20181108
 pytest<=3.4.1
 websocket-client<=0.40.2,>=0.32.0

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -106,7 +106,7 @@ cachetools==3.1.0
 certifi==2019.3.9
 cffi==1.12.2
 cfgv==2.0.1
-cfme-testcases==0.15.1
+cfme-testcases==0.12
 chardet==3.0.4
 Click==7.0
 cliff==2.14.1
@@ -128,7 +128,7 @@ docker-py==1.10.6
 docker-pycreds==0.4.0
 docutils==0.15.2
 dogpile.cache==0.7.1
-dump2polarion==0.45.0
+dump2polarion==0.44.0
 entrypoints==0.3
 fauxfactory==3.0.6
 flake8==3.7.8


### PR DESCRIPTION
Setting of testrun ID via configuration isn't working in cfme-testcases 0.15.1, change came in at 0.13.
dump2polarion downgrade as well, upgrade both together when cfme-testcases issue #1 is resolved