### PR TITLE
[1LP][RFR]Fixed bytes to string decode for public key in test_keypairs

### DIFF
--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -66,7 +66,7 @@ def test_keypair_crud_with_key(provider, appliance):
             3. Delete keypair.
     """
     key = RSA.generate(1024)
-    public_key = key.publickey().exportKey('OpenSSH')
+    public_key = key.publickey().exportKey('OpenSSH').decode('utf-8')
     keypair = appliance.collections.cloud_keypairs.create(
         fauxfactory.gen_alphanumeric(),
         provider,


### PR DESCRIPTION
Fixed bytes to string decode for public key in test_keypairs.
Probably new version of package that generates public_key is returning bytes instead of string.