### PR TITLE
[1LP][RFR][NOTEST] Remove old test that is covered by automation

### DIFF
--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -296,8 +296,13 @@ def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, r
 @pytest.mark.tier(1)
 @pytest.mark.meta(blockers=[
     BZ(1756984, unblock=lambda provider: not provider.one_of(AzureProvider))])
+@pytest.mark.meta(automates=[1353285])
 def test_provider_refresh_relationship(provider, setup_provider):
     """Tests provider refresh
+
+    Bugzilla:
+        1353285
+        1756984
 
     Polarion:
         assignee: ghubale

--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -270,25 +270,3 @@ def test_check_disk_allocation_size_scvmm(vm):
         "Snapshots"
     )
     assert usage_snapshots.split()[0] > 0
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_vm_volume_specchar1_scvmm():
-    """
-    Special Test to verify that VMs that have Volumes with no drive letter
-    assigned don"t cause systemic SCVMM provider errors.  This is a low
-    priority test.
-
-    Bugzilla:
-        1353285
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Infra
-        caseimportance: low
-        initialEstimate: 1/4h
-        startsin: 5.6.1
-        upstream: no
-    """
-    pass


### PR DESCRIPTION
Removing the test case `test_vm_volume_specchar1_scvmm` as this test case is already covered by automation with `test_provider_refresh_relationship`