### PR TITLE
[RFR] Add browser isolation marker for test items

### DIFF
--- a/cfme/markers/__init__.py
+++ b/cfme/markers/__init__.py
@@ -13,4 +13,5 @@ pytest_plugins = [
     "cfme.markers.marker_filters",
     "cfme.markers.uses",
     "cfme.markers.uncollect",
+    "cfme.markers.isolation",
 ]

--- a/cfme/markers/isolation.py
+++ b/cfme/markers/isolation.py
@@ -1,0 +1,26 @@
+"""Marker for browser isolation on specific tests"""
+import pytest
+
+from cfme.test_framework.browser_isolation import browser_implementation_quits
+from cfme.utils.log import logger
+
+
+# Add Marker
+def pytest_configure(config):
+    config.addinivalue_line('markers', 'browser_isolation: Mark a test case for browser isolation')
+
+
+@pytest.mark.hookwrapper(tryfirst=True)
+def pytest_runtest_setup(item):
+    if item.get_marker('browser_isolation'):
+        logger.info('Browser isolation for marker in setup')
+        browser_implementation_quits(item)
+    yield
+
+
+@pytest.mark.hookwrapper(trylast=True)
+def pytest_runtest_teardown(item, nextitem):
+    yield
+    if item.get_marker("browser_isolation"):
+        logger.info('Browser isolation for marker in teardown')
+        browser_implementation_quits(item)

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -27,6 +27,7 @@ pytestmark = [
                auth_mode in ['external', 'ldaps'] and
                auth_data.auth_providers[prov_key].type == 'openldaps')),
         BZ(1593171)]),  # 510z groups page doesn't load
+    pytest.mark.browser_isolation,
     pytest.mark.usefixtures('prov_key', 'auth_mode', 'auth_provider', 'configure_auth', 'auth_user')
 ]
 


### PR DESCRIPTION
Browser isolation is needed at a lower level than wrapped around every test case via the CLI option.

This adds a marker (to auth tests first) that enforces setup/teardown based browser isolation.