### PR TITLE
[1LP][RFR] resetter should point all active services

### DIFF
--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -369,7 +369,7 @@ class MyServiceAll(CFMENavigateStep):
         self.prerequisite_view.navigation.select('Services', 'My Services')
 
     def resetter(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select('Services', 'My Services')
+        self.view.myservice.tree.click_path('Active Services')
 
 
 @navigator.register(MyService, 'Details')


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent

- Fix 
```
AttributeError: 'MyServiceAll' object has no attribute 'prerequisite_view'
```
- `resetter` should never use `prerequisite_view`; it can use `view` as its post operation
- We had this resetter to point `ActiveServices` so restoring old line.

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
-->

{{py.test: cfme/tests/services/test_service_performance.py::test_services_performance cfme/tests/automate/custom_button/test_service_objects.py::test_custom_button_automate_service_obj[Service-Submit_all-ViaUI] -vv}}
