### PR TITLE
[1LP][RFR] Add methods to add and delete folders and subfolders

### DIFF
--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -101,6 +101,10 @@ class ReportMenu(BaseEntity):
         view.discard_button.click()
         return fields
 
+    def _action(self, action, manager, folder_name):
+        with manager as folder_manager:
+            getattr(folder_manager, action)(folder_name)
+
     def add_folder(self, group, folder):
         """Adds a folder under top-level.
 
@@ -108,8 +112,7 @@ class ReportMenu(BaseEntity):
             group: User group.
             folder: Name of the new folder.
         """
-        with self.manage_folder() as top_level:
-            top_level.add(folder)
+        self._action("add", self.manage_folder(group), folder)
 
     def add_subfolder(self, group, folder, subfolder):
         """Adds a subfolder under specified folder.
@@ -117,10 +120,28 @@ class ReportMenu(BaseEntity):
         Args:
             group: User group.
             folder: Name of the folder.
-            subfolder: Name of the new subdfolder.
+            subfolder: Name of the new subfolder.
         """
-        with self.manage_folder(folder) as fldr:
-            fldr.add(subfolder)
+        self._action("add", self.manage_folder(group, folder), subfolder)
+
+    def remove_folder(self, group, folder):
+        """Removes a folder under top-level.
+
+        Args:
+            group: User group.
+            folder: Name of the folder.
+        """
+        self._action("delete", self.manage_folder(group), folder)
+
+    def remove_subfolder(self, group, folder, subfolder):
+        """Removes a subfolder under specified folder.
+
+        Args:
+            group: User group.
+            folder: Name of the folder.
+            subfolder: Name of the subfolder.
+        """
+        self._action("delete", self.manage_folder(group, folder), subfolder)
 
     def reset_to_default(self, group):
         """Clicks the `Default` button.

--- a/cfme/tests/intelligence/reports/test_menus.py
+++ b/cfme/tests/intelligence/reports/test_menus.py
@@ -265,7 +265,7 @@ def test_reset_report_menus(appliance, get_custom_report, group, report_menus):
 
 @pytest.mark.parametrize("group", GROUPS)
 @pytest.mark.meta(coverage=[1762363])
-def test_custom_reports_menu_crd(
+def test_custom_reports_menu(
     appliance, group, report_menus, request, get_custom_report
 ):
     """

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3900,7 +3900,7 @@ class FolderManager(Widget):
 
     def add(self, folder_name):
         self.add_button.click()
-        wait_for(lambda: self.browser.elements(self._new_field) is not None, num_sec=5, delay=0.1)
+        wait_for(lambda: bool(self.browser.elements(self._new_field)), num_sec=5, delay=0.1)
         self.browser.double_click(self._new_field)
         self.browser.handle_alert(prompt=folder_name)
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3845,6 +3845,7 @@ class FolderManager(Widget):
 
     _fields = ".//div[@id='folder_grid']/div/div/div"
     _field = ".//div[@id='folder_grid']/div/div/div[normalize-space(.)={folder}]"
+    _new_field = ".//div[@id='folder_grid']/div/div[contains(normalize-space(.), 'New Folder')]"
 
     def __init__(self, parent, locator, logger=None):
         Widget.__init__(self, parent, logger=logger)
@@ -3897,11 +3898,15 @@ class FolderManager(Widget):
         else:
             return self.selected_field_element.text.encode("utf-8").strip()
 
-    def add(self, subfolder):
-        self.add_subfolder()
-        wait_for(lambda: self.selected_field_element is not None, num_sec=5, delay=0.1)
-        self.browser.double_click(self.selected_field_element, wait_ajax=False)
-        self.browser.handle_alert(prompt=subfolder)
+    def add(self, folder_name):
+        self.add_button.click()
+        wait_for(lambda: self.browser.elements(self._new_field) is not None, num_sec=5, delay=0.1)
+        self.browser.double_click(self._new_field)
+        self.browser.handle_alert(prompt=folder_name)
+
+    def delete(self, folder_name):
+        self.select_field(folder_name)
+        self.delete_button.click()
 
     def select_field(self, field):
         """Select field by text.


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ 
    1. `add_folder` and `add_subfolder` of ReportMenus
    2. Fix `add` method of `FolderManager` widget of wt.manageiq
- __Extending__ 
    1. Add `remove_folder` and `remove_subfolder` to ReportMenus
    2. Add ` delete` method to `FolderManager` widget of wt.manageiq
- __Adding tests__ 
    1. `test_reports_menu_folder_crd` to `test_menus.py`

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_menus.py -k "test_custom_reports_menu" -vvvv }}