### PR TITLE
[WIPTEST] Test migration without conversion hosts

### DIFF
--- a/cfme/v2v/migration_plans.py
+++ b/cfme/v2v/migration_plans.py
@@ -375,7 +375,8 @@ class MigrationPlan(BaseEntity):
     MIGRATION_STATES = {'Started': lambda self: self.plan_started(),
                         'In_Progress': lambda self: self.in_progress(),
                         'Completed': lambda self: self.completed(),
-                        'Successful': lambda self: self.successful()}
+                        'Successful': lambda self: self.successful(),
+                        'Stucked': lambda self: self.stucked_in_conversion()}
 
     def plan_started(self):
         """waits until the plan begins and starts showing progress time"""
@@ -437,6 +438,12 @@ class MigrationPlan(BaseEntity):
         """ Find migration plan and checks if plan is successful."""
         view = navigate_to(self, "Complete")
         return view.plans_completed_list.is_plan_succeeded(self.name)
+
+    def stucked_in_conversion(self):
+        """ Find migration plan stucked in conversion error"""
+        view = navigate_to(self, "InProgress")
+        error_msg = view.progress_card.is_plan_failed(self.name)
+        return "no conversion host" in error_msg
 
     def delete_not_started_plan(self):
         """ Find migration plan and delete."""

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -5353,6 +5353,7 @@ class MigrationProgressBar(Widget):
     VMS_LOCATOR = './/strong[contains(@id,"vms-migrated")]'
     SPINNER_LOCATOR = './/div[contains(@class,"spinner")]'
     ERROR_LOCATOR = './/div/span[contains(@class,"pficon-error-circle-o")]'
+    ERROR_TXT = './/p[contains(@class, "blank-slate-pf-info")]'
     PROGRESS_BARS = './/div[@class="progress-bar"]'
     PROGRESS_DESCRIPTION = './/div[contains(@class,"progress-description")]'
 
@@ -5446,6 +5447,17 @@ class MigrationProgressBar(Widget):
             for div in self.browser.elements(self.PROGRESS_BARS, parent=el)
         ]
         return dict(list(zip(desc, val)))
+
+    def is_plan_failed(self, plan_name):
+        """Returns false if plan is in progress and error if migration plan failed"""
+        el = self._get_card_element(plan_name)
+        error_displayed = self.browser.is_displayed(self.ERROR_LOCATOR, parent=el)
+        if error_displayed:
+            error_text = self.browser.text(self.ERROR_TXT, parent=el)
+            self.browser.click(".//button[contains(text(), 'Cancel Migration')]", parent=el)
+            return error_text
+        else:
+            return False
 
 
 class MigrationDashboardStatusCard(AggregateStatusCard):


### PR DESCRIPTION
## Purpose or Intent
- __Adding test__ to check migration without setting conversion host entry 

## pytest
{{ pytest: cfme/tests/v2v/test_v2v_migrations_ui.py --use-provider rhv43 --use-provider vsphere67-ims --provider-limit 2 -vvvv -k 'test_migration_with_no_conversion' }}

