### PR TITLE
[1LP][RFR] Automated BZ 1742839 applicable for CF5.11

### DIFF
--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -19,6 +19,7 @@ class MyService(Updateable, Navigatable, Taggable, sentaku.modeling.ElementMixin
     retire_on_date = sentaku.ContextualMethod()
     exists = sentaku.ContextualProperty()
     delete = sentaku.ContextualMethod()
+    status = sentaku.ContextualProperty()
     set_ownership = sentaku.ContextualMethod()
     get_ownership = sentaku.ContextualMethod()
     edit_tags = sentaku.ContextualMethod()

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -315,6 +315,12 @@ def delete(self):
     view.flash.assert_success_message('Service "{}": Delete successful'.format(self.name))
 
 
+@MiqImplementationContext.external_for(MyService.status.getter, ViaUI)
+def status(self):
+    view = navigate_to(self, 'Details')
+    return view.provisioning.results.get_text_of("Status")
+
+
 @MiqImplementationContext.external_for(MyService.set_ownership, ViaUI)
 def set_ownership(self, owner, group):
     view = navigate_to(self, 'SetOwnership')

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -892,3 +892,27 @@ ansible_service_catalog, ansible_service_funcscope, ansible_service_request_func
         if appliance.version < "5.11"
         else "Finished"
     )
+
+
+@pytest.mark.tier(3)
+@pytest.mark.ignore_stream("5.10")
+@pytest.mark.meta(automates=[1742839], server_roles=["-ems_operations"])
+def test_ansible_service_with_operations_role_disabled(appliance, ansible_catalog_item,
+ansible_service_catalog, ansible_service_funcscope, ansible_service_request_funcscope):
+    """If the embedded ansible role is *not* on the same server as the ems_operations role,
+    then the run will never start.
+
+    Bugzilla:
+        1742839
+
+    Polarion:
+        assignee: sbulage
+        casecomponent: Ansible
+        initialEstimate: 1/3h
+        tags: ansible_embed
+    """
+    service_request = ansible_service_catalog.order()
+    service_request.wait_for_request(num_sec=300, delay=20)
+
+    view = navigate_to(ansible_service_funcscope, "Details")
+    assert view.provisioning.results.get_text_of("Status") == "Finished"

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -914,5 +914,4 @@ ansible_service_catalog, ansible_service_funcscope, ansible_service_request_func
     service_request = ansible_service_catalog.order()
     service_request.wait_for_request(num_sec=300, delay=20)
 
-    view = navigate_to(ansible_service_funcscope, "Details")
-    assert view.provisioning.results.get_text_of("Status") == "Finished"
+    assert ansible_service_funcscope.status == "Finished"


### PR DESCRIPTION
## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
Automated Ansible tests which stuck in queue and never finishes if "Provider Operations" role is disabled.
### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked
-->
{{pytest: cfme/tests/ansible/test_embedded_ansible_services.py -k "test_ansible_service_with_operations_role_disabled" --long-running -svvvv }}