### PR TITLE
[1LP][RFR] Add test_compare_provider_templates to test_providers.py

### DIFF
--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -585,5 +585,5 @@ class TemplatesCompareView(InfraProvidersView):
     @property
     def is_displayed(self):
         title = "Compare VM Template and Image"
-        return (self.logged_in_as_current_user and self.navigation.currently_selected == [
-                'Compute', 'Infrastructure', 'Providers'] and self.title.text == title)
+        return (self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers']
+                and self.title.text == title)

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -16,7 +16,6 @@ from cfme.common.host_views import HostEntitiesView
 from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import BaseEntitiesView
-from widgetastic_manageiq import BaseNonInteractiveEntitiesView
 from widgetastic_manageiq import Button
 from widgetastic_manageiq import Checkbox
 from widgetastic_manageiq import DetailsToolBarViewSelector

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -2,19 +2,21 @@ from lxml.html import document_fromstring
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import Version
 from widgetastic.widget import ConditionalSwitchableView
+from widgetastic.widget import Table
 from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapNav
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Dropdown
-
 from cfme.common import BaseLoggedInPage
 from cfme.common import TimelinesView
 from cfme.common.host_views import HostEntitiesView
+
 from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import BaseEntitiesView
+from widgetastic_manageiq import BaseNonInteractiveEntitiesView
 from widgetastic_manageiq import Button
 from widgetastic_manageiq import Checkbox
 from widgetastic_manageiq import DetailsToolBarViewSelector
@@ -581,6 +583,7 @@ class ContainerProviderEditView(ProviderEditView):
 class TemplatesCompareView(InfraProvidersView):
     """Compare Templates page."""
     title = Text('.//div[@id="center_div" or @id="main-content"]//h1')
+    comparison_table = Table(locator='//div[@id="compare-grid"]/table')
 
     @property
     def is_displayed(self):

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -580,11 +580,10 @@ class ContainerProviderEditView(ProviderEditView):
 
 class TemplatesCompareView(InfraProvidersView):
     """Compare Templates page."""
+    title = Text('.//div[@id="center_div" or @id="main-content"]//h1')
 
     @property
     def is_displayed(self):
-        title = "Compare Templates"
-        return (self.logged_in_as_current_user and
-                # self.navigation.currently_selected == ['Compute', 'Infrastructure',
-                #                                       'Hosts', 'Compare Host / Node'] and
-                self.title.text == title)
+        title = "Compare VM Template and Image"
+        return (self.logged_in_as_current_user and self.navigation.currently_selected == [
+                'Compute', 'Infrastructure', 'Providers'] and self.title.text == title)

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -13,7 +13,6 @@ from widgetastic_patternfly import Dropdown
 from cfme.common import BaseLoggedInPage
 from cfme.common import TimelinesView
 from cfme.common.host_views import HostEntitiesView
-
 from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import Accordion
 from widgetastic_manageiq import BaseEntitiesView

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -576,3 +576,15 @@ class ContainerProviderEditView(ProviderEditView):
         for widget in self.COND_WIDGETS:
             if values.get(widget):
                 getattr(self, widget).fill(values.get(widget))
+
+
+class TemplatesCompareView(InfraProvidersView):
+    """Compare Templates page."""
+
+    @property
+    def is_displayed(self):
+        title = "Compare Templates"
+        return (self.logged_in_as_current_user and
+                # self.navigation.currently_selected == ['Compute', 'Infrastructure',
+                #                                       'Hosts', 'Compare Host / Node'] and
+                self.title.text == title)

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lxml.html import document_fromstring
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import Version
@@ -589,3 +591,18 @@ class TemplatesCompareView(InfraProvidersView):
         title = "Compare VM Template and Image"
         return (self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers']
                 and self.title.text == title)
+
+    def verify_checked_items_compared(self, checkedList, view):
+        # The first and last header items do not contain template names, so are not iterated upon.
+        for header_with_template in view.comparison_table.headers[1:-1]:
+            try:
+                # Split and slice are used to remove extra characters in the header item
+                checkedList.remove(header_with_template.split(' ')[0])
+            except ValueError:
+                pytest.fail(f"Entity {header_with_template.split(' ')[0]} is in compare view, "
+                            f"but was not checked.")
+            except TypeError:
+                pytest.fail('No entities found in compare view.')
+        if len(checkedList) > 0:
+            pytest.fail(f'Some checked items did not appear in the compare view: {checkedList}.')
+        return True

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -1,5 +1,4 @@
 import pytest
-
 from lxml.html import document_fromstring
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import Version

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -9,6 +9,7 @@ from widgetastic_patternfly import BootstrapNav
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Dropdown
+
 from cfme.common import BaseLoggedInPage
 from cfme.common import TimelinesView
 from cfme.common.host_views import HostEntitiesView

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -510,7 +510,6 @@ def setup_provider_min_templates(request, appliance, provider, min_templates):
     setup_or_skip(request, provider)
 
 
-@test_requirements.infra_hosts
 @pytest.mark.parametrize("min_templates", [1, 2, 4])
 @pytest.mark.meta(blockers=[BZ(1746449, forced_streams=["5.10"])], automates=[1746449])
 def test_compare_provider_templates(appliance, setup_provider_min_templates, provider,

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -497,7 +497,7 @@ def test_infra_discovery_screen(appliance):
 
 
 @test_requirements.infra_hosts
-#@pytest.mark.meta(blockers=[BZ(1746449, forced_streams=["5.10"])], automates=[1746449])
+@pytest.mark.meta(blockers=[BZ(1746449, forced_streams=["5.10"])], automates=[1746449])
 def test_compare_provider_templates(appliance, setup_provider, provider):
     """
     Polarion:
@@ -517,7 +517,6 @@ def test_compare_provider_templates(appliance, setup_provider, provider):
         pytest.skip('not enough templates in appliance UI to run test')
     for t in view.entities.get_all()[:3]:
         t.check()
-    view.toolbar.configuration.item_select('Compare Selected Templates',
-                                                 handle_alert=True)
+    view.toolbar.configuration.item_select('Compare Selected Templates', handle_alert=True)
     compare_templates_view = provider.create_view(TemplatesCompareView)
     assert compare_templates_view.is_displayed

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -496,6 +496,7 @@ def test_infra_discovery_screen(appliance):
         view.start.click()
         view.flash.assert_message(ips['msg'])
 
+
 @pytest.fixture
 def setup_provider_min_templates(request, appliance, provider, min_templates):
     templates_yaml = len(provider.data.get('templates', {}))

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -511,6 +511,7 @@ def setup_provider_min_templates(request, appliance, provider, min_templates):
 
 
 @pytest.mark.parametrize("min_templates", [2, 4])
+@pytest.mark.meta(blockers=[BZ(1784180, forced_streams=["5.10"])], automates=[1784180])
 def test_compare_provider_templates(appliance, setup_provider_min_templates, provider,
                                     min_templates):
     """
@@ -521,7 +522,6 @@ def test_compare_provider_templates(appliance, setup_provider_min_templates, pro
         initialEstimate: 1/6h
     Bugzilla:
         1746449
-    Consider parameterizing for say 3, 7, and all
     """
     my_slice = slice(0, min_templates, None)
     view = navigate_to(provider, 'ProviderTemplates')

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -503,7 +503,7 @@ def setup_provider_min_templates(request, appliance, provider, min_templates):
     if templates_yaml < min_templates:
         pytest.skip(f'Number of templates defined in yaml for {provider} does not meet minimum '
                     f'for test parameter {min_templates}, skipping and not setting up provider')
-    if len(provider.mgmt.list_host()) < min_templates:
+    if len(provider.mgmt.list_template()) < min_templates:
         pytest.skip(f'Number of templates on {provider} does not meet minimum '
                     f'for test parameter {min_templates}, skipping and not setting up provider')
     # Function-scoped fixture to set up a provider

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -512,12 +512,12 @@ def setup_provider_min_templates(request, appliance, provider, min_templates):
 
 def verify_checked_items_compared(checkedList, view):
     for e in view.comparison_table.headers[1:-1]:
-            try:
-                checkedList.remove(e.split(' ')[0])
-            except ValueError:
-                pytest.fail(f"Entity {e.split(' ')[0]} is in compare view, but was not checked.")
-            except TypeError:
-                pytest.fail('No entities found in compare view.')
+        try:
+            checkedList.remove(e.split(' ')[0])
+        except ValueError:
+            pytest.fail(f"Entity {e.split(' ')[0]} is in compare view, but was not checked.")
+        except TypeError:
+            pytest.fail('No entities found in compare view.')
     if len(checkedList) > 0:
         pytest.fail(f'Some checked items did not appear in the compare view: {checkedList}.')
     return True

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -511,11 +511,13 @@ def setup_provider_min_templates(request, appliance, provider, min_templates):
 
 
 def verify_checked_items_compared(checkedList, view):
-    for e in view.comparison_table.headers[1:-1]:
+    # The first and last header items do not contain template names, so are not iterated upon.
+    for header_with_template in view.comparison_table.headers[1:-1]:
         try:
-            checkedList.remove(e.split(' ')[0])
+            # Split and slice are used to remove extra characters in the header item
+            checkedList.remove(header_with_template.split(' ')[0])
         except ValueError:
-            pytest.fail(f"Entity {e.split(' ')[0]} is in compare view, but was not checked.")
+            pytest.fail(f"Entity {header_with_template.split(' ')[0]} is in compare view, but was not checked.")
         except TypeError:
             pytest.fail('No entities found in compare view.')
     if len(checkedList) > 0:

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -506,22 +506,7 @@ def setup_provider_min_templates(request, appliance, provider, min_templates):
     setup_or_skip(request, provider)
 
 
-def verify_checked_items_compared(checkedList, view):
-    # The first and last header items do not contain template names, so are not iterated upon.
-    for header_with_template in view.comparison_table.headers[1:-1]:
-        try:
-            # Split and slice are used to remove extra characters in the header item
-            checkedList.remove(header_with_template.split(' ')[0])
-        except ValueError:
-            pytest.fail(f"Entity {header_with_template.split(' ')[0]} is in compare view, "
-                        f"but was not checked.")
-        except TypeError:
-            pytest.fail('No entities found in compare view.')
-    if len(checkedList) > 0:
-        pytest.fail(f'Some checked items did not appear in the compare view: {checkedList}.')
-    return True
-
-
+@pytest.mark.provider([InfraProvider], selector=ONE, scope="function")
 @pytest.mark.parametrize("min_templates", [2, 4])
 @pytest.mark.meta(blockers=[BZ(1784180, forced_streams=["5.10"])], automates=[1784180])
 def test_compare_provider_templates(appliance, setup_provider_min_templates, provider,
@@ -544,4 +529,5 @@ def test_compare_provider_templates(appliance, setup_provider_min_templates, pro
     view.toolbar.configuration.item_select('Compare Selected Templates', handle_alert=True)
     compare_templates_view = provider.create_view(TemplatesCompareView)
     assert compare_templates_view.is_displayed
-    assert verify_checked_items_compared(templateList, compare_templates_view)
+    assert compare_templates_view.verify_checked_items_compared(templateList,
+                                                                compare_templates_view)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -500,9 +500,6 @@ def test_infra_discovery_screen(appliance):
 @pytest.fixture
 def setup_provider_min_templates(request, appliance, provider, min_templates):
     templates_yaml = len(provider.data.get('templates', {}))
-    if templates_yaml < min_templates:
-        pytest.skip(f'Number of templates defined in yaml for {provider} does not meet minimum '
-                    f'for test parameter {min_templates}, skipping and not setting up provider')
     if len(provider.mgmt.list_templates()) < min_templates:
         pytest.skip(f'Number of templates on {provider} does not meet minimum '
                     f'for test parameter {min_templates}, skipping and not setting up provider')

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -510,8 +510,7 @@ def setup_provider_min_templates(request, appliance, provider, min_templates):
     setup_or_skip(request, provider)
 
 
-@pytest.mark.parametrize("min_templates", [1, 2, 4])
-@pytest.mark.meta(blockers=[BZ(1746449, forced_streams=["5.10"])], automates=[1746449])
+@pytest.mark.parametrize("min_templates", [2, 4])
 def test_compare_provider_templates(appliance, setup_provider_min_templates, provider,
                                     min_templates):
     """

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -499,7 +499,6 @@ def test_infra_discovery_screen(appliance):
 
 @pytest.fixture
 def setup_provider_min_templates(request, appliance, provider, min_templates):
-    templates_yaml = len(provider.data.get('templates', {}))
     if len(provider.mgmt.list_templates()) < min_templates:
         pytest.skip(f'Number of templates on {provider} does not meet minimum '
                     f'for test parameter {min_templates}, skipping and not setting up provider')
@@ -514,7 +513,8 @@ def verify_checked_items_compared(checkedList, view):
             # Split and slice are used to remove extra characters in the header item
             checkedList.remove(header_with_template.split(' ')[0])
         except ValueError:
-            pytest.fail(f"Entity {header_with_template.split(' ')[0]} is in compare view, but was not checked.")
+            pytest.fail(f"Entity {header_with_template.split(' ')[0]} is in compare view, "
+                        f"but was not checked.")
         except TypeError:
             pytest.fail('No entities found in compare view.')
     if len(checkedList) > 0:

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -542,7 +542,7 @@ def test_compare_provider_templates(appliance, setup_provider_min_templates, pro
     for t in view.entities.get_all(slice=my_slice):
         t.ensure_checked()
         templateList.append(t.name)
-    #view.toolbar.configuration.item_select('Compare Selected Templates', handle_alert=True)
+    view.toolbar.configuration.item_select('Compare Selected Templates', handle_alert=True)
     compare_templates_view = provider.create_view(TemplatesCompareView)
     assert compare_templates_view.is_displayed
     assert verify_checked_items_compared(templateList, compare_templates_view)


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ for BZ  1746449. This covers the comparison of provider templates.

### PRT Run
{{ pytest: --use-provider complete --long-running cfme/tests/infrastructure/test_providers.py::test_compare_provider_templates}}
