### PR TITLE
[1LP][RFR] Extend test_refresh_relationships: check for errors in evm.log

### DIFF
--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -10,6 +10,7 @@ from cfme.cloud.flavor import ProviderFlavorAllView
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider import CloudProviderImagesView
 from cfme.cloud.provider import CloudProviderInstancesView
+from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.cloud.stack import ProviderStackAllView
@@ -293,7 +294,8 @@ def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, r
 @pytest.mark.rhv1
 @pytest.mark.provider([CloudProvider, InfraProvider])
 @pytest.mark.tier(1)
-@pytest.mark.meta(blockers=[BZ(1756984)])
+@pytest.mark.meta(blockers=[
+    BZ(1756984, unblock=lambda provider: not provider.one_of(AzureProvider))])
 def test_provider_refresh_relationship(provider, setup_provider):
     """Tests provider refresh
 

--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -35,6 +35,7 @@ from cfme.storage.manager import ProviderStorageManagerAllView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
+from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for
 
 HOST_RELATIONSHIPS = [
@@ -292,6 +293,7 @@ def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, r
 @pytest.mark.rhv1
 @pytest.mark.provider([CloudProvider, InfraProvider])
 @pytest.mark.tier(1)
+@pytest.mark.meta(blockers=[BZ(1756984)])
 def test_provider_refresh_relationship(provider, setup_provider):
     """Tests provider refresh
 
@@ -302,8 +304,11 @@ def test_provider_refresh_relationship(provider, setup_provider):
         initialEstimate: 1/8h
         tags: relationship
     """
+    result = LogValidator("/var/www/miq/vmdb/log/evm.log", failure_patterns=[r".*ERROR.*"])
+    result.start_monitoring()
     provider.refresh_provider_relationships(method='ui')
     wait_for_relationship_refresh(provider)
+    assert result.validate(wait="60s")
 
 
 @test_requirements.relationships


### PR DESCRIPTION
There should be no errors during refreshing relationships.
By checking for errors in a more specific test case of this one [1] 5.10.11 blocker [2] was found. (Which will also block 5.10 of this test for now.)

[1] - https://github.com/ManageIQ/integration_tests/pull/9400
[2] - https://bugzilla.redhat.com/show_bug.cgi?id=1756984

{{ pytest:  cfme/tests/cloud_infra_common/test_relationships.py -v --use-provider complete  }}