### PR TITLE
[1LP][RFR] Add planned-in to requirements for polarion

### DIFF
--- a/cfme/test_requirements.py
+++ b/cfme/test_requirements.py
@@ -59,7 +59,6 @@ ansible = pytest.mark.requirement(
     "Ansible Automation",
     description='Embedded Ansible Automation Requirement',
     assignee_id='sbulage',
-    planned_in_ids="5_11",
 )
 
 access = pytest.mark.requirement(

--- a/cfme/test_requirements.py
+++ b/cfme/test_requirements.py
@@ -43,7 +43,7 @@ Supported requirement metadata fields (and example data)
             "assignee_id": "mkourim",
             "category_ids": "category_id1, category_id2",
             "due_date": "2018-09-30",
-            "planned_in_ids": "planned_id1, planned_id2",
+            "planned_in_ids": "planned_id1 planned_id2",
             "initial_estimate": "1/4h",
             "priority_id": "high",
             "severity_id": "should_have",
@@ -54,16 +54,19 @@ Supported requirement metadata fields (and example data)
 """
 import pytest
 
+
 ansible = pytest.mark.requirement(
     "Ansible Automation",
     description='Embedded Ansible Automation Requirement',
     assignee_id='sbulage',
+    planned_in_ids="5_11",
 )
 
 access = pytest.mark.requirement(
     "Access",
     description='Direct integration of SaaS offerings in MIQ/CFME',
     assignee_id='juwatts',
+    planned_in_ids="5_11",
 )
 
 alert = pytest.mark.requirement(
@@ -100,6 +103,7 @@ bottleneck = pytest.mark.requirement(
     "Optimization and Bottleneck",
     description='Optimizations and Bottleneck ID, planned deprecation',
     assignee_id='nachandr',
+    planned_in_ids="5_10",
 )
 
 c_and_u = pytest.mark.requirement(
@@ -153,7 +157,8 @@ custom_button = pytest.mark.requirement(
 customer_stories = pytest.mark.requirement(
     "Customer Stories",
     description='Integration of multiple FAs, Day 2 Operations type tests',
-    assignee_id='ndhandre',)
+    assignee_id='ndhandre',
+)
 
 dashboard = pytest.mark.requirement(
     "Dashboard",

--- a/conf/polarion_tools.yaml
+++ b/conf/polarion_tools.yaml
@@ -33,6 +33,7 @@ default_fields:
     work_item_id: ""
 
 requirements_default_fields:
+    planned-in-ids: "5_10 5_11"
     approver-ids: "mshriver akarol smallamp jkrocil rhcf3_machine:approved"
     status-id: "approved"
 

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -128,7 +128,7 @@ docker-py==1.10.6
 docker-pycreds==0.4.0
 docutils==0.15.2
 dogpile.cache==0.7.1
-dump2polarion==0.46.0
+dump2polarion==0.46.1
 ecdsa==0.13.2
 entrypoints==0.3
 fauxfactory==3.0.6


### PR DESCRIPTION
An update to requirement meta, including 'planned in' ID's for polarion.

Default in yaml are the default supported versions of the framework.

Specific requirements can set the ID's as needed.