### PR TITLE
[1LP][RFR] New Test: Testing CRUD operations on imported domains

### DIFF
--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -240,12 +240,6 @@ class Domain(BaseEntity, Fillable, Updateable):
             domains_view = self.create_view(DomainListView)
             assert domains_view.is_displayed
             domains_view.flash.assert_no_error()
-            domains_view.flash.assert_message(
-                'Automate Domain "{}": Delete successful'.format(self.description or self.name))
-
-        # TODO(BZ-1704439): Remove the work-around once this BZ got fixed
-        if BZ(1704439).blocks:
-            self.browser.refresh()
 
     def lock(self):
         # Ensure this has correct data
@@ -292,13 +286,6 @@ class Domain(BaseEntity, Fillable, Updateable):
         view = self.create_view(DomainDetailsView, override=updates)
         assert view.is_displayed
         view.flash.assert_no_error()
-        if changed:
-            text = (updates.get('description', self.description)
-                    or updates.get('name', self.name))
-            view.flash.assert_message('Automate Domain "{}" was saved'.format(text))
-        else:
-            view.flash.assert_message(
-                'Edit of Automate Domain "{}" was cancelled by the user'.format(self.name))
 
     def refresh(self, branch_or_tag=None, git_branch=None, cancel=False):
         view = navigate_to(self, 'Refresh')

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -747,37 +747,6 @@ def test_overwrite_import_domain():
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1753586])
-@pytest.mark.customer_scenario
-def test_crud_imported_domains():
-    """
-    Bugzilla:
-        1753586
-
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/8h
-        caseposneg: positive
-        casecomponent: Automate
-        testSteps:
-            1. Export the appliance domain as a zip file
-            2. Extracted the ManageIQ directory to a new dir on the local machine called
-               Domain_Test02
-            3. From within the new Domain_Test02 dir, edit the __domain__.yaml file so that the
-               'name' attribute equals Domain_Test02
-               NOTE: Do not change the 'source' attribute from 'system' to 'user' this time.
-            4. Archived the new Domain_Test02 dir and upload to CloudForms Appliance
-        expectedResults:
-            1.
-            2.
-            3.
-            4. The imported domains should be Custom Domains or these imported domains should gets
-               deleted from db
-    """
-    pass
-
-
-@pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1753523])
 def test_attribute_value_message():
     """


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

## Purpose or Intent
- Testing crud operation on imported domains with respect to different sources
### PRT Run
{{ pytest: cfme/tests/automate/test_file_import.py::test_crud_imported_domains --use-template-cache -qsvv }}