### PR TITLE
[1LP][RFR] Fixed instance type issue of rhos with quota

### DIFF
--- a/cfme/tests/cloud/test_quota_tagging.py
+++ b/cfme/tests/cloud/test_quota_tagging.py
@@ -46,9 +46,13 @@ def template_name(provisioning):
 def prov_data(provider, vm_name, template_name, provisioning):
     if provider.one_of(OpenStackProvider):
         return {
-            "catalog": {'vm_name': vm_name, 'catalog_name': {'name': template_name}},
-            "environment": {'automatic_placement': True},
-            "properties": {'instance_type': partial_match(provisioning["instance_type2"])}
+            "catalog": {"vm_name": vm_name, "catalog_name": {"name": template_name}},
+            "environment": {"automatic_placement": True},
+            "properties": {
+                "instance_type": partial_match(
+                    provisioning.get("instance_type2", "Instance type is not available")
+                )
+            },
         }
 
 


### PR DESCRIPTION
## Purpose or Intent
- This issue is related to instance type of rhos13 provider. Where m1.large is not available in now. So updated the test case with m1.small instance type.
- Now instance type is fetched from cfme_data.yml
- Also updated test case code
- My bad! I missed this file while working on this issue in PR https://github.com/ManageIQ/integration_tests/pull/9331
### PRT Run
{{ pytest: cfme/tests/cloud/test_tenant_quota.py --use-template-cache -qsvvvv --use-provider rhos13 --long-running }}