### PR TITLE
[1LP][RFR] Add module scope to override provider markers in test_provision_stack

### DIFF
--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -208,7 +208,8 @@ def test_reconfigure_service(appliance, service_catalogs, request):
 @pytest.mark.provider(gen_func=providers,
                       filters=[cloud_filter, not_ec2],
                       override=True,
-                      selector=ONE_PER_TYPE)
+                      selector=ONE_PER_TYPE,
+                      scope='module')
 def test_remove_non_read_only_orch_template(appliance, provider, template, service_catalogs,
                                             request):
     """
@@ -232,7 +233,7 @@ def test_remove_non_read_only_orch_template(appliance, provider, template, servi
     assert not template.exists
 
 
-@pytest.mark.provider([EC2Provider], selector=ONE_PER_TYPE, override=True)
+@pytest.mark.provider([EC2Provider], selector=ONE_PER_TYPE, override=True, scope='module')
 def test_remove_read_only_orch_template_neg(appliance, provider, template, service_catalogs,
                                             request):
     """


### PR DESCRIPTION
Tests are failing in PRT because of some issues in the tests, not because of the provider fixture scope mismatch as @jaryn reported.