### PR TITLE
[1LP][RFR] New Test: Test embedded method copy to new domain

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -148,6 +148,9 @@ class MethodDetailsView(AutomateExplorerView):
     created_on = SummaryFormItem('Main Info', 'Created On', text_filter=parsetime.from_iso_with_utc)
     inputs = Table(locator='#params_grid', assoc_column='Input Name')
     script = ScriptBox()
+    embedded_method_table = Table(
+        "//*[@id='embedded_methods_div']/table[contains(@class, 'table')]"
+    )
 
     @property
     def is_displayed(self):

--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -579,39 +579,6 @@ def test_embed_tower_repo_add_remote_zone():
 
 
 @pytest.mark.tier(2)
-def test_automate_ansible_playbook_method_copy():
-    """
-    When copying a method within the automate model the copied method
-    does not have the Embedded Methods that are a part of the source method
-
-    Bugzilla:
-        1592140
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        initialEstimate: 1/2h
-        testSteps:
-            1. Configure a CFME appliance with the Embedded Ansible provider
-            2. Create Catalog item.
-            3. Create catalog.
-            4. Create Domain.
-            5. Create Method.
-            6. Create another domain.
-            7. Copy above method.
-        expectedResults:
-            1. Check Embedded Ansible Role is started.
-            2. Check catalog item is created.
-            3. Check catalog is added.
-            4. Check Domain is added.
-            5. Check method is added.
-            6. check second Domain attached.
-            7. Check method is being copied along with Path.
-    """
-    pass
-
-
-@pytest.mark.tier(2)
 def test_embed_tower_playbook_with_retry_interval():
     """
 


### PR DESCRIPTION
  
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>
## Purpose or Intent
 - Testing embedded method attached with inline automate method is getting copied to new domain
- Updated test steps by going through BZ. This does not belogs to ansible. So changed case component and assignee.
### PRT Run
{{ pytest: cfme/tests/automate/test_method.py::test_copy_with_embedded_method --use-template-cache -qsvv}}