### PR TITLE
[1LP][RFR] Update entities.get_all() to allow return of subset of total entities and optimize how I determine number of entities in test.

### DIFF
--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -378,7 +378,7 @@ def test_infrastructure_hosts_refresh_multi(appliance, setup_provider_min_hosts,
     """
     slice = 2
     hosts_view = navigate_to(provider.collections.hosts, "All")
-    num_hosts = len(hosts_view.entities._current_page_elements)
+    num_hosts = hosts_view.entities.paginator.items_amount
     if num_hosts < 2:
         pytest.skip('not enough hosts in appliance UI to run test')
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -363,7 +363,7 @@ def test_infrastructure_hosts_refresh_multi(appliance, setup_provider_min_hosts,
         initialEstimate: 1/6h
         testSteps:
             1. Navigate to the Compute > Infrastructure > Providers view.
-            2. Click on a provider guadicon, and then the hosts link along the top row of the view.
+            2. Click on a provider quadicon, and then the hosts link along the top row of the view.
             3. Select all hosts (need at least 2 hosts) by checking the box in upper left of
                quadicons.
             4. Click "Refresh Relationships and Power States" under the Configuration

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -376,22 +376,23 @@ def test_infrastructure_hosts_refresh_multi(appliance, setup_provider_min_hosts,
                banner where "X" is the number of selected hosts. Properties for each host are
                refreshed. Making changes to test pre-commithooks
     """
-    slice = 2
+    refresh = 2
+    my_slice = slice(0, refresh, None)
     hosts_view = navigate_to(provider.collections.hosts, "All")
     num_hosts = hosts_view.entities.paginator.items_amount
-    if num_hosts < 2:
+    if num_hosts < refresh:
         pytest.skip('not enough hosts in appliance UI to run test')
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=[f"'Refresh Provider' successfully initiated for "
-                                              f"{slice} Hosts"],
+                                              f"{refresh} Hosts"],
                             hostname=appliance.hostname)
     evm_tail.start_monitoring()
-    for h in hosts_view.entities.get_all(slice=slice):
+    for h in hosts_view.entities.get_all(slice=my_slice):
         h.check()
     hosts_view.toolbar.configuration.item_select('Refresh Relationships and Power States',
                                                  handle_alert=True)
     hosts_view.flash.assert_success_message(
-        f'Refresh initiated for {slice} Hosts from the CFME Database'
+        f'Refresh initiated for {refresh} Hosts from the CFME Database'
     )
     try:
         wait_for(provider.is_refreshed, func_kwargs={'force_refresh': False}, num_sec=300,

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -376,15 +376,15 @@ def test_infrastructure_hosts_refresh_multi(appliance, setup_provider_min_hosts,
                banner where "X" is the number of selected hosts. Properties for each host are
                refreshed. Making changes to test pre-commithooks
     """
-    refresh = 2
-    my_slice = slice(0, refresh, None)
+    num_refresh = 2
+    my_slice = slice(0, num_refresh, None)
     hosts_view = navigate_to(provider.collections.hosts, "All")
     num_hosts = hosts_view.entities.paginator.items_amount
-    if num_hosts < refresh:
+    if num_hosts < num_refresh:
         pytest.skip('not enough hosts in appliance UI to run test')
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=[f"'Refresh Provider' successfully initiated for "
-                                              f"{refresh} Hosts"],
+                                              f"{num_refresh} Hosts"],
                             hostname=appliance.hostname)
     evm_tail.start_monitoring()
     for h in hosts_view.entities.get_all(slice=my_slice):
@@ -392,7 +392,7 @@ def test_infrastructure_hosts_refresh_multi(appliance, setup_provider_min_hosts,
     hosts_view.toolbar.configuration.item_select('Refresh Relationships and Power States',
                                                  handle_alert=True)
     hosts_view.flash.assert_success_message(
-        f'Refresh initiated for {refresh} Hosts from the CFME Database'
+        f'Refresh initiated for {num_refresh} Hosts from the CFME Database'
     )
     try:
         wait_for(provider.is_refreshed, func_kwargs={'force_refresh': False}, num_sec=300,

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3441,9 +3441,10 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         """ obtains all entities like QuadIcon displayed by view
         Args:
             surf_pages (bool): current page entities if False, all entities otherwise
-            slice(int): if None, return all elements, else return the first {slice} elements.
+            slice(slice object): if None, return all elements, else apply {slice} to slice the
+            elements returned.
 
-        Returns: all entities (QuadIcon/etc.) displayed by view
+        Returns: all entities (QuadIcon/etc.) displayed by view, or sliced entities if slice.
         """
         if not surf_pages:
             return [

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3448,7 +3448,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         if not surf_pages:
             return [
                 self.parent.entity_class(parent=self, entity_id=el["entity_id"], name=el["name"])
-                for el in self._current_page_elements[:slice]
+                for el in self._current_page_elements[slice]
             ]
         else:
             entities = []
@@ -3458,7 +3458,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
                         self.parent.entity_class(
                             parent=self, entity_id=el["entity_id"], name=el["name"]
                         )
-                        for el in self._current_page_elements[:slice]
+                        for el in self._current_page_elements[slice]
                     ]
                 )
             return entities

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3437,17 +3437,18 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         # get_all uses self.entity_names, which handles versioned name query
         return [e.name for e in self.get_all(surf_pages=True)]
 
-    def get_all(self, surf_pages=False):
+    def get_all(self, surf_pages=False, slice=None):
         """ obtains all entities like QuadIcon displayed by view
         Args:
             surf_pages (bool): current page entities if False, all entities otherwise
+            slice(int): if None, return all elements, else return the first this many elements.
 
         Returns: all entities (QuadIcon/etc.) displayed by view
         """
         if not surf_pages:
             return [
                 self.parent.entity_class(parent=self, entity_id=el["entity_id"], name=el["name"])
-                for el in self._current_page_elements
+                for el in self._current_page_elements[:slice]
             ]
         else:
             entities = []
@@ -3457,7 +3458,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
                         self.parent.entity_class(
                             parent=self, entity_id=el["entity_id"], name=el["name"]
                         )
-                        for el in self._current_page_elements
+                        for el in self._current_page_elements[:slice]
                     ]
                 )
             return entities

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3437,7 +3437,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         # get_all uses self.entity_names, which handles versioned name query
         return [e.name for e in self.get_all(surf_pages=True)]
 
-    def get_all(self, surf_pages=False, slice=slice(0,None)):
+    def get_all(self, surf_pages=False, slice=slice(0, None)):
         """ obtains all entities like QuadIcon displayed by view
         Args:
             surf_pages (bool): current page entities if False, all entities otherwise

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3441,7 +3441,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         """ obtains all entities like QuadIcon displayed by view
         Args:
             surf_pages (bool): current page entities if False, all entities otherwise
-            slice(int): if None, return all elements, else return the first this many elements.
+            slice(int): if None, return all elements, else return the first {slice} elements.
 
         Returns: all entities (QuadIcon/etc.) displayed by view
         """

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3437,7 +3437,7 @@ class EntitiesConditionalView(View, ReportDataControllerMixin):
         # get_all uses self.entity_names, which handles versioned name query
         return [e.name for e in self.get_all(surf_pages=True)]
 
-    def get_all(self, surf_pages=False, slice=None):
+    def get_all(self, surf_pages=False, slice=slice(0,None)):
         """ obtains all entities like QuadIcon displayed by view
         Args:
             surf_pages (bool): current page entities if False, all entities otherwise


### PR DESCRIPTION
##  Purpose or Intent

- __Extending__  entities.get_all() to allow it to return only a subset of the available entities.  This will keep entities I am not using from being built.

### PRT Run
{{ pytest: --use-provider complete --long-running cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_refresh_multi cfme/tests/infrastructure/test_host.py::test_multiple_host_good_creds }}
