### PR TITLE
[1LP][RFR]Fix tests and cleanup

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -9,6 +9,7 @@ import fauxfactory
 import pytest
 from wait_for import wait_for
 from widgetastic.exceptions import MoveTargetOutOfBoundsException
+from widgetastic.widget import Text
 from wrapanapi import VmState
 
 from cfme import test_requirements
@@ -673,7 +674,11 @@ def test_cloud_names_grid_floating_ips(appliance, ec2_provider, soft_assert):
     view = navigate_to(floating_ips_collection, "All")
     view.toolbar.view_selector.select('Grid View')
     for entity in view.entities.get_all():
-        soft_assert('title="{}"'.format(entity.data['address']) in entity.data['quadicon'])
+        title = Text(
+            view,
+            f'//*[@id="miq-gtl-view"]//a[@title="{entity.data["address"]}"]'
+        )
+        soft_assert(title.is_displayed)
 
 
 @test_requirements.general_ui

--- a/cfme/tests/configure/test_landing_page.py
+++ b/cfme/tests/configure/test_landing_page.py
@@ -97,7 +97,6 @@ ALL_LANDING_PAGES = list(SPECIAL_LANDING_PAGES.keys()) + [
     "Monitor / Alerts / Most Recent Alerts",
     "Monitor / Alerts / Overview",
     "Networks / Floating IPs",
-    "Networks / Load Balancers",
     "Networks / Network Ports",
     "Networks / Network Routers",
     "Networks / Networks",
@@ -149,6 +148,7 @@ PAGES_NOT_IN_511 = [
     "Optimize / Planning",
     "Optimize / Utilization",
     "Red Hat Access Insights",
+    "Networks / Load Balancers",
 ]
 
 

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -149,7 +149,7 @@ def test_provision_vlan(request, appliance, provision_data, vnic_profile, provid
         vnic_profile = '<Empty>'
     # For 'specific_vnic_profile'
     else:
-        vnic_profile = '{0} ({0})'.format(profile_name)
+        vnic_profile = profile_name
     provision_data['vm_fields']['vlan'] = vnic_profile
     request.addfinalizer(lambda: clean_vm(appliance, provider, vm_name))
     appliance.rest_api.collections.provision_requests.action.create(**provision_data)
@@ -174,7 +174,7 @@ def test_provision_vlan(request, appliance, provision_data, vnic_profile, provid
     else:
         vnic_srv = provider.mgmt.api.system_service().vnic_profiles_service()
         profile_via_provider = vnic_srv.profile_service(profile.id).get()
-        assert profile_via_provider.name == profile_name, \
+        assert profile_via_provider.name == profile_name.split()[0], \
             "The vNIC profile name is {}, but should be {}".\
             format(profile_via_provider.name, profile_name)
 

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -174,9 +174,10 @@ def test_provision_vlan(request, appliance, provision_data, vnic_profile, provid
     else:
         vnic_srv = provider.mgmt.api.system_service().vnic_profiles_service()
         profile_via_provider = vnic_srv.profile_service(profile.id).get()
-        assert profile_via_provider.name == profile_name.split()[0], \
-            "The vNIC profile name is {}, but should be {}".\
-            format(profile_via_provider.name, profile_name)
+        assert (                                                                   # noqa: F631
+            profile_via_provider.name == profile_name.split()[0],
+            f"The vNIC profile name is {profile_via_provider.name}, but should be {profile_name}"
+        )
 
 
 @pytest.mark.rhv3

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -15,6 +15,7 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import automation_requests_data
 from cfme.rest.gen_data import vm as _vm
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data
 from cfme.utils.ftp import FTPClientWrapper
 from cfme.utils.rest import assert_response
@@ -216,6 +217,7 @@ def test_query_simple_collections(appliance, collection_name):
         list(collection)
 
 
+@pytest.mark.meta(automates=[1392595], coverage=[1754972])
 @pytest.mark.tier(3)
 @pytest.mark.parametrize('collection_name', COLLECTIONS_ALL)
 @pytest.mark.uncollectif(
@@ -223,7 +225,7 @@ def test_query_simple_collections(appliance, collection_name):
         collection_name in COLLECTIONS_OMITTED or
         _collection_not_in_this_version(appliance, collection_name)
 )
-def test_collections_actions(appliance, collection_name):
+def test_collections_actions(appliance, collection_name, soft_assert):
     """Tests that there are only actions with POST methods in collections.
 
     Other methods (like DELETE) are allowed for individual resources inside collections,
@@ -231,6 +233,7 @@ def test_collections_actions(appliance, collection_name):
 
     Bugzilla:
         1392595
+        1754972
 
     Metadata:
         test_flag: rest
@@ -241,14 +244,17 @@ def test_collections_actions(appliance, collection_name):
         caseimportance: high
         initialEstimate: 1/4h
     """
-    collection_href = '{}/{}'.format(appliance.rest_api._entry_point, collection_name)
-    response = appliance.rest_api.get(collection_href)
+    response = appliance.rest_api.get(
+        getattr(appliance.rest_api.collections, collection_name)._href
+    )
     actions = response.get('actions')
     if not actions:
         # nothing to test in this collection
         return
     for action in actions:
-        assert action['method'].lower() == 'post'
+        if BZ(1754972).blocks and collection_name == "pxe_servers":
+            pytest.skip("pxe_servers contains methods other than post.")
+        soft_assert(action['method'].lower() == 'post')
 
 
 @pytest.mark.tier(3)
@@ -645,7 +651,7 @@ def test_rest_paging(appliance, paging):
     assert response['subcount'] == expected_subcount
     assert len(response['resources']) == expected_subcount
 
-    expected_pages_num = (response['count'] / limit) + (1 if response['count'] % limit else 0)
+    expected_pages_num = (response['count'] // limit) + (1 if response['count'] % limit else 0)
     assert response['pages'] == expected_pages_num
 
     links = response['links']
@@ -723,7 +729,7 @@ def test_collection_class_valid(appliance, provider, vendor):
     # all returned entities must have the same type
     if response.count:
         rand_num = 5 if response.count >= 5 else response.count
-        rand_entities = random.sample(response, rand_num)
+        rand_entities = random.sample(response.resources, rand_num)
         for entity in rand_entities:
             assert entity.type == tested_type
 

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -1270,8 +1270,8 @@ def test_custom_logos_via_api(appliance, image_type, request):
     assert branding_info[image_type] == expected_name.format(image_type)
 
 
-@pytest.mark.provider([VMwareProvider], override=True)
-@pytest.mark.provider([RHEVMProvider], fixture_name="second_provider")
+@pytest.mark.provider([VMwareProvider], override=True, selector=ONE)
+@pytest.mark.provider([RHEVMProvider], fixture_name="second_provider", selector=ONE)
 def test_provider_specific_vm(
     appliance, request, soft_assert, provider, second_provider
 ):

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -55,24 +55,6 @@ def test_automation_request_task():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.rest
-def test_provider_specific_vm():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Infra
-        caseimportance: medium
-        initialEstimate: 1/4h
-        testSteps:
-            1. Add multiple provider and query vms related to a specific provider.
-                GET /api/providers/:provider_id/vms
-        expectedResults:
-            1. Should receive all VMs related to the provider.
-    """
-    pass
-
-
 @test_requirements.rest
 @pytest.mark.manual()
 @pytest.mark.tier(1)

--- a/cfme/tests/test_ui.py
+++ b/cfme/tests/test_ui.py
@@ -1,3 +1,5 @@
+import pytest
+
 from cfme import test_requirements
 from cfme.fixtures.soft_assert import soft_assert
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -21,17 +23,23 @@ def traverse(dic, paths, path=None):
     return paths
 
 
+@pytest.mark.meta(coverage=[1648338])
 def test_each_page(appliance):
     """
+    Bugzilla:
+        1648338
+
     Polarion:
         assignee: pvala
         initialEstimate: 1/4h
         casecomponent: WebUI
     """
     view = navigate_to(appliance.server, 'Dashboard')
-    # test meta is here and CFME will be displayed correctly in IE11
-    edge_header = view.browser.element('//meta[@content="IE=edge"]')
-    soft_assert(edge_header.get_attribute('http-equiv') == 'X-UA-Compatible')
+    # no meta is present for 5.11
+    if appliance.version < "5.11":
+        # test meta is here and CFME will be displayed correctly in IE11
+        edge_header = view.browser.element('//meta[@content="IE=edge"]')
+        soft_assert(edge_header.get_attribute('http-equiv') == 'X-UA-Compatible')
     tree = view.navigation.nav_item_tree()
     paths = []
     traverse(tree, paths, path=None)


### PR DESCRIPTION
## Purpose or Intent
- __Fixing__ 
    1. Fix test: test_cloud_names_grid_floating_ips - no `title` is present in `entity.quadicon`, as a workaround, a temporary `Text` widget is created which points to the title of quadicon.
    2. Fix test: test_landing_page_admin[infra-Networks / Load Balancers] - because Load Balancers have been deprecated in 5.11
    3. Fix test: test_provision_vlan - fix `vnic_profile` name whose format has changed
    4. Fix test_rest.py tests - 
        1. `test_collections_actions[pxe-servers]` - a bug(1754972) has been filed for `pxe_servers` collection
        2. `test_rest_paging` - use `/` instead of `//` which returns an int value, instead of float which caused test failure.
        3. `test_collection_class_valid` - `random.sample` requires a list or tuple, but `response` doesn't always return that, instead use `response.resources` which will always be a list. 
- __Extending__ 
    1. Add selector to test_provider_specific_vm and remove its manual test.
    2. Catch exceptions for BaseVM.rest_api_entity - fix this property to raise an appropriate error when the VM doesn't exist.

### PRT Run
{{ pytest: cfme/tests/cloud/test_providers.py::test_cloud_names_grid_floating_ips cfme/tests/infrastructure/test_provisioning_rest.py::test_provision_vlan cfme/tests/test_rest.py::test_collections_actions cfme/tests/test_rest.py::test_rest_paging cfme/tests/test_rest.py::test_collection_class_valid cfme/tests/test_ui.py  --long-running --use-provider=complete -vvv }}