### PR TITLE
[1LP][RFR] Embedded Ansible service to check "Cloud Credentials" used in the service.

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -405,25 +405,6 @@ def test_service_ansible_playbook_order_credentials_usecredsfromservicedialog():
 
 
 @pytest.mark.tier(3)
-def test_service_ansible_playbook_machine_credentials_service_details_opsui():
-    """
-    Bugzilla:
-        1515561
-
-    When the service is viewed in my services it should also show that the cloud and
-    machine credentials were attached to the service.
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: medium
-        initialEstimate: 1/2h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(3)
 def test_service_ansible_playbook_machine_credentials_service_details_sui():
     """
     Bugzilla:

--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -388,25 +388,6 @@ def test_service_ansible_playbook_with_already_existing_catalog_item_name():
 
 
 @pytest.mark.tier(3)
-def test_service_ansible_playbook_cloud_credentials():
-    """
-    Bugzilla:
-        1444092
-
-    When the service is viewed in my services it should also show that the cloud credentials
-    were attached to the service.
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        caseimportance: low
-        initialEstimate: 1/4h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(3)
 def test_service_ansible_playbook_order_credentials_usecredsfromservicedialog():
     """
     Test if creds from Service Dialog are picked up for execution of

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -41,7 +41,7 @@ SERVICE_CATALOG_VALUES = [
 CREDENTIALS = [
     ("Amazon", "", "list_ec2_instances.yml"),
     ("VMware", "vcenter_host", "gather_all_vms_from_vmware.yml"),
-    ("Red Hat Virtualization", "host", "connect_to_rhv.yml"),
+    ("Red Hat Virtualization", "host", "get_vms_facts_rhv.yaml"),
     ("Azure", "", "get_resourcegroup_facts_azure.yml"),
 ]
 
@@ -121,7 +121,7 @@ def provider_credentials(appliance, provider, credential):
     else:
         credentials["username"] = creds.principal
         credentials["password"] = creds.secret
-        credentials[hostname] = provider.hostname
+        credentials[hostname] = f"https://{provider.hostname}/ovirt-engine/api"
 
     credential = appliance.collections.ansible_credentials.create(
         "{}_credential_{}".format(cred_type, fauxfactory.gen_alpha()),


### PR DESCRIPTION
## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

- [x] Automated manual tests which has BZ associated with it.

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked



Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->

{{pytest: cfme/tests/ansible/test_embedded_ansible_services.py -k "test_ansible_service_cloud_credentials" --long-running --use-provider=complete -svvvv }}