### PR TITLE
[1LP][RFR] Multi tenancy : Test group crud as tenant admin

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -19,7 +19,6 @@ from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.update import update
 
-
 pytestmark = [
     test_requirements.rbac
 ]
@@ -59,7 +58,7 @@ def child_tenant(appliance, request):
         parent=appliance.collections.tenants.get_root_tenant()
     )
     yield child_tenant
-    child_tenant.delete_if_exist()
+    child_tenant.delete_if_exists()
 
 
 @pytest.fixture(scope='module')
@@ -86,11 +85,11 @@ def new_tenant_admin(appliance, request, child_tenant, tenant_role):
     group = appliance.collections.groups.create(
         description=f'tenant_grp_{fauxfactory.gen_alphanumeric()}', role=tenant_role.name,
         tenant=f'My Company/{child_tenant.name}')
-    request.addfinalizer(group.delete_if_exists)
 
     tenant_admin = new_user(appliance, group, name='tenant_admin_user')
     yield tenant_admin
     tenant_admin.delete_if_exists()
+    group.delete_if_exists()
 
 
 @pytest.fixture(scope='function')

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -50,6 +50,35 @@ def new_role(appliance, name=None):
         vm_restriction='None')
 
 
+@pytest.fixture(scope='module')
+def new_tenant_admin(appliance, request):
+    tenant_collection = appliance.collections.tenants
+    child_tenant = tenant_collection.create(
+        name='child_tenant{}'.format(fauxfactory.gen_alphanumeric()),
+        description='tenant description',
+        parent=tenant_collection.get_root_tenant()
+    )
+    request.addfinalizer(child_tenant.delete_if_exists)
+
+    role = appliance.collections.roles.instantiate(name='EvmRole-tenant_administrator')
+    tenant_role = role.copy()
+    request.addfinalizer(tenant_role.delete_if_exists)
+
+    group_collection = appliance.collections.groups
+    group = group_collection.create(
+        description='tenant_grp{}'.format(fauxfactory.gen_alphanumeric()), role=tenant_role.name, tenant='My Company/' + child_tenant.name)
+    request.addfinalizer(group.delete_if_exists)
+
+    tenant_admin = new_user(appliance, group, name='tenant_admin')
+    request.addfinalizer(tenant_admin.delete_if_exists)
+    return {
+        "tenant_admin": tenant_admin,
+        "tenant": child_tenant.name,
+        "role": tenant_role.name,
+        "group": group.description
+    }
+
+
 @pytest.fixture(scope='function')
 def check_item_visibility(tag):
     def _check_item_visibility(item, user_restricted):
@@ -1462,6 +1491,93 @@ def test_superadmin_tenant_admin_crud(appliance):
         user.name = "{}_edited".format(user.name)
     user.delete()
     assert not user.exists
+
+
+@pytest.mark.tier(2)
+@test_requirements.multi_tenancy
+def test_tenantadmin_user_cruds(new_tenant_admin, request, appliance):
+    """
+    Perform CRUD operations on users as Tenant administrator.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: Configuration
+        caseimportance: high
+        tags: cfme_tenancy
+        initialEstimate: 1/4h
+        startsin: 5.5
+        testSteps:
+            1. Create new tenant admin user and assign him into group EvmGroup-tenant_administrator
+            2. As Tenant administrator, create new user, update user and delete user.
+    """
+    tenant_admin = new_tenant_admin['tenant_admin']
+    group_name = new_tenant_admin['group']
+
+    with tenant_admin:
+        pytest.set_trace()
+        appliance.server.logout()
+        navigate_to(appliance.server, 'LoggedIn')
+        assert appliance.server.current_full_name() == tenant_admin.name
+
+        group_collection = appliance.collections.groups
+        group = group_collection.instantiate(description=group_name)
+        tenant_user = new_user(appliance, group)
+        request.addfinalizer(tenant_user.delete)
+        assert tenant_user.exists
+
+        with update(tenant_user):
+            tenant_user.name = "{}edited".format(tenant_user.name)
+
+        tenant_user.delete()
+        assert not tenant_user.exists
+
+
+@pytest.mark.tier(2)
+@test_requirements.multi_tenancy
+def test_tenantadmin_group_cruds(new_tenant_admin, request, appliance):
+    """
+    Perform CRUD operations on users as Tenant administrator.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: Configuration
+        caseimportance: high
+        tags: cfme_tenancy
+        initialEstimate: 1/4h
+        startsin: 5.5
+        testSteps:
+            1. Create new tenant admin user and assign him into group EvmGroup-tenant_administrator
+            2. As Tenant administrator, create new user, update user and delete user.
+    group_name = 'EvmGroup-tenant_administrator'
+    group_collection = appliance.collections.groups
+    group = group_collection.instantiate(description=group_name)
+    tenantadmin = new_user(appliance, [group])
+    # request.addfinalizer(tenantadmin.delete)
+    # request.addfinalizer(appliance.server.login_admin)
+    assert tenantadmin.exists
+    """
+    tenant_admin = new_tenant_admin['tenant_admin']
+
+    pytest.set_trace()
+    with tenant_admin:
+        appliance.server.logout()
+        navigate_to(appliance.server, 'LoggedIn')
+        assert appliance.server.current_full_name() == tenant_admin.name
+
+        role = 'EvmRole-administrator'
+        group_collection = appliance.collections.groups
+        group = group_collection.create(
+            description='tenantgrp_{}'.format(fauxfactory.gen_alphanumeric()), role=new_tenant_admin['role'],
+            tenant='My Company/' + new_tenant_admin['tenant'])
+        request.addfinalizer(group.delete_if_exists)
+        assert group.exists
+
+        with update(group):
+            group.description = "{}edited".format(group.description)
+
+        pytest.set_trace()
+        group.delete()
+        assert not group.exists
 
 
 @pytest.mark.tier(3)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -1545,7 +1545,7 @@ def test_tenantadmin_user_crud(new_tenant_admin, request, appliance):
 
 @pytest.mark.tier(2)
 @test_requirements.multi_tenancy
-def test_tenantadmin_group_cruds(new_tenant_admin, request, appliance):
+def test_tenantadmin_group_crud(new_tenant_admin, request, appliance):
     """
     Perform CRUD operations on users as Tenant administrator.
 
@@ -1816,38 +1816,6 @@ def test_tenant_unique_automation_domain_name_on_parent_level(appliance, request
                 domain2.delete()
         except NameError:
             pass
-
-
-@pytest.mark.manual
-@pytest.mark.ignore_stream("upstream")
-@test_requirements.multi_tenancy
-def test_tenantadmin_user_crud():
-    """
-    As a Tenant Admin I want to be able to create users in my tenant
-
-    Polarion:
-        assignee: nachandr
-        casecomponent: Configuration
-        caseimportance: high
-        tags: cfme_tenancy
-        initialEstimate: 1/4h
-        startsin: 5.5
-        testSteps:
-            1. Login as super admin and create new tenant
-            2. Create new role by copying EvmRole-tenant_administrator
-            3. Create new group and choose role created in previous step and your
-            tenant
-            4. Create new tenant admin user and assign him into group created in
-            previous step
-            5. login as tenant admin
-            6. Perform crud operations
-
-            Note: BZ 1278484 - tenant admin role has no permissions to create new roles,
-            Workaround is to add modify permissions to tenant_administrator role or Roles
-            must be created by superadministrator. In 5.5.0.13 after giving additional permissions
-            to tenant_admin,able to create new roles
-    """
-    pass
 
 
 @pytest.mark.manual

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -59,7 +59,7 @@ def child_tenant(appliance, request):
         parent=appliance.collections.tenants.get_root_tenant()
     )
     yield child_tenant
-    child_tenant.delete()
+    child_tenant.delete_if_exist()
 
 
 @pytest.fixture(scope='module')
@@ -78,19 +78,19 @@ def tenant_role(appliance, request):
                 (['Everything', 'Main Configuration', 'Settings'], True)
             ]
     yield tenant_role
-    tenant_role.delete()
+    tenant_role.delete_if_exists()
 
 
 @pytest.fixture(scope='module')
 def new_tenant_admin(appliance, request, child_tenant, tenant_role):
     group = appliance.collections.groups.create(
-        description='tenant_grp{}'.format(fauxfactory.gen_alphanumeric()), role=tenant_role.name,
-        tenant='My Company/' + child_tenant.name)
+        description=f'tenant_grp_{fauxfactory.gen_alphanumeric()}', role=tenant_role.name,
+        tenant=f'My Company/{child_tenant.name}')
     request.addfinalizer(group.delete_if_exists)
 
     tenant_admin = new_user(appliance, group, name='tenant_admin_user')
     yield tenant_admin
-    tenant_admin.delete()
+    tenant_admin.delete_if_exists()
 
 
 @pytest.fixture(scope='function')
@@ -1511,7 +1511,7 @@ def test_superadmin_tenant_admin_crud(appliance):
 @test_requirements.multi_tenancy
 def test_tenantadmin_group_crud(new_tenant_admin, tenant_role, child_tenant, request, appliance):
     """
-    Perform CRUD operations on users as Tenant administrator.
+    Perform CRUD operations on groups as Tenant administrator.
 
     Polarion:
         assignee: nachandr
@@ -1530,8 +1530,8 @@ def test_tenantadmin_group_crud(new_tenant_admin, tenant_role, child_tenant, req
 
         group_collection = appliance.collections.groups
         group = group_collection.create(
-            description='tenantgrp_{}'.format(fauxfactory.gen_alphanumeric()),
-            role=tenant_role.name, tenant='My Company/' + child_tenant.name)
+            description=f'tenantgrp_{fauxfactory.gen_alphanumeric()}',
+            role=tenant_role.name, tenant=f'My Company/{child_tenant.name}')
         request.addfinalizer(group.delete_if_exists)
         assert group.exists
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -66,7 +66,8 @@ def new_tenant_admin(appliance, request):
 
     group_collection = appliance.collections.groups
     group = group_collection.create(
-        description='tenant_grp{}'.format(fauxfactory.gen_alphanumeric()), role=tenant_role.name, tenant='My Company/' + child_tenant.name)
+        description='tenant_grp{}'.format(fauxfactory.gen_alphanumeric()), role=tenant_role.name,
+        tenant='My Company/' + child_tenant.name)
     request.addfinalizer(group.delete_if_exists)
 
     tenant_admin = new_user(appliance, group, name='tenant_admin')
@@ -1564,11 +1565,10 @@ def test_tenantadmin_group_cruds(new_tenant_admin, request, appliance):
         navigate_to(appliance.server, 'LoggedIn')
         assert appliance.server.current_full_name() == tenant_admin.name
 
-        role = 'EvmRole-administrator'
         group_collection = appliance.collections.groups
         group = group_collection.create(
-            description='tenantgrp_{}'.format(fauxfactory.gen_alphanumeric()), role=new_tenant_admin['role'],
-            tenant='My Company/' + new_tenant_admin['tenant'])
+            description='tenantgrp_{}'.format(fauxfactory.gen_alphanumeric()),
+            role=new_tenant_admin['role'], tenant='My Company/' + new_tenant_admin['tenant'])
         request.addfinalizer(group.delete_if_exists)
         assert group.exists
 


### PR DESCRIPTION
{{pytest: cfme/tests/configure/test_access_control.py -k tenantadmin}}

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
Automating group crud operations for Tenant administrator
-->

###PRT results:
510 - PASS
511 - PASS

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
