### PR TITLE
[1LP][RFR] Add test_infrastructure_hosts_crud to test_host.py to cover BZ1634794

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -119,6 +119,9 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
     def __eq__(self, other):
         return type(self) is type(other) and self.key == other.key
 
+    def __str__(self):
+        return self.name
+    
     @property
     def data(self):
         """ Returns yaml data for this provider.

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -121,7 +121,7 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
 
     def __str__(self):
         return self.name
-    
+
     @property
     def data(self):
         """ Returns yaml data for this provider.

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -119,9 +119,6 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
     def __eq__(self, other):
         return type(self) is type(other) and self.key == other.key
 
-    def __str__(self):
-        return self.name
-
     @property
     def data(self):
         """ Returns yaml data for this provider.

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -356,10 +356,10 @@ def test_hosts_not_displayed_several_times(appliance, provider, setup_provider):
 def setup_provider_min_hosts(request, appliance, provider, num_hosts):
     hosts_yaml = len(provider.data.get('hosts', {}))
     if hosts_yaml < num_hosts:
-        pytest.skip(f'Number of hosts defined in yaml for {provider.name} does not meet minimum '
+        pytest.skip(f'Number of hosts defined in yaml for {provider} does not meet minimum '
                     f'for test parameter {num_hosts}, skipping and not setting up provider')
     if len(provider.mgmt.list_host()) < num_hosts:
-        pytest.skip(f'Number of hosts on {provider.name} does not meet minimum '
+        pytest.skip(f'Number of hosts on {provider} does not meet minimum '
                     f'for test parameter {num_hosts}, skipping and not setting up provider')
     # Function-scoped fixture to set up a provider
     setup_or_skip(request, provider)

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -526,4 +526,4 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
         assert final_view.is_displayed
     except UnexpectedAlertPresentException:
         pytest.fail("Abandon changes alert displayed, but no changes made.")
-    # Todo add additional crud functionality.
+    # TODO add additional crud functionality.


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ for infra_hosts FA to cover BZ1634794 fixed in 5.11. And also updated setup_provider_min_hosts fixture and tests that use it.


### PRT Run

{{ pytest: --use-provider complete --long-running cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_crud
cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_refresh_multi
cfme/tests/infrastructure/test_host.py::test_compare_hosts_from_provider_allhosts }}
