### PR TITLE
[1LP][WIPTEST] fix ansible repo enable check

### DIFF
--- a/cfme/ansible/repositories.py
+++ b/cfme/ansible/repositories.py
@@ -256,10 +256,13 @@ class RepositoryCollection(BaseCollection):
             delete_on_update=delete_on_update,
             update_on_launch=update_on_launch)
 
-        wait_for(lambda: repository.exists,
-                 fail_func=repo_list_page.browser.selenium.refresh,
-                 delay=5,
-                 timeout=900)
+        wait_for(
+            lambda: repository.exists,
+            fail_func=repo_list_page.browser.refresh,
+            delay=5,
+            timeout=1080,
+            message=f'Waiting for "{name}" repository',
+        )
 
         return repository
 
@@ -350,10 +353,10 @@ class Add(CFMENavigateStep):
         # workaround for disabled Dropdown
         dropdown = self.prerequisite_view.toolbar.configuration
         wait_for(
-            dropdown.item_enabled,
-            func_args=["Add New Repository"],
+            lambda: dropdown.is_enabled,
             timeout=120,
-            fail_func=self.prerequisite_view.browser.refresh
+            fail_func=self.prerequisite_view.browser.refresh,
+            message="Waiting for configuration [Add New Repository] enable",
         )
         dropdown.item_select("Add New Repository")
 


### PR DESCRIPTION
Signed-off-by: Nikhil Dhandre <ndhandre@redhat.com>

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- Fix ansible 5.10 problem as it took time to enable ansible
```
DropdownDisabled
b'Dropdown "Configuration" is not enabled'
```
- Now if all `items` in `Dropdown` disabled then over all Dropdown disabled.
 
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/ansible/test_embedded_ansible_crud.py}}