### PR TITLE
[1LP][RFR] cleanup volume on target provider

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -378,6 +378,17 @@ def __set_conversion_instance_for_osp_ui(appliance, source_provider,  # noqa
                                        osp_ca_cert=tls_cert_key)
 
 
+def cleanup_target(provider, migrated_vm):
+    """Helper function to cleanup instances and associated volumes from openstack"""
+    if provider.one_of(OpenStackProvider):
+        volumes = []
+        vm = provider.mgmt.get_vm(migrated_vm.name)
+        for vol in vm.raw._info['os-extended-volumes:volumes_attached']:
+            volumes.append(vol['id'])
+        migrated_vm.cleanup_on_provider()
+        provider.mgmt.delete_volume(*volumes)
+
+
 def get_vm(request, appliance, source_provider, template, datastore='nfs'):
     """ Helper method that takes template , source provider and datastore
         and creates VM on source provider to migrate .

--- a/cfme/tests/v2v/test_v2v_ansible.py
+++ b/cfme/tests/v2v/test_v2v_ansible.py
@@ -4,6 +4,7 @@ import pytest
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.fixtures.provider import rhel7_minimal
+from cfme.fixtures.v2v_fixtures import cleanup_target
 from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -137,10 +138,6 @@ def test_migration_playbooks(request, appliance, source_provider, provider,
     mapping_data = mapping_data_vm_obj_single_datastore.infra_mapping_data
     mapping = infrastructure_mapping_collection.create(**mapping_data)
 
-    @request.addfinalizer
-    def _cleanup():
-        infrastructure_mapping_collection.delete(mapping)
-
     # vm_obj is a list, with only 1 VM object, hence [0]
     src_vm_obj = mapping_data_vm_obj_single_datastore.vm_list[0]
 
@@ -170,4 +167,10 @@ def test_migration_playbooks(request, appliance, source_provider, provider,
     view.flash.assert_no_error()
 
     migrated_vm = get_migrated_vm(src_vm_obj, provider)
+
+    @request.addfinalizer
+    def _cleanup():
+        infrastructure_mapping_collection.delete(mapping)
+        cleanup_target(provider, migrated_vm)
+
     assert src_vm_obj.mac_address == migrated_vm.mac_address

--- a/cfme/tests/v2v/test_v2v_schedule_migrations.py
+++ b/cfme/tests/v2v/test_v2v_schedule_migrations.py
@@ -4,6 +4,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
+from cfme.fixtures.v2v_fixtures import cleanup_target
 from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -31,7 +32,7 @@ pytestmark = [
 
 
 @pytest.mark.tier(3)
-def test_schedule_migration(appliance, provider, mapping_data_vm_obj_mini, soft_assert):
+def test_schedule_migration(appliance, provider, mapping_data_vm_obj_mini, soft_assert, request):
     """
     Test to validate schedule migration plan
 
@@ -67,4 +68,9 @@ def test_schedule_migration(appliance, provider, mapping_data_vm_obj_mini, soft_
     assert migration_plan.wait_for_state("Completed")
     assert migration_plan.wait_for_state("Successful")
     migrated_vm = get_migrated_vm(src_vm_obj, provider)
+
+    @request.addfinalizer
+    def _cleanup():
+        cleanup_target(provider, migrated_vm)
+
     soft_assert(src_vm_obj.mac_address == migrated_vm.mac_address)

--- a/cfme/tests/v2v/test_v2v_smoke.py
+++ b/cfme/tests/v2v/test_v2v_smoke.py
@@ -5,6 +5,7 @@ import pytest
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.fixtures.provider import rhel7_minimal
+from cfme.fixtures.v2v_fixtures import cleanup_target
 from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -59,10 +60,6 @@ def test_single_vm_migration_with_ssh_and_vddk(
     mapping_data = mapping_data_multiple_vm_obj_single_datastore.infra_mapping_data
     mapping = infrastructure_mapping_collection.create(**mapping_data)
 
-    @request.addfinalizer
-    def _cleanup():
-        infrastructure_mapping_collection.delete(mapping)
-
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
         name="plan_{}".format(fauxfactory.gen_alphanumeric()),
@@ -80,4 +77,10 @@ def test_single_vm_migration_with_ssh_and_vddk(
     # validate MAC address matches between source and target VMs
     src_vm = mapping_data_multiple_vm_obj_single_datastore.vm_list.pop()
     migrated_vm = get_migrated_vm(src_vm, provider)
+
+    @request.addfinalizer
+    def _cleanup():
+        infrastructure_mapping_collection.delete(mapping)
+        cleanup_target(provider, migrated_vm)
+
     assert src_vm.mac_address == migrated_vm.mac_address

--- a/cfme/v2v/migration_plans.py
+++ b/cfme/v2v/migration_plans.py
@@ -424,7 +424,7 @@ class MigrationPlan(BaseEntity):
             func=_in_progress,
             message="migration plan is in progress, be patient please",
             delay=5,
-            num_sec=1800,
+            num_sec=3600,
             fail_cond=False
         )
 


### PR DESCRIPTION
{{ pytest: cfme/tests/v2v/test_v2v_migrations.py --use-provider rhv43 --use-provider vsphere67-ims --provider-limit 2 -vvvv --long-running -k rhevm-4.3-virtualcenter-6.7-mapping_data_dual_vm_obj_dual_datastore0 }}