### PR TITLE
[1LP][RFR] automate test_ec2_tags_image & instance

### DIFF
--- a/cfme/fixtures/vm.py
+++ b/cfme/fixtures/vm.py
@@ -91,12 +91,3 @@ def testing_instance(appliance, provider, small_template, setup_provider):
     instance = _create_instance(appliance, provider, small_template.name)
     yield instance
     instance.cleanup_on_provider()
-
-
-@pytest.fixture(scope="function")
-def testing_instance2(appliance, provider, small_template, setup_provider):
-    """ Fixture to provision instance on the provider
-    """
-    instance2 = _create_instance(appliance, provider, small_template.name)
-    yield instance2
-    instance2.cleanup_on_provider()

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -43,24 +43,6 @@ def create_instance(appliance, provider, template_name):
     return instance
 
 
-@pytest.fixture(scope="function")
-def testing_instance(appliance, provider, small_template, setup_provider):
-    """ Fixture to provision instance on the provider
-    """
-    instance = create_instance(appliance, provider, small_template.name)
-    yield instance
-    instance.cleanup_on_provider()
-
-
-@pytest.fixture(scope="function")
-def testing_instance2(appliance, provider, small_template, setup_provider):
-    """ Fixture to provision instance on the provider
-    """
-    instance2 = create_instance(appliance, provider, small_template.name)
-    yield instance2
-    instance2.cleanup_on_provider()
-
-
 # This fixture must be named 'vm_name' because its tied to cfme/fixtures/virtual_machine
 @pytest.fixture(scope="function")
 def vm_name(testing_instance):

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -43,6 +43,15 @@ def create_instance(appliance, provider, template_name):
     return instance
 
 
+@pytest.fixture(scope="function")
+def testing_instance2(appliance, provider, small_template, setup_provider):
+    """ Fixture to provision instance on the provider
+    """
+    instance2 = create_instance(appliance, provider, small_template.name)
+    yield instance2
+    instance2.cleanup_on_provider()
+
+
 # This fixture must be named 'vm_name' because its tied to cfme/fixtures/virtual_machine
 @pytest.fixture(scope="function")
 def vm_name(testing_instance):

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -259,6 +259,5 @@ def test_ec2_tags(provider, request, ec2taggable, testing_instance):
     else:
         taggable = system.get_vm(testing_instance.name)
     taggable.set_tag(tag_key, tag_value)
-    provider.refresh_provider_relationships()
-    wait_for(provider.is_refreshed, func_kwargs={'refresh_delta': 10}, timeout=600)
+    provider.refresh_provider_relationships(wait=600)
     assert taggable.get_tag_value(tag_key) == tag_value

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -243,11 +243,10 @@ def test_ec2_tags(provider, request, collection_type, testing_instance):
             test:testing in Labels field
             5. Delete that instance/untag image
     """
-    system = provider.mgmt
     tag_key = f"test_{fauxfactory.gen_alpha()}"
     tag_value = f"testing_{fauxfactory.gen_alpha()}"
     if collection_type == "templates":
-        taggable = system.list_templates()[0]
+        taggable = provider.mgmt.list_templates()[0]
         request.addfinalizer(lambda: taggable.unset_tag(tag_key, tag_value))
     else:
         taggable = testing_instance.mgmt

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -2,7 +2,6 @@ import fauxfactory
 import pytest
 from widgetastic.utils import partial_match
 from wrapanapi.exceptions import ImageNotFoundError
-
 from wrapanapi.systems.ec2 import EC2Image
 from wrapanapi.systems.ec2 import EC2Instance
 
@@ -11,7 +10,6 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.exceptions import ItemNotFound
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
-from cfme.tests.cloud.test_instance_power_control import testing_instance
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -262,4 +262,3 @@ def test_ec2_tags(provider, request, ec2taggable, testing_instance):
     provider.refresh_provider_relationships()
     wait_for(provider.is_refreshed, func_kwargs={'refresh_delta': 10}, timeout=600)
     assert taggable.get_tag_value(tag_key) == tag_value
-

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -226,36 +226,6 @@ def test_mapping_tags(
     soft_assert(not '{}: {}'.format(category.name, tag_value) in entity.get_tags())
 
 
-@pytest.mark.manual
-@pytest.mark.tier(2)
-@pytest.mark.provider([EC2Provider], override=True, scope='function')
-def test_ec2_tags_instances(provider, testing_instance):
-    """ probably to_delete
-    Requirement: Have an ec2 provider
-
-    Polarion:
-        assignee: anikifor
-        casecomponent: Cloud
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.8
-        testSteps:
-            1. Create an instance with tag test:testing
-            2. Refresh provider
-            3. Go to summary of this instance and check whether there is
-            test:testing in Labels field
-            4. Delete that instance
-    """
-    """system = provider.mgmt
-    tag_key = f"test_{fauxfactory.gen_alpha()}"
-    tag_value = f"testing_{fauxfactory.gen_alpha()}"
-    instance = system.get_vm(testing_instance.name)
-    instance.set_tag(tag_key, tag_value)
-    provider.refresh_provider_relationships()
-    wait_for(provider.is_refreshed, func_kwargs={'refresh_delta': 10}, timeout=600)
-    assert instance.get_tag_value(tag_key) == tag_value"""
-
-
 @pytest.mark.tier(2)
 @pytest.mark.parametrize("ec2taggable", [EC2Image, EC2Instance])
 @pytest.mark.provider([EC2Provider], override=True, scope='function')
@@ -269,29 +239,27 @@ def test_ec2_tags(provider, request, ec2taggable, testing_instance):
         caseimportance: medium
         initialEstimate: 1/6h
         startsin: 5.8
-        testSteps Image:
+        testSteps:
             1. Select an AMI in AWS console and tag it with test:testing
             2. Refresh provider
             3. Go to summary of this image  and check whether there is
             test:testing in Labels field
             4. Delete that tag
-        testSteps Instance:
+        testSteps:
             1. Create an instance with tag test:testing
             2. Refresh provider
             3. Go to summary of this instance and check whether there is
             test:testing in Labels field
             4. Delete that instance
     """
-
     system = provider.mgmt
     tag_key = f"test_{fauxfactory.gen_alpha()}"
     tag_value = f"testing_{fauxfactory.gen_alpha()}"
     if ec2taggable == EC2Image:
         taggable = system.list_templates()[0]
-        request.addfinalizer(lambda: taggable.unset_tag(tag_key,tag_value))
+        request.addfinalizer(lambda: taggable.unset_tag(tag_key, tag_value))
     else:
         taggable = system.get_vm(testing_instance.name)
-
     taggable.set_tag(tag_key, tag_value)
     provider.refresh_provider_relationships()
     wait_for(provider.is_refreshed, func_kwargs={'refresh_delta': 10}, timeout=600)

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -2,9 +2,6 @@ import fauxfactory
 import pytest
 from widgetastic.utils import partial_match
 from wrapanapi.exceptions import ImageNotFoundError
-from wrapanapi.systems.ec2 import EC2Image
-#from wrapanapi.systems.ec2 import EC2Instance
-from cfme.cloud.instance.ec2 import EC2Instance
 
 from cfme import test_requirements
 from cfme.cloud.provider.azure import AzureProvider
@@ -239,17 +236,12 @@ def test_ec2_tags(provider, request, collection_type, testing_instance):
         initialEstimate: 1/6h
         startsin: 5.8
         testSteps:
-            1. Select an AMI in AWS console and tag it with test:testing
-            2. Refresh provider
-            3. Go to summary of this image  and check whether there is
+            1. Create an instance/choose image
+            2. tag it with test:testing on EC side
+            3. Refresh provider
+            4. Go to summary of this instance/image and check whether there is
             test:testing in Labels field
-            4. Delete that tag
-        testSteps:
-            1. Create an instance with tag test:testing
-            2. Refresh provider
-            3. Go to summary of this instance and check whether there is
-            test:testing in Labels field
-            4. Delete that instance
+            5. Delete that instance/untag image
     """
     system = provider.mgmt
     tag_key = f"test_{fauxfactory.gen_alpha()}"
@@ -258,7 +250,7 @@ def test_ec2_tags(provider, request, collection_type, testing_instance):
         taggable = system.list_templates()[0]
         request.addfinalizer(lambda: taggable.unset_tag(tag_key, tag_value))
     else:
-        taggable = system.get_vm(testing_instance.name)
+        taggable = testing_instance.mgmt
     taggable.set_tag(tag_key, tag_value)
     provider.refresh_provider_relationships(wait=600)
     collection = provider.appliance.provider_based_collection(provider, coll_type=collection_type)


### PR DESCRIPTION
{{ pytest: cfme/tests/cloud/test_tag_mapping.py::test_ec2_tags -v --use-provider complete }}
{{ pytest: cfme/tests/cloud/test_instance_power_control.py -v --use-provider complete }}