### PR TITLE
[1LP][RFR] Archive vm custom button

### DIFF
--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -465,7 +465,7 @@ def test_custom_button_role_access_service(context):
 
 @test_requirements.customer_stories
 @pytest.mark.meta(automates=[BZ(1439883)])
-@pytest.mark.provider([VMwareProvider], override=True, scope="module")
+@pytest.mark.provider([VMwareProvider], override=True)
 @pytest.mark.uncollectif(lambda button_group: "GENERIC" in button_group)
 def test_custom_button_dialog_service_archived(
     request, appliance, provider, setup_provider, service_vm, button_group, dialog
@@ -545,7 +545,7 @@ def test_custom_button_dialog_service_archived(
                         delay=5,
                     )
                 except TimedOutError:
-                    assert False, f"Expected '1' requests; found '{log.matches[request_pattern]}'"
+                    pytest.fail(f"Expected '1' requests; found '{log.matches[request_pattern]}'")
 
 
 @pytest.mark.parametrize("context", [ViaUI, ViaSSUI])


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/automate/custom_button/test_service_objects.py::test_custom_button_dialog_service_archived -vv --use-provider vsphere67-nested}}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:


Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
