### PR TITLE
[1LP][RFR] Specify a timeout on test_import_own_module

### DIFF
--- a/cfme/tests/test_modules_importable.py
+++ b/cfme/tests/test_modules_importable.py
@@ -38,4 +38,4 @@ def test_import_own_module(module_path):
         pytest.skip("{} is a known failed path".format(ROOT.dirpath().bestrelpath(module_path)))
     subprocess.check_call(
         [sys.executable, '-c',
-        'import sys, py;py.path.local(sys.argv[1]).pyimport()', str(module_path)])
+        'import sys, py;py.path.local(sys.argv[1]).pyimport()', str(module_path)], timeout=60)


### PR DESCRIPTION
Recently I opened a PR that caused `test_import_own_module` to hang in travis -- causing it to fail on a timeout. It is difficult to pinpoint the module that causes travis to hang. Specifying a timeout will allow users to see which module is causing the hang in the travis output. E.g.

```python
=================================== FAILURES ===================================
_________________ test_import_own_module[cfme/scripting/bz.py] _________________
module_path = local('/home/travis/build/ManageIQ/integration_tests/cfme/scripting/bz.py')
    @pytest.mark.parametrize('module_path', MODULES, ids=ROOT.dirpath().bestrelpath)
    @pytest.mark.long_running
    def test_import_own_module(module_path):
        """
        Polarion:
            assignee: mshriver
            casecomponent: Appliance
            initialEstimate: 1/4h
        """
        if module_path in KNOWN_FAILURES:
            pytest.skip("{} is a known failed path".format(ROOT.dirpath().bestrelpath(module_path)))
        subprocess.check_call(
            [sys.executable, '-c',
>           'import sys, py;py.path.local(sys.argv[1]).pyimport()', str(module_path)], timeout=60)
``` 