### PR TITLE
[1LP][RFR] skip pdf download

### DIFF
--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -27,4 +27,7 @@ def test_download_report(infra_provider, report, filetype):
         caseimportance: high
         initialEstimate: 1/20h
     """
+    if filetype == "pdf":
+        # TODO: fix pdf download or create a manual test
+        pytest.skip("pdf printing opens a window and all the next tests fail")
     report.download(filetype)


### PR DESCRIPTION
## Purpose or Intent
Last jenkins run revealed that this test is problematic and all tests that are executed after it fail, because when downloading pdf, the separate window opens and the focus is lost.

It could be possibly fixed by https://github.com/RedHatQE/widgetastic.core/pull/157

For now this should not be run in automation to avoid random failures.

### PRT Run
{{ pytest: -v cfme/tests/intelligence/test_download_report.py }}
