### PR TITLE
[WIPTEST] Remove uses of uncollectif where provider markers should be used

### DIFF
--- a/cfme/tests/automate/custom_button/__init__.py
+++ b/cfme/tests/automate/custom_button/__init__.py
@@ -9,21 +9,6 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Dropdown
 
 
-OBJ_TYPE_59 = [
-    "CLOUD_TENANT",
-    "CLOUD_VOLUME",
-    "CLUSTERS",
-    "CONTAINER_NODES",
-    "CONTAINER_PROJECTS",
-    "DATASTORES",
-    "GENERIC",
-    "HOSTS",
-    "PROVIDER",
-    "SERVICE",
-    "TEMPLATE_IMAGE",
-    "VM_INSTANCE",
-]
-
 OBJ_TYPE = [
     "AZONE",
     "CLOUD_NETWORK",

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -12,7 +12,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.tests.automate.custom_button import log_request_check
 from cfme.tests.automate.custom_button import OBJ_TYPE
-from cfme.tests.automate.custom_button import OBJ_TYPE_59
 from cfme.tests.automate.custom_button import TextInputDialogView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -41,9 +40,6 @@ def buttongroup(appliance):
 # IMPORTANT: This is a canonical test. It shows how a proper test should look like under new order.
 @pytest.mark.sauce
 @pytest.mark.tier(1)
-@pytest.mark.uncollectif(
-    lambda appliance, obj_type: obj_type not in OBJ_TYPE_59 and appliance.version < "5.10"
-)
 @pytest.mark.parametrize("obj_type", OBJ_TYPE, ids=[obj.capitalize() for obj in OBJ_TYPE])
 def test_button_group_crud(request, appliance, obj_type):
     """Test crud operation for Button Group
@@ -103,9 +99,6 @@ def test_button_group_crud(request, appliance, obj_type):
 
 @pytest.mark.sauce
 @pytest.mark.tier(1)
-@pytest.mark.uncollectif(
-    lambda appliance, obj_type: obj_type not in OBJ_TYPE_59 and appliance.version < "5.10"
-)
 @pytest.mark.parametrize("obj_type", OBJ_TYPE, ids=[obj.capitalize() for obj in OBJ_TYPE])
 def test_button_crud(appliance, dialog, request, buttongroup, obj_type):
     """Test crud operation for Custom Button
@@ -416,10 +409,6 @@ def test_custom_button_simulation(request, appliance, provider, setup_provider, 
         assert False, "Requests not found in automation log"
 
 
-@pytest.mark.uncollectif(
-    lambda appliance, button_tag: appliance.version < "5.10" and button_tag == "Evm",
-    reason="Evm objects not available in lower version",
-)
 @pytest.mark.parametrize("button_tag", ["Evm", "Build"])
 @pytest.mark.provider([VMwareProvider], override=True, scope="module", selector=ONE_PER_TYPE)
 def test_custom_button_order_sort(appliance, request, provider, setup_provider, button_tag):

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -8,7 +8,6 @@ from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.tests.automate.custom_button import log_request_check
-from cfme.tests.automate.custom_button import OBJ_TYPE_59
 from cfme.tests.automate.custom_button import TextInputDialogView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -101,10 +100,6 @@ def setup_objs(button_group, provider):
 
 
 @pytest.mark.tier(1)
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
-    and appliance.version < "5.10"
-)
 @pytest.mark.parametrize(
     "display",
     list(DISPLAY_NAV.keys()), ids=["_".join(item.split()) for item in DISPLAY_NAV.keys()]
@@ -151,10 +146,6 @@ def test_custom_button_display_cloud_obj(appliance, request, display, setup_objs
 
 
 @pytest.mark.meta(automates=[1635797, 1574403, 1640592, 1710350, 1732436])
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
-    and appliance.version < "5.10"
-)
 def test_custom_button_dialog_cloud_obj(appliance, dialog, request, setup_objs, button_group):
     """ Test custom button with dialog and InspectMe method
 
@@ -232,10 +223,6 @@ def test_custom_button_dialog_cloud_obj(appliance, dialog, request, setup_objs, 
 
 
 @pytest.mark.meta(automates=[1628224])
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
-    and appliance.version < "5.10"
-)
 @pytest.mark.parametrize("submit", SUBMIT, ids=[item.replace(" ", "_") for item in SUBMIT])
 def test_custom_button_automate_cloud_obj(appliance, request, submit, setup_objs, button_group):
     """ Test custom button for automate and requests count as per submit
@@ -330,10 +317,6 @@ def test_custom_button_automate_cloud_obj(appliance, request, submit, setup_objs
                 )
 
 
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
-    and appliance.version < "5.10"
-)
 @pytest.mark.parametrize("expression", ["enablement", "visibility"])
 def test_custom_button_expression_cloud_obj(
     appliance, request, setup_objs, button_group, expression
@@ -403,7 +386,9 @@ def test_custom_button_expression_cloud_obj(
 
 
 @pytest.mark.meta(
-    blockers=[BZ(1680525, unblock=lambda button_group: "CLOUD_NETWORK" not in button_group)]
+    blockers=[BZ(1680525,
+                 unblock=lambda button_group: "CLOUD_NETWORK" not in button_group,
+                 forced_streams=['5.10'])]
 )
 @pytest.mark.parametrize("btn_dialog", [False, True], ids=["simple", "dialog"])
 def test_custom_button_events_cloud_obj(request, dialog, setup_objs, button_group, btn_dialog):

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -8,7 +8,6 @@ from cfme import test_requirements
 from cfme.containers.provider import ContainersProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.tests.automate.custom_button import log_request_check
-from cfme.tests.automate.custom_button import OBJ_TYPE_59
 from cfme.tests.automate.custom_button import TextInputDialogView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
@@ -21,7 +20,6 @@ pytestmark = [
     test_requirements.custom_button,
     pytest.mark.usefixtures("setup_provider"),
     pytest.mark.provider([ContainersProvider], selector=ONE_PER_TYPE),
-    pytest.mark.meta(blockers=[BZ(1640304, forced_streams=["5.10"])]),
 ]
 
 CONTAINER_OBJECTS = [
@@ -74,10 +72,6 @@ def setup_obj(appliance, provider, button_group):
 
 
 @pytest.mark.tier(1)
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
-    and appliance.version < "5.10"
-)
 @pytest.mark.parametrize(
     "display",
     list(DISPLAY_NAV.keys()),
@@ -125,10 +119,6 @@ def test_custom_button_display_container_obj(request, display, setup_obj, button
 
 
 @pytest.mark.meta(automates=[1729903, 1732489])
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
-    and appliance.version < "5.10"
-)
 def test_custom_button_dialog_container_obj(appliance, dialog, request, setup_obj, button_group):
     """ Test custom button with dialog and InspectMe method
 
@@ -198,10 +188,6 @@ def test_custom_button_dialog_container_obj(appliance, dialog, request, setup_ob
         assert False, "Expected 1 requests not found in automation log"
 
 
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: not bool([obj for obj in OBJ_TYPE_59 if obj in button_group])
-    and appliance.version < "5.10"
-)
 @pytest.mark.parametrize("expression", ["enablement", "visibility"])
 def test_custom_button_expression_container_obj(
     appliance, request, setup_obj, button_group, expression

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -121,9 +121,6 @@ def setup_obj(button_group, provider):
 @pytest.mark.parametrize(
     "display", DISPLAY_NAV.keys(), ids=["_".join(item.split()) for item in DISPLAY_NAV.keys()]
 )
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: appliance.version < "5.10" and "SWITCH" in button_group
-)
 def test_custom_button_display_infra_obj(request, display, setup_obj, button_group):
     """ Test custom button display on a targeted page
 
@@ -174,12 +171,6 @@ def test_custom_button_display_infra_obj(request, display, setup_obj, button_gro
 
 
 @pytest.mark.parametrize("submit", SUBMIT, ids=["_".join(item.split()) for item in SUBMIT])
-@pytest.mark.meta(
-    blockers=[BZ(1628224, forced_streams=["5.10"], unblock=lambda submit: submit != "Submit all")]
-)
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: appliance.version < "5.10" and "SWITCH" in button_group
-)
 def test_custom_button_automate_infra_obj(appliance, request, submit, setup_obj, button_group):
     """ Test custom button for automate and requests count as per submit
 
@@ -277,10 +268,8 @@ def test_custom_button_automate_infra_obj(appliance, request, submit, setup_obj,
 
 
 @pytest.mark.meta(
-    blockers=[BZ(1685555, unblock=lambda button_group: "SWITCH" not in button_group)]
-)
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: appliance.version < "5.10" and "SWITCH" in button_group
+    blockers=[BZ(1685555,
+                 unblock=lambda button_group: "SWITCH" not in button_group)]
 )
 def test_custom_button_dialog_infra_obj(appliance, dialog, request, setup_obj, button_group):
     """ Test custom button with dialog and InspectMe method
@@ -358,9 +347,6 @@ def test_custom_button_dialog_infra_obj(appliance, dialog, request, setup_obj, b
 
 
 @pytest.mark.parametrize("expression", ["enablement", "visibility"])
-@pytest.mark.uncollectif(
-    lambda appliance, button_group: appliance.version < "5.10" and "SWITCH" in button_group
-)
 def test_custom_button_expression_infra_obj(
     appliance, request, setup_obj, button_group, expression
 ):

--- a/cfme/tests/automate/custom_button/test_rest_custom_button.py
+++ b/cfme/tests/automate/custom_button/test_rest_custom_button.py
@@ -5,7 +5,6 @@ from cfme import test_requirements
 from cfme.rest import gen_data
 from cfme.tests.automate.custom_button import CLASS_MAP
 from cfme.tests.automate.custom_button import OBJ_TYPE
-from cfme.tests.automate.custom_button import OBJ_TYPE_59
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.rest import assert_response
@@ -17,9 +16,6 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     pytest.mark.tier(3),
     test_requirements.custom_button,
-    pytest.mark.uncollectif(
-        lambda appliance, obj_type: obj_type not in OBJ_TYPE_59 and appliance.version < "5.10"
-    ),
     pytest.mark.parametrize("obj_type", OBJ_TYPE, ids=[obj.capitalize() for obj in OBJ_TYPE],
                             scope="module"),
 ]

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -276,8 +276,10 @@ def test_custom_button_automate_service_obj(
         # for 5.10 group ui
         BZ(
             1659452,
-            unblock=lambda serv_button_group, context: "button" in serv_button_group
-            or ("group" in serv_button_group and context == ViaSSUI),
+            unblock=lambda serv_button_group, context: "button" in serv_button_group or
+                                                       ("group" in serv_button_group and
+                                                        context == ViaSSUI),
+            forced_streams=['5.10']
         ),
         # for 5.10 and 5.11 group ssui
         BZ(

--- a/cfme/tests/candu/test_azone_graph.py
+++ b/cfme/tests/candu/test_azone_graph.py
@@ -43,8 +43,9 @@ def azone(appliance, provider):
         unblock=lambda provider, graph_type: not provider.one_of(AzureProvider) and
         graph_type != "azone_memory")]
 )
-@pytest.mark.uncollectif(lambda provider, graph_type: provider.one_of(EC2Provider)
-    and graph_type == "azone_disk")
+@pytest.mark.uncollectif(lambda provider, graph_type:
+                         provider.one_of(EC2Provider) and graph_type == "azone_disk",
+                         reason='azone_disk graph not supported on EC2')
 def test_azone_graph_screen(provider, azone, graph_type, interval, enable_candu):
     """Test Availibility zone graphs for Hourly
 

--- a/cfme/tests/candu/test_host_graph.py
+++ b/cfme/tests/candu/test_host_graph.py
@@ -8,7 +8,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.tests.candu import compare_data
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 
@@ -19,7 +18,6 @@ pytestmark = [
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.provider([VMwareProvider, RHEVMProvider], selector=ONE_PER_TYPE,
                          required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')]),
-    pytest.mark.meta(blockers=[BZ(1635126, forced_streams=['5.10'])])
 ]
 
 
@@ -49,8 +47,8 @@ def host(appliance, provider):
 
 
 @pytest.mark.uncollectif(lambda provider, graph_type:
-                         provider.one_of(RHEVMProvider) and
-                         graph_type == "host_disk")
+                         provider.one_of(RHEVMProvider) and graph_type == "host_disk",
+                         reason='host_disk graph type not supported on RHEVM')
 @pytest.mark.parametrize('graph_type', HOST_RECENT_HR_GRAPHS)
 def test_host_most_recent_hour_graph_screen(graph_type, provider, host, enable_candu):
     """ Test Host graphs for most recent hour displayed or not
@@ -106,8 +104,8 @@ def test_host_most_recent_hour_graph_screen(graph_type, provider, host, enable_c
 
 
 @pytest.mark.uncollectif(lambda provider, graph_type:
-                         provider.one_of(RHEVMProvider) and
-                         graph_type == "host_disk")
+                         provider.one_of(RHEVMProvider) and graph_type == "host_disk",
+                         reason='host_disk graph type not supported on RHEVM')
 @pytest.mark.parametrize('interval', INTERVAL)
 @pytest.mark.parametrize('graph_type', HOST_GRAPHS)
 def test_host_graph_screen(provider, interval, graph_type, host, enable_candu):

--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -5,7 +5,6 @@ from operator import attrgetter
 import pytest
 
 from cfme import test_requirements
-from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
@@ -187,8 +186,11 @@ def test_raw_metric_vm_network(metrics_collection, appliance, provider):
 
 
 @pytest.mark.rhv2
-@pytest.mark.uncollectif(
-    lambda provider: provider.one_of(EC2Provider))
+@pytest.mark.provider(
+    [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider, GCEProvider],
+    required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    override=True
+)
 @pytest.mark.meta(automates=[BZ(1671580)])
 def test_raw_metric_vm_disk(metrics_collection, appliance, provider):
     """
@@ -209,7 +211,11 @@ def test_raw_metric_vm_disk(metrics_collection, appliance, provider):
 
 
 @pytest.mark.rhv2
-@pytest.mark.uncollectif(lambda provider: provider.one_of(CloudProvider))
+@pytest.mark.provider(
+    [VMwareProvider, RHEVMProvider],
+    required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    override=True
+)
 def test_raw_metric_host_cpu(metrics_collection, appliance, provider):
     """
     Polarion:
@@ -228,7 +234,11 @@ def test_raw_metric_host_cpu(metrics_collection, appliance, provider):
 
 
 @pytest.mark.rhv2
-@pytest.mark.uncollectif(lambda provider: provider.one_of(CloudProvider))
+@pytest.mark.provider(
+    [VMwareProvider, RHEVMProvider],
+    required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    override=True
+)
 def test_raw_metric_host_memory(metrics_collection, appliance, provider):
     """
     Polarion:
@@ -248,7 +258,11 @@ def test_raw_metric_host_memory(metrics_collection, appliance, provider):
 
 
 @pytest.mark.rhv2
-@pytest.mark.uncollectif(lambda provider: provider.one_of(CloudProvider))
+@pytest.mark.provider(
+    [VMwareProvider, RHEVMProvider],
+    required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    override=True
+)
 def test_raw_metric_host_network(metrics_collection, appliance, provider):
     """
     Polarion:
@@ -267,7 +281,11 @@ def test_raw_metric_host_network(metrics_collection, appliance, provider):
 
 
 @pytest.mark.rhv2
-@pytest.mark.uncollectif(lambda provider: provider.one_of(CloudProvider))
+@pytest.mark.provider(
+    [VMwareProvider, RHEVMProvider],
+    required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    override=True
+)
 def test_raw_metric_host_disk(metrics_collection, appliance, provider):
     """
     Polarion:

--- a/cfme/tests/candu/test_vm_graph.py
+++ b/cfme/tests/candu/test_vm_graph.py
@@ -34,11 +34,12 @@ INTERVAL = ['Hourly', 'Daily']
 
 # ToDo: Currently disk activity for EC2 not collecting due to infra issue.
 # collect test as infra issue resolves.
-@pytest.mark.uncollectif(lambda provider, graph_type:
-                         ((provider.one_of(RHEVMProvider) or provider.one_of(AzureProvider)) and
-                          graph_type == "vm_cpu_state") or
-                         (provider.one_of(EC2Provider) and
-                          graph_type in ["vm_cpu_state", "vm_memory", "vm_disk"]))
+@pytest.mark.uncollectif(
+    lambda provider, graph_type:
+        (provider.one_of(RHEVMProvider, AzureProvider) and graph_type == "vm_cpu_state") or
+        (provider.one_of(EC2Provider) and graph_type in ["vm_cpu_state", "vm_memory", "vm_disk"]),
+    reason='Invalid graph_type and provider type combination'
+)
 @pytest.mark.parametrize('graph_type', VM_GRAPHS)
 def test_vm_most_recent_hour_graph_screen(graph_type, provider, enable_candu):
     """ Test VM graphs for most recent hour displayed or not
@@ -95,13 +96,13 @@ def test_vm_most_recent_hour_graph_screen(graph_type, provider, enable_candu):
     assert graph_data > 0
 
 
-@pytest.mark.uncollectif(lambda provider, interval, graph_type:
-                         ((provider.one_of(RHEVMProvider) or provider.one_of(AzureProvider)) and
-                          graph_type == "vm_cpu_state") or
-                         (provider.one_of(EC2Provider) and
-                          graph_type in ["vm_cpu_state", "vm_memory", "vm_disk"]) or
-                         ((provider.one_of(CloudProvider) or provider.one_of(RHEVMProvider)) and
-                         interval == 'Daily'))
+@pytest.mark.uncollectif(
+    lambda provider, interval, graph_type:
+        (provider.one_of(RHEVMProvider, AzureProvider) and graph_type == "vm_cpu_state") or
+        (provider.one_of(EC2Provider) and graph_type in ["vm_cpu_state", "vm_memory", "vm_disk"]) or
+        (provider.one_of(CloudProvider, RHEVMProvider) and interval == 'Daily'),
+    reason='Invalid combintation of graph_type or interval and provider type'
+)
 @pytest.mark.parametrize('interval', INTERVAL)
 @pytest.mark.parametrize('graph_type', VM_GRAPHS)
 def test_vm_graph_screen(provider, interval, graph_type, enable_candu):

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -154,7 +154,6 @@ def test_keypair_create_invalid_key_validation(provider, appliance):
 
 
 @test_requirements.tag
-@pytest.mark.uncollectif(lambda provider: provider.one_of(EC2Provider))
 @pytest.mark.provider([OpenStackProvider], override=True, scope="module", selector=ONE_PER_TYPE)
 def test_keypair_add_and_remove_tag(keypair):
     """ This will test whether it will add and remove tag for newly created Keypair or not

--- a/cfme/tests/cloud_infra_common/test_cockpit_server.py
+++ b/cfme/tests/cloud_infra_common/test_cockpit_server.py
@@ -5,28 +5,35 @@ from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
+from cfme.markers.env_markers.provider import providers
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.generators import random_vm_name
+from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
 
 
 @pytest.fixture(scope="function")
-def new_vm(appliance, provider, request):
-    if provider.one_of(CloudProvider):
-        vm = appliance.collections.cloud_instances.instantiate(random_vm_name(context='cockpit'),
-                                                               provider)
-    else:
-        vm = appliance.collections.infra_vms.instantiate(random_vm_name(context='cockpit'),
-                                                         provider)
+def new_vm(appliance, provider):
+    collection = appliance.provider_based_collection(provider)
+    vm = collection.instantiate(random_vm_name(context='cockpit'), provider)
+
+    created = False
     if not provider.mgmt.does_vm_exist(vm.name):
+        created = True
         vm.create_on_provider(find_in_cfme=True, allow_skip="default")
-        request.addfinalizer(vm.cleanup_on_provider)
-    return vm
+    yield vm
+
+    if created:
+        vm.cleanup_on_provider()
 
 
 @pytest.mark.rhv3
-@pytest.mark.uncollectif(lambda provider: provider.one_of(GCEProvider))
-@pytest.mark.provider([CloudProvider, InfraProvider], selector=ONE_PER_TYPE)
+@pytest.mark.provider(
+    gen_func=providers,
+    filters=[
+        ProviderFilter(classes=[CloudProvider, InfraProvider], selector=ONE_PER_TYPE),
+        ProviderFilter(classes=[GCEProvider], inverted=True)]
+)
 @pytest.mark.parametrize('enable', [False, True], ids=['disabled', 'enabled'])
 def test_cockpit_server_role(appliance, provider, setup_provider, new_vm, enable):
     """ The test checks the cockpit "Web Console" button enable and disabled working.

--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -8,7 +8,9 @@ from cfme.cloud.provider.gce import GCEProvider
 from cfme.common.provider import BaseProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
+from cfme.markers.env_markers.provider import providers
 from cfme.utils.generators import random_vm_name
+from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
 
 
@@ -177,8 +179,11 @@ def test_suspend_vm_rest(appliance, vm_obj, ensure_vm_running, soft_assert, from
         soft_assert(verify_vm_power_state(vm, vm_obj.STATE_SUSPENDED), "vm not suspended")
 
 
-@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider, AzureProvider),
-                         reason='Not supported for RHV or Azure provider')
+@pytest.mark.provider(
+    gen_func=providers,
+    filters=[ProviderFilter(BaseProvider),
+             ProviderFilter([RHEVMProvider, AzureProvider], inverted=True)]
+)
 def test_reset_vm_rest(vm_obj, ensure_vm_running, from_detail, appliance):
     """
     Test reset vm

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -24,9 +24,8 @@ pytestmark = [
     pytest.mark.tier(1),
     pytest.mark.long_running,
     test_requirements.retirement,
-    pytest.mark.provider(gen_func=providers,
-                         filters=[ProviderFilter(classes=[CloudProvider, InfraProvider],
-                                                 required_flags=['provision', 'retire'])]),
+    pytest.mark.provider([CloudProvider, InfraProvider],
+                         required_flags=['provision', 'retire']),
 ]
 
 
@@ -222,7 +221,6 @@ def test_set_retirement_date(retire_vm, warn):
 
 @pytest.mark.tier(2)
 @pytest.mark.parametrize('warn', warnings, ids=[warning.id for warning in warnings])
-@pytest.mark.uncollectif(lambda provider: provider.one_of(InfraProvider))  # TODO remove when common
 def test_set_retirement_offset(retire_vm, warn):
     """Tests setting the retirement by offset
 

--- a/cfme/tests/cloud_infra_common/test_snapshots_rest.py
+++ b/cfme/tests/cloud_infra_common/test_snapshots_rest.py
@@ -188,7 +188,7 @@ class TestRESTSnapshots(object):
                 raise
 
     @pytest.mark.rhv2
-    @pytest.mark.uncollectif(lambda provider: not provider.one_of(InfraProvider))
+    @pytest.mark.provider([VMwareProvider, RHEVMProvider], override=True)
     def test_revert_snapshot(self, appliance, provider, vm_snapshot):
         """Reverts VM/instance snapshot using REST API.
 

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -93,7 +93,8 @@ def test_default_view_infra_reset(appliance):
 @pytest.mark.parametrize('group_name', list(GTL_PARAMS.keys()), scope="module")
 @pytest.mark.parametrize('view', ['List View', 'Tile View', 'Grid View'])
 @pytest.mark.uncollectif(
-    lambda view, group_name: view == "Grid View" and group_name == "Service Catalogs"
+    lambda view, group_name: view == "Grid View" and group_name == "Service Catalogs",
+    reason='Incompatible combination of grid view and service catalogs'
 )
 def test_infra_default_view(appliance, group_name, view):
     """This test case changes the default view of an infra related page and asserts the change.

--- a/cfme/tests/configure/test_landing_page.py
+++ b/cfme/tests/configure/test_landing_page.py
@@ -175,7 +175,8 @@ def set_landing_page(appliance, my_settings, start_page):
     lambda start_page, appliance: (
         (appliance.version < "5.11" and start_page in PAGES_NOT_IN_510)
         or (appliance.version > "5.11" and start_page in PAGES_NOT_IN_511)
-    )
+    ),
+    reason='Start page not available on the appliance version under test'
 )
 @test_requirements.settings
 def test_landing_page_admin(

--- a/cfme/tests/configure/test_server_roles.py
+++ b/cfme/tests/configure/test_server_roles.py
@@ -10,6 +10,8 @@ server_roles_conf = cfme_data.get('server_roles',
 @pytest.fixture(scope="session")
 def all_possible_roles(appliance):
     roles = server_roles_conf['all']
+    if roles == []:
+        pytest.skip('Empty server roles in cfme_data, cannot generate tests')
     if appliance.version < '5.11':
         roles.remove('internet_connectivity')
         roles.remove('remote_console')
@@ -26,8 +28,9 @@ def roles(request, all_possible_roles):
             result[role] = role in cfme_data.get('server_roles', {})['sets'][request.param]
     except (KeyError, AttributeError):
         pytest.skip(
-            f"Failed looking up role '{role}' in \
-            cfme_data['server_roles']['sets']['{request.param}']")
+            f"Failed looking up role '{role}' in "
+            f"cfme_data['server_roles']['sets']['{request.param}']"
+        )
     # Hard-coded protection
     result['user_interface'] = True
 
@@ -36,7 +39,6 @@ def roles(request, all_possible_roles):
 
 @pytest.mark.tier(3)
 @pytest.mark.sauce
-@pytest.mark.uncollectif(lambda: not server_roles_conf['all'])
 def test_server_roles_changing(request, roles, appliance):
     """ Test that sets and verifies the server roles in configuration.
 

--- a/cfme/tests/containers/test_logging.py
+++ b/cfme/tests/containers/test_logging.py
@@ -5,18 +5,13 @@ from cfme.containers.node import Node
 from cfme.containers.node import NodeCollection
 from cfme.containers.provider import ContainersProvider
 from cfme.containers.provider import ContainersTestItem
-from cfme.markers.env_markers.provider import providers
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.providers import ProviderFilter
-from cfme.utils.version import current_version
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda provider: current_version() < "5.8"),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(1),
-    pytest.mark.provider(gen_func=providers,
-                         filters=[ProviderFilter(classes=[ContainersProvider],
-                                                 required_flags=['cmqe_logging'])],
+    pytest.mark.provider([ContainersProvider],
+                         required_flags=['cmqe_logging'],
                          scope='function'),
     test_requirements.containers
 ]

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -26,7 +26,7 @@ from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 
 pf1 = ProviderFilter(classes=[InfraProvider])
-pf2 = ProviderFilter(classes=[SCVMMProvider], inverted=True)
+pf2 = ProviderFilter(classes=[SCVMMProvider, RHEVMProvider, KubeVirtProvider], inverted=True)
 
 CANDU_PROVIDER_TYPES = [VMwareProvider]
 
@@ -34,7 +34,6 @@ CANDU_PROVIDER_TYPES = [VMwareProvider]
 pytestmark = [
     pytest.mark.long_running,
     pytest.mark.meta(server_roles=["+automate", "+smartproxy", "+notifier"]),
-    pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider, KubeVirtProvider)),
     pytest.mark.usefixtures("setup_provider_modscope"),
     pytest.mark.tier(3),
     test_requirements.alert

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -29,8 +29,7 @@ pytestmark = [
     pytest.mark.tier(3),
     pytest.mark.provider([InfraProvider],
                          required_fields=['hosts'], scope='module',
-                         selector=ONE_PER_VERSION,
-                         ),
+                         selector=ONE_PER_VERSION),
 ]
 
 VIEWS = ('Grid View', 'Tile View', 'List View')
@@ -93,7 +92,10 @@ def navigate_and_select_quads(provider):
     return edit_view
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(VMwareProvider))
+@pytest.mark.provider([VMwareProvider],
+                      required_fields=['hosts'],
+                      selector=ONE_PER_VERSION,
+                      override=True)
 def test_discover_host(request, provider, appliance, host_ips):
     """Tests hosts discovery.
 
@@ -134,7 +136,7 @@ def test_discover_host(request, provider, appliance, host_ips):
 @pytest.mark.uncollectif(
     lambda provider, creds:
         creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
-    reason="Not relevant for RHEVM Provider."
+    reason="cred type not relevant for RHEVM Provider."
 )
 def test_multiple_host_good_creds(setup_provider, provider, creds):
     """

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import miq_version
 import pytest
 from widgetastic.utils import partial_match
 
@@ -62,10 +61,11 @@ def host_with_credentials(provider, host_name):
 
 @pytest.mark.rhv1
 @pytest.mark.uncollectif(
-    lambda provider, appliance:
-    appliance.version == miq_version.UPSTREAM and provider.one_of(RHEVMProvider))
-@pytest.mark.meta(blockers=[BZ(1650179, forced_streams=['5.10'],
-    unblock=lambda provider: not provider.one_of(RHEVMProvider))])
+    lambda provider, appliance: not appliance.is_downstream and provider.one_of(RHEVMProvider)
+)
+@pytest.mark.meta(blockers=[BZ(1650179,
+                               forced_streams=['5.10'],
+                               unblock=lambda provider: not provider.one_of(RHEVMProvider))])
 def test_run_host_analysis(setup_provider_modscope, provider, host_type, host_name, register_event,
                            soft_assert, host_with_credentials):
     """ Run host SmartState analysis

--- a/cfme/tests/infrastructure/test_individual_host_creds.py
+++ b/cfme/tests/infrastructure/test_individual_host_creds.py
@@ -50,8 +50,8 @@ def get_host_data_by_name(provider_key, host_name):
                          ids=["default", "remote", "web"])
 @pytest.mark.uncollectif(
     lambda provider, creds:
-        creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
-    reason="Not relevant for RHEVM Provider."
+    creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
+    reason="Cred type not relevant for RHEVM Provider."
 )
 def test_host_good_creds(appliance, request, setup_provider, provider, creds):
     """
@@ -113,7 +113,7 @@ def test_host_good_creds(appliance, request, setup_provider, provider, creds):
 @pytest.mark.uncollectif(
     lambda provider, creds:
         creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
-    reason="Not relevant for RHEVM Provider."
+    reason="Cred type not relevant for RHEVM Provider."
 )
 def test_host_bad_creds(appliance, request, setup_provider, provider, creds):
     """

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -302,7 +302,7 @@ def test_infra_provider_crud(provider):
 @pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(1)
 @pytest.mark.parametrize('verify_tls', [False, True], ids=['no_tls', 'tls'])
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(RHEVMProvider))
+@pytest.mark.provider([RHEVMProvider], override=True)
 def test_provider_rhv_create_delete_tls(request, provider, verify_tls):
     """Tests RHV provider creation with and without TLS encryption
 

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -179,7 +179,8 @@ def test_change_cpu_ram(provisioner, soft_assert, provider, prov_data, vm_name):
     (not provider.one_of(RHEVMProvider) and disk_format == "Preallocated") or
     # Temporarily, our storage domain cannot handle Preallocated disks
     (provider.one_of(RHEVMProvider) and disk_format == "Preallocated") or
-    (provider.one_of(SCVMMProvider))
+    (provider.one_of(SCVMMProvider)),
+    reason='Invalid combination of disk format and provider type or appliance version (or both!)'
 )
 def test_disk_format_select(provisioner, disk_format, provider, prov_data, vm_name):
     """ Tests disk format selection in provisioning dialog.

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -120,8 +120,7 @@ def test_provision(request, appliance, provider, provision_data):
 
 
 @pytest.mark.rhv2
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(RHEVMProvider),
-                         reason='These profile names are RHV specific.')
+@pytest.mark.provider([RHEVMProvider], override=True)  # These profile names are RHV specific
 @pytest.mark.parametrize('vnic_profile', ['empty_vnic_profile', 'specific_vnic_profile'])
 def test_provision_vlan(request, appliance, provision_data, vnic_profile, provider):
     """Tests provision via REST API for vlan Empty/Specific vNic profile.

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -274,10 +274,10 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
 
 
 @pytest.mark.rhv1
-@pytest.mark.uncollectif(lambda provider: (provider.one_of(RHEVMProvider) and provider.version < 4),
-                         'Must be RHEVM provider version >= 4')
 def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request):
     """Tests revert snapshot
+
+    Only valid for RHV 4+ providers, due to EOL we are not explicitly checking/blocking on this
 
     Metadata:
         test_flag: snapshot, provision

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -142,7 +142,9 @@ def test_vm_reconfig_add_remove_hw_cold(provider, full_vm, ensure_vm_stopped, ch
     'disk_mode', ['persistent', 'independent_persistent', 'independent_nonpersistent'])
 @pytest.mark.uncollectif(
     # Disk modes cannot be specified when adding disk to VM in RHV provider
-    lambda disk_mode, provider: disk_mode != 'persistent' and provider.one_of(RHEVMProvider))
+    lambda disk_mode, provider: disk_mode != 'persistent' and provider.one_of(RHEVMProvider),
+    reason='Disk modes cannot be specified on RHEVM, only persistent included'
+)
 @pytest.mark.meta(
     blockers=[BZ(1692801, forced_streams=['5.10'],
                  unblock=lambda provider: not provider.one_of(RHEVMProvider))]

--- a/cfme/tests/openstack/infrastructure/test_host_power_control.py
+++ b/cfme/tests/openstack/infrastructure/test_host_power_control.py
@@ -1,11 +1,9 @@
 import pytest
 
 from cfme.infrastructure.provider.openstack_infra import OpenstackInfraProvider
-from cfme.utils.version import current_version
 
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda: current_version() < '5.7'),
     pytest.mark.usefixtures("setup_provider_modscope"),
     pytest.mark.provider([OpenstackInfraProvider], scope='module'),
 ]

--- a/cfme/tests/optimize/test_bottlenecks.py
+++ b/cfme/tests/optimize/test_bottlenecks.py
@@ -13,7 +13,8 @@ from cfme.utils.timeutil import parsetime
 
 pytestmark = [
     test_requirements.bottleneck,
-    pytest.mark.uncollectif(lambda appliance: appliance.is_pod),
+    pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                            reason='Tests not supported on pod appliance'),
     pytest.mark.ignore_stream('5.11')]
 
 

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -18,8 +18,7 @@ pytestmark = [
         ids=['template_job', 'template_limit_job', 'template_survey_job', 'textarea_survey_job'],
         scope='module'),
     pytest.mark.ignore_stream('upstream'),
-    pytest.mark.uncollectif(lambda appliance,
-        job_type: appliance.version < '5.10' and job_type == 'workflow')]
+]
 
 
 def pytest_generate_tests(metafunc):

--- a/cfme/tests/services/test_myservice.py
+++ b/cfme/tests/services/test_myservice.py
@@ -13,7 +13,6 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.browser import ensure_browser_open
 from cfme.utils.update import update
-from cfme.utils.version import appliance_is_downstream
 from cfme.utils.wait import wait_for
 
 pytestmark = [
@@ -101,7 +100,9 @@ def test_crud_set_ownership_and_edit_tags(appliance, context, service_vm):
 @pytest.mark.parametrize('context', [ViaUI])
 @pytest.mark.parametrize("filetype", ["Text", "CSV", "PDF"])
 # PDF not present on upstream
-@pytest.mark.uncollectif(lambda filetype: filetype == 'PDF' and not appliance_is_downstream())
+@pytest.mark.uncollectif(lambda appliance, filetype:
+                         filetype == 'PDF' and not appliance.is_downstream,
+                         reason='PDF downloads not supported on upstream')
 def test_download_file(appliance, context, needs_firefox, service_vm, filetype):
     """Tests my service download files
 

--- a/cfme/tests/services/test_service_catalogs_multi_region.py
+++ b/cfme/tests/services/test_service_catalogs_multi_region.py
@@ -17,12 +17,10 @@ pytestmark = [
 @test_requirements.multi_region
 @test_requirements.service
 @pytest.mark.parametrize('context', [ViaREST, ViaUI])
-@pytest.mark.parametrize('catalog_location', ['global', 'remote'])
+@pytest.mark.parametrize('catalog_location', ['remote'])  # TODO add global
 @pytest.mark.parametrize('item_type', ['AMAZON', 'ANSIBLE', 'TOWER', 'AZURE', 'GENERIC',
                                        'OPENSTACK', 'ORCHESTRATION', 'RHV', 'SCVMM', 'VMWARE',
                                        'BUNDLE'])
-@pytest.mark.uncollectif(lambda catalog_location: catalog_location == 'global',
-                         reason="isn't supported yet")
 def test_service_provision_retire_from_global_region(item_type, catalog_location, context):
     """
     Polarion:

--- a/cfme/tests/v2v/test_csv_import.py
+++ b/cfme/tests/v2v/test_csv_import.py
@@ -269,7 +269,21 @@ def test_csv_archived_vm(appliance, infra_map, archived_vm):
     assert error_msg == hover_error
 
 
-@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider))
+@pytest.mark.provider(
+    classes=[OpenStackProvider],
+    selector=ONE_PER_VERSION,
+    required_flags=["v2v"],
+    scope="module",
+    override=True,
+)
+@pytest.mark.provider(
+    classes=[VMwareProvider],
+    selector=ONE_PER_TYPE,
+    fixture_name="source_provider",
+    required_flags=["v2v"],
+    scope="module",
+    override=True,
+)
 def test_csv_security_group_flavor(appliance, infra_map, valid_vm, provider):
     """Test csv with secondary openstack security group and flavor
     Polarion:

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -52,7 +52,9 @@ pytestmark = [
 )
 @pytest.mark.uncollectif(
     lambda source_provider, mapping_data_vm_obj_single_datastore:
-    source_provider.version == 6.5 and "local" in mapping_data_vm_obj_single_datastore
+    source_provider.one_of(VMwareProvider) and source_provider.version == 6.5 and
+    "local" in mapping_data_vm_obj_single_datastore,
+    reason='Single datastore of local and source provider version 6.5 not supported'
 )
 def test_single_datastore_single_vm_migration(
     request, appliance, provider, mapping_data_vm_obj_single_datastore
@@ -104,7 +106,9 @@ def test_single_datastore_single_vm_migration(
 )
 @pytest.mark.uncollectif(
     lambda source_provider, mapping_data_vm_obj_single_network:
-    source_provider.version != 6.5 and "DPortGroup" in mapping_data_vm_obj_single_network
+    source_provider.one_of(VMwareProvider) and source_provider.version != 6.5 and
+    "DPortGroup" in mapping_data_vm_obj_single_network,
+    reason='Single network of DPortGroup only supported on source provider version 6.5'
 )
 def test_single_network_single_vm_migration(
     request, appliance, provider, mapping_data_vm_obj_single_network
@@ -207,7 +211,9 @@ def test_dual_datastore_dual_vm_migration(
 )
 @pytest.mark.uncollectif(
     lambda source_provider, mapping_data_vm_obj_dual_nics:
-    source_provider.version != 6.5 and "DPortGroup" in mapping_data_vm_obj_dual_nics
+    source_provider.one_of(VMwareProvider) and source_provider.version != 6.5 and
+    "DPortGroup" in mapping_data_vm_obj_dual_nics,
+    reason='Dual network of DPortGroup only supported on source provider version 6.5'
 )
 def test_dual_nics_migration(request, appliance, provider, mapping_data_vm_obj_dual_nics):
     """

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -318,7 +318,21 @@ def test_v2v_infra_map_special_chars(request, appliance, source_provider, provid
         pass
 
 
-@pytest.mark.uncollectif(lambda provider: provider.one_of(OpenStackProvider))
+@pytest.mark.provider(
+    classes=[RHEVMProvider],
+    selector=ONE_PER_VERSION,
+    required_flags=["v2v"],
+    scope="module",
+    override=True,
+)
+@pytest.mark.provider(
+    classes=[VMwareProvider],
+    selector=ONE_PER_TYPE,
+    fixture_name="source_provider",
+    required_flags=["v2v"],
+    scope="module",
+    override=True
+)
 def test_v2v_rbac(appliance, new_credential):
     """
     Test migration with role-based access control

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -3054,12 +3054,15 @@ class DummyAppliance(object):
     hostname = 'DummyApplianceHostname'
     browser_steal = False
     version = attr.ib(default=Version('5.11.0'), converter=_version_for_version_or_stream)
-    is_downstream = True
     is_pod = False
     is_dev = False
-    build = 'missing :)'
+    build = 'dummyappliance'
     managed_known_providers = []
     collections = attr.ib(default=attr.Factory(collections_for_appliance, takes_self=True))
+
+    @property
+    def is_downstream(self):
+        return not (self.version.is_in_series('master') or self.version.is_in_series('upstream'))
 
     @classmethod
     def from_config(cls, pytest_config):


### PR DESCRIPTION
Trying to keep test collection consistent here, but not looking to fix any tests that may be failing.

Removed some old BZ's and appliance version references as I came across them

Added an is_downstream property to DummyAppliance