### PR TITLE
[RFR] Fixed tag remove issue

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -366,6 +366,7 @@ class TaggableCommonBase(object):
                 row = view.form.tags.row(category=category, assigned_value=tag)
             row[0].click()
         else:
+            category = category.strip(' *')
             view.form.tags(category).remove()
 
     def _tags_action(self, view, cancel, reset):


### PR DESCRIPTION
## Purpose or Intent
- This issue is occurring because of change in names of tags assigned to user and groups. Tag category names differs in 5.10 and 5.11. 
- This issue is present on 5.11 while removing assigned tag.
- This fix is required for PR https://github.com/ManageIQ/integration_tests/pull/9331
## PRT RUN
{{ pytest: cfme/tests/cloud_infra_common/test_tag_objects.py --use-template-cache -qsvvv --long-running}}