### PR TITLE
[1LP][RFR] Automated BZ1656308, Add Ansible repository in another zone.

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -431,32 +431,6 @@ def test_automate_ansible_playbook_method_type_verbosity():
 
 
 @pytest.mark.tier(2)
-def test_embed_tower_repo_add_remote_zone():
-    """
-    Test whether repository or credentials on New Zone.
-
-    Bugzilla:
-        1656308
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Ansible
-        initialEstimate: 1/2h
-        testSteps:
-            1. Configure a CFME appliance with the Embedded Ansible provider
-            2. Create a new zone
-            3. Move the appliance into the new zone
-            4. Add an embedded Ansible repository or credential
-        expectedResults:
-            1. Check Embedded Ansible Role is started.
-            2.
-            3.
-            4. Check Repository or Credentials were added.
-    """
-    pass
-
-
-@pytest.mark.tier(2)
 def test_embed_tower_playbook_with_retry_interval():
     """
 


### PR DESCRIPTION
## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

- [x] This will automate Embedded Ansible behavior after moving to another Zone(New).

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

-->

{{pytest: cfme/tests/ansible/test_embedded_ansible_basic.py::test_embed_tower_repo_add_new_zone  --long-running -svvvv }}