### PR TITLE
[1LP][RFR] Fix logic for whether server or zone display as current

### DIFF
--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -266,13 +266,13 @@ def test_collect_unconfigured(appliance):
     assert not view_zone.toolbar.collect.is_displayed
 
 
-@pytest.mark.parametrize('from_slave', [True, False], ids=['from_slave', 'from_master'])
+@pytest.mark.parametrize('from_secondary', [True, False], ids=['from_secondary', 'from_current'])
 @pytest.mark.parametrize('zone_collect', [True, False], ids=['zone_collect', 'server_collect'])
 @pytest.mark.parametrize('collect_type', ['all', 'current'], ids=['collect_all', 'collect_current'])
 @pytest.mark.tier(3)
 def test_collect_multiple_servers(log_depot, temp_appliance_preconfig, depot_machine_ip, request,
                                   configured_external_appliance, zone_collect, collect_type,
-                                  from_slave):
+                                  from_secondary):
 
     """
     Polarion:
@@ -302,7 +302,7 @@ def test_collect_multiple_servers(log_depot, temp_appliance_preconfig, depot_mac
     with appliance:
         uri = '{}{}'.format(log_depot.machine_ip, log_depot.access_dir)
         with update(collect_logs):
-            collect_logs.second_server_collect = from_slave
+            collect_logs.second_server_collect = from_secondary
             collect_logs.depot_type = log_depot.protocol
             collect_logs.depot_name = fauxfactory.gen_alphanumeric()
             collect_logs.uri = uri
@@ -314,14 +314,14 @@ def test_collect_multiple_servers(log_depot, temp_appliance_preconfig, depot_mac
         else:
             collect_logs.collect_current()
 
-    slave_servers = appliance.server.slave_servers
-    first_slave_server = slave_servers[0] if slave_servers else None
+    secondary_servers = appliance.server.secondary_servers
+    secondary_server = secondary_servers[0] if secondary_servers else None
 
-    if from_slave and zone_collect:
-        check_ftp(appliance, log_depot.ftp, first_slave_server.name, first_slave_server.sid)
+    if from_secondary and zone_collect:
+        check_ftp(appliance, log_depot.ftp, secondary_server.name, secondary_server.sid)
         check_ftp(appliance, log_depot.ftp, appliance.server.name, appliance.server.zone.id)
-    elif from_slave:
-        check_ftp(appliance, log_depot.ftp, first_slave_server.name, first_slave_server.sid)
+    elif from_secondary:
+        check_ftp(appliance, log_depot.ftp, secondary_server.name, secondary_server.sid)
     else:
         check_ftp(appliance, log_depot.ftp, appliance.server.name, appliance.server.zone.id)
 

--- a/cfme/tests/configure/test_paginator.py
+++ b/cfme/tests/configure/test_paginator.py
@@ -7,6 +7,7 @@ from cfme import test_requirements
 from cfme.configure.configuration.region_settings import RedHatUpdates
 from cfme.utils.appliance.implementations.ui import navigate_to
 
+
 general_list_pages = [
     ('servers', None, 'Details', False),
     ('servers', None, 'Authentication', False),
@@ -113,9 +114,9 @@ def test_paginator_config_pages(appliance, place_info):
         if place_name == 'regions':
             test_class = test_class.instantiate()
         elif place_name == 'servers':
-            test_class = test_class.get_master()
+            test_class = appliance.server
         elif place_name == 'zones':
-            test_class = appliance.collections.servers.get_master().zone
+            test_class = appliance.server.zone
     view = navigate_to(test_class, place_navigation)
     assert check_paginator_for_page(view) == paginator_expected_result
 

--- a/cfme/tests/configure/test_remote_server_tabs.py
+++ b/cfme/tests/configure/test_remote_server_tabs.py
@@ -32,7 +32,7 @@ def test_remote_server_advanced_config(temp_appliance_preconfig, request,
         casecomponent: Configuration
     """
     appliance = temp_appliance_preconfig
-    remote_server = appliance.server.slave_servers[0]
+    remote_server = appliance.server.secondary_servers[0]
     #  Advanced tab exists for remote servers
     navigate_to(remote_server, 'Advanced')
 


### PR DESCRIPTION
Navigation within the configuration accordion requires special logic to determine whether the string '(current)' follows a zone or server. The logic currently used by the views and navigation classes in cfme.base.ui, however, is incorrect. It assumes that '(current)' is displayed for the master server (and its associated zone) in a multi-appliance/zone environment. The actual logic, however, is based on whether the web UI request was handled by that server. E.g., if there are two appliances, both of which have the 'User Interface' server role, then a browser connecting to server A will show server A and its zone as 'current', whereas a browser connecting to server B will show server B and its zone as 'current'.

This PR updates the logic in cfme/base/ui.py, and like recent PR #9382 , it avoids redundant code by moving the associated logic into the Server, Zone, and Region classes in cfme/base/__init__.py as 'tree_path' and 'diagnostics_tree_path' properties. Also, view and navigation classes in cfme/configure/configuration/diagnostics_settings.py explicitly used 'Master' and 'Slave' in their names. To avoid confusion, these have been renamed:

Master -> First
Slave -> Second

{{ pytest: cfme/tests/configure/test_paginator.py cfme/tests/configure/test_remote_server_tabs.py -v }}