### PR TITLE
[1LP][RFR] New Test: test_reports_schedules_user

### DIFF
--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -19,12 +19,25 @@ from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
+from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
 from widgetastic_manageiq import AlertEmail
 from widgetastic_manageiq import PaginationPane
 from widgetastic_manageiq import SummaryForm
 from widgetastic_manageiq import Table
+
+
+class VolatileBootstrapSelect(BootstrapSelect):
+    def fill(self, items):
+        try:
+            super(VolatileBootstrapSelect, self).fill(items)
+        except NoSuchElementException:
+            logger.warning(
+                "fill() operation was successful, but no options are left in BootstrapSelect to"
+                " display/select hence the widget has disappeared. Returning True."
+            )
+            return True
 
 
 class SchedulesAllView(CloudIntelReportsView):
@@ -86,6 +99,7 @@ class SchedulesFormCommon(CloudIntelReportsView):
         emails_send = Checkbox("send_email_cb")
         from_email = TextInput(name="from")
         to_emails = AlertEmail()
+        user_email = VolatileBootstrapSelect("user_email")
 
     @View.nested
     class email_options(View):  # noqa

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -245,3 +245,5 @@ def test_reports_schedules_user(appliance, request, user, schedule_data):
     schedule = appliance.collections.schedules.create(**schedule_data)
     request.addfinalizer(schedule.delete)
     assert schedule.exists
+    view = schedule.create_view(ScheduleDetailsView)
+    assert view.schedule_info.get_text_of("To E-mail") == f"{user.name} ({user.email})"

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -6,6 +6,7 @@ import yaml
 from cfme import test_requirements
 from cfme.intelligence.reports.schedules import NewScheduleView
 from cfme.intelligence.reports.schedules import ScheduleDetailsView
+from cfme.rest.gen_data import users as _users
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.path import data_path
 from cfme.utils.wait import wait_for
@@ -90,6 +91,21 @@ def schedule(schedule_data, appliance):
     schedule = appliance.collections.schedules.create(**schedule_data)
     yield schedule
     schedule.delete_if_exists()
+
+
+@pytest.fixture
+def user(appliance, request):
+    users, user_data = _users(
+        request,
+        appliance,
+        name="Sherlock Holmes",
+        email="shholmes@redhat.com",
+        userid="shholmes",
+        password="smartvm",
+        group="EvmGroup-super_administrator",
+    )
+
+    return users[0]
 
 
 @pytest.mark.parametrize("interval", TIMER)
@@ -208,3 +224,24 @@ def test_reports_disable_enable_schedule_from_summary(appliance, schedule):
     navigate_to(schedule, "Details")
     view.configuration.item_select("Enable this Schedule")
     assert schedule.enabled
+
+
+def test_reports_schedules_user(appliance, request, user, schedule_data):
+    """
+    This test checks if a user is visible under the Emails options of schedule form
+    while creating a schedule
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        initialEstimate: 1/10h
+        setup:
+            1. Create a user with an email belonging to the same group as logged in user.
+        testSteps:
+            1. Create a schedule and check if the newly created user is available
+            under `User` dropdown.
+    """
+    schedule_data["email"] = {"user_email": f"{user.name} ({user.email})"}
+    schedule = appliance.collections.schedules.create(**schedule_data)
+    request.addfinalizer(schedule.delete)
+    assert schedule.exists


### PR DESCRIPTION
## Purpose or Intent
- __Extending__ 
    1. `ScheduleCollection` to include a new attribute `user_email`.
- __Adding tests__ 
    1. `test_reports_schedules_user`
- __Enhancement__
    1. Add a new widget `VolatileBootstrapSelect` for `user_email`.

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_reports_schedules.py -k "test_reports_schedules_user" -vvv }}