### PR TITLE
[1LP][RFR] Remove superfluous manual vm retirement tests

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -35,8 +35,6 @@ from cfme.utils.pretty import Pretty
 from cfme.utils.rest import assert_response
 from cfme.utils.timeutil import parsetime
 from cfme.utils.update import Updateable
-from cfme.utils.version import LOWEST
-from cfme.utils.version import VersionPicker
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
 
@@ -220,14 +218,10 @@ class BaseVM(
     def is_retired(self):
         """Check retirement status of vm"""
         view = navigate_to(self, "Details", use_resetter=False)
-        if view.entities.summary('Lifecycle').get_text_of('Retirement Date').lower() != 'never':
+        if view.entities.summary('Lifecycle').get_text_of('Retirement Date') != 'Never':
             try:
-                retirement_state = VersionPicker({
-                    LOWEST: 'Retirement state',
-                    '5.10': 'Retirement State'
-                })
-                status = view.entities.summary('Lifecycle').get_text_of(retirement_state).lower()
-                return status == 'retired'
+                status = view.entities.summary('Lifecycle').get_text_of('Retirement State')
+                return status == 'Retired'
             except NameError:
                 return False
         else:
@@ -618,10 +612,6 @@ class BaseVMCollection(BaseCollection):
             if not BZ(1608967, forced_streams=['5.10']).blocks:
                 wait_for(lambda: view.flash.messages, fail_condition=[], timeout=10, delay=2,
                         message='wait for Flash Success')
-            # This flash message is not flashed in 5.10.
-            if self.appliance.version < 5.10:
-                wait_for(lambda: view.flash.messages, fail_condition=[], timeout=10, delay=2,
-                         message='wait for Flash Success')
             view.flash.assert_no_error()
             if wait:
                 if request_description is None:

--- a/cfme/tests/cloud_infra_common/test_retirement.py
+++ b/cfme/tests/cloud_infra_common/test_retirement.py
@@ -83,7 +83,7 @@ def verify_retirement_state(retire_vm):
     assert wait_for(
         lambda: retire_vm.is_retired, delay=5, num_sec=15 * 60,
         fail_func=view.toolbar.reload.click,
-        message="Wait for VM '{}' to enter retired state".format(retire_vm.name)
+        message=f"Wait for VM '{retire_vm.name}' to enter retired state"
     )
 
     retirement_states = ['retired']
@@ -140,6 +140,7 @@ def generate_retirement_date_now():
 
 
 @pytest.mark.rhv1
+@pytest.mark.meta(automates=[1518926, 1565128])
 def test_retirement_now(retire_vm):
     """Tests on-demand retirement of an instance/vm
 
@@ -147,9 +148,13 @@ def test_retirement_now(retire_vm):
         assignee: tpapaioa
         casecomponent: Provisioning
         initialEstimate: 1/6h
+
+    Bugzilla:
+        1518926
+        1565128
     """
-    # For 5.7 capture two times to assert the retire time is within a window.
-    # Too finicky to get it down to minute precision, nor is it really needed here
+    # Assert the Retirement Date is within a window +/- 5 minutes surrounding the actual
+    # retirement. Too finicky to get it down to minute precision, nor is it really needed here.
     retire_times = dict()
     retire_times['start'] = generate_retirement_date_now() + timedelta(minutes=-5)
     retire_vm.retire()

--- a/cfme/tests/cloud_infra_common/test_retirement_manual.py
+++ b/cfme/tests/cloud_infra_common/test_retirement_manual.py
@@ -27,28 +27,6 @@ def test_retire_infra_vms_folder():
     pass
 
 
-def test_retirement_date_uses_correct_time_zone():
-    """
-    Bug 1565128 - Wrong timezone when selecting retirement time
-
-    Bugzilla:
-        1565128
-
-    After saving VM retirement date/time (using both "Specific Date and
-    Time" and "Time Delay from Now" options), the displayed Retirement
-    Date has the correct date and time-zone appropriate time.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: Infra
-        caseimportance: medium
-        initialEstimate: 1/15h
-        startsin: 5.9
-        title: Retirement date uses correct time zone
-    """
-    pass
-
-
 @pytest.mark.tier(2)
 def test_retire_cloud_vms_date_folder():
     """
@@ -91,26 +69,6 @@ def test_retire_infra_vms_date_folder():
         casecomponent: Provisioning
         caseimportance: medium
         initialEstimate: 1/2h
-    """
-    pass
-
-
-def test_vms_retirement_state_field_is_capitalized_correctly():
-    """
-    Bug 1518926 - Inconsistent capitalization for Retirement State field
-
-    Bugzilla:
-        1518926
-
-    When a VM is retiring or retired, the VM should show a "Retirement
-    State" field, not "Retirement state".
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: WebUI
-        caseimportance: medium
-        initialEstimate: 1/15h
-        title: VM's Retirement State field is capitalized correctly
     """
     pass
 


### PR DESCRIPTION
This PR removes manual VM retirement tests that are already taken care of by existing automated tests:

test_vms_retirement_state_field_is_capitalized_correctly
test_retirement_date_uses_correct_time_zone

The capitalization of 'Retirement State' is fixed in 5.10 and later, so the version-specific capitalization is removed from the is_retired method. The datetime checking in verify_retirement_date verifies the expected time zone.

{{pytest: cfme/tests/cloud_infra_common/test_retirement.py -k 'not from_global_region' --use-provider vsphere67-nested -v --long-running}}