### PR TITLE
[1LP][RFR][NOTEST] Remove insights and load balancers to fix test

### DIFF
--- a/cfme/roles.py
+++ b/cfme/roles.py
@@ -310,7 +310,6 @@ role_access_ui_510z = {
         'Networks': ['Subnets', 'Load Balancers', 'Providers', 'Security Groups', 'Floating IPs',
                      'Network Ports', 'Topology', 'Networks', 'Network Routers'],
         'Optimize': ['Bottlenecks', 'Planning', 'Utilization'],
-        'Red Hat Insights': ['Rules', 'Overview', 'Inventory', 'Actions'],
         'Services': ['Requests', 'Workloads', 'Catalogs', 'My Services'],
         'Storage': {
             'Block Storage': ['Volume Snapshots', 'Managers', 'Volume Backups', 'Volumes',

--- a/cfme/tests/configure/test_landing_page.py
+++ b/cfme/tests/configure/test_landing_page.py
@@ -107,7 +107,6 @@ ALL_LANDING_PAGES = list(SPECIAL_LANDING_PAGES.keys()) + [
     "Optimize / Bottlenecks",
     "Optimize / Planning",
     "Optimize / Utilization",
-    "Red Hat Access Insights",
     "Services / Catalogs",
     "Services / My Services",
     "Services / Requests",
@@ -148,8 +147,6 @@ PAGES_NOT_IN_511 = [
     "Optimize / Bottlenecks",
     "Optimize / Planning",
     "Optimize / Utilization",
-    "Red Hat Access Insights",
-    "Networks / Load Balancers",
 ]
 
 
@@ -210,8 +207,6 @@ def test_landing_page_admin(
     # splitting steps splits Import and Export, which we do not wanted, so joining them with /
     if "Import / Export" in start_page:
         steps = steps[:-2] + ["Import / Export"]
-    elif "Red Hat Access Insights" in start_page:
-        steps = ["Red Hat Insights", "Actions"]
     elif "Most Recent Alerts" in start_page:
         steps = steps[:-1]
 

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -876,7 +876,6 @@ FEATURES_511 = COMMON_FEATURES + [
 
 FEATURES_510 = COMMON_FEATURES + [
     "Cloud Intel",
-    "Red Hat Insights",
     "Optimize",
     "Access Rules for all Virtual Machines",
 ]


### PR DESCRIPTION
## Purpose or Intent
Red Hat Insights is no longer present, remove all references
- __Fixing__ 
    1. cfme/tests/configure/test_landing_page.py
    2. test_delete_users_from_collection