### PR TITLE
[1LP][RFR] New Test: Testing default values of dialog widgets

### DIFF
--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -4,6 +4,7 @@ from widgetastic.widget import Select
 from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic.xpath import quote
+from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import BootstrapSwitch
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
@@ -54,7 +55,10 @@ class ElementForm(AddBoxView):
         )
         field_required = DialogBootstrapSwitch(label='Required')
         default_value = DialogBootstrapSwitch(label='Default value')
-        field_required = DialogBootstrapSwitch(label='Required')
+        default_value_dropdown = BootstrapSelect(
+            locator='//label[contains(normalize-space(.), '
+                    '"Default value")]/following-sibling::div/span/div'
+        )
         field_past_dates = DialogBootstrapSwitch(label='Show Past Dates')
         field_category = Select(
             locator='.//select[../../../../label[normalize-space(text())="Category"]]')

--- a/cfme/services/service_catalogs/__init__.py
+++ b/cfme/services/service_catalogs/__init__.py
@@ -17,6 +17,7 @@ from cfme.exceptions import ItemNotFound
 from cfme.utils.appliance import Navigatable
 from cfme.utils.update import Updateable
 from cfme.utils.wait import TimedOutError
+from widgetastic_manageiq import RadioGroup
 
 
 class ServiceCatalogs(Navigatable, Taggable, Updateable, sentaku.modeling.ElementMixin):
@@ -67,6 +68,10 @@ class BaseOrderForm(View):
             locator=ParametrizedLocator(
                 '//label[contains(text(), "{key}")]/following-sibling::div/button'
             )
+        )
+        radiogroup = RadioGroup(locator=(
+            '//div[contains(@ng-switch-when, "DialogFieldRadioButton")]/span[contains(@class, '
+            '"ng-scope")]')
         )
 
         @property

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from datetime import date
+
 import fauxfactory
 import pytest
 from widgetastic.exceptions import NoSuchElementException
@@ -7,67 +9,70 @@ from widgetastic.utils import partial_match
 from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.infrastructure.provider import InfraProvider
-from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 
 pytestmark = [
-    pytest.mark.meta(server_roles="+automate",
-                     blockers=[BZ(1633540, forced_streams=['5.10'],
-                        unblock=lambda provider: not provider.one_of(RHEVMProvider))]),
     pytest.mark.ignore_stream("upstream"),
-    pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
     test_requirements.dialog,
     pytest.mark.long_running,
-    pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE,
-                         required_fields=[['provisioning', 'template'],
-                                          ['provisioning', 'host'],
-                                          ['provisioning', 'datastore']],
-                         scope="module")
 ]
+
+WIDGETS = {
+    "Text Box": ("input", fauxfactory.gen_alpha()),
+    "Check Box": ("checkbox", True),
+    "Text Area": ("input", fauxfactory.gen_alpha()),
+    "Radio Button": ("radiogroup", "One"),
+    "Dropdown": ("dropdown", "Three"),
+    "Tag Control": ("dropdown", "Service Level"),
+    "Timepicker": ("input", date.today().strftime("%m/%d/%Y"))
+}
 
 
 @pytest.fixture(scope="function")
-def tagcontrol_dialog(appliance):
+def service_dialog(appliance, widget_name):
     service_dialog = appliance.collections.service_dialogs
-    dialog = "dialog_" + fauxfactory.gen_alphanumeric()
     element_data = {
         'element_information': {
-            'ele_label': "Service Level",
-            'ele_name': "service_level",
-            'ele_desc': "service_level_desc",
-            'choose_type': "Tag Control",
+            'ele_label': fauxfactory.gen_alphanumeric(start="label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(start="name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(start="desc_"),
+            'choose_type': widget_name,
         },
         'options': {
-            'field_category': "Service Level",
             'field_required': True
         }
     }
-    sd = service_dialog.create(label=dialog, description="my dialog")
-    tab = sd.tabs.create(tab_label='tab_' + fauxfactory.gen_alphanumeric(),
-        tab_desc="my tab desc")
-    box = tab.boxes.create(box_label='box_' + fauxfactory.gen_alphanumeric(),
-        box_desc="my box desc")
+    wt, value = WIDGETS[widget_name]
+    if widget_name in ["Text Box", "Text Area"]:
+        element_data['options']['default_text_box'] = value
+    if widget_name in ["Dropdown", "Radio Button"]:
+        element_data['options']['default_value_dropdown'] = value
+    if widget_name == "Check Box":
+        element_data['options']['default_value'] = value
+    if widget_name == "Tag Control":
+        element_data['options']['field_category'] = value
+
+    sd = service_dialog.create(label=fauxfactory.gen_alphanumeric(start="dialog_"),
+                               description="my dialog")
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
+                         tab_desc="my tab desc")
+    box = tab.boxes.create(box_label=fauxfactory.gen_alphanumeric(start="box_"),
+                           box_desc="my box desc")
     box.elements.create(element_data=[element_data])
-    yield sd
+    yield sd, element_data
+    sd.delete_if_exists()
 
 
 @pytest.fixture(scope="function")
-def catalog(appliance):
-    catalog = "cat_" + fauxfactory.gen_alphanumeric()
-    cat = appliance.collections.catalogs.create(name=catalog, description="my catalog")
-    yield cat
-
-
-@pytest.fixture(scope="function")
-def catalog_item(appliance, provider, provisioning, tagcontrol_dialog, catalog):
-    template, host, datastore, iso_file, vlan = list(map(provisioning.get,
-        ('template', 'host', 'datastore', 'iso_file', 'vlan')))
-
+def catalog_item(appliance, provider, provisioning, service_dialog, catalog):
+    sd, element_data = service_dialog
+    template, host, datastore, iso_file, vlan = list(map(
+        provisioning.get, ('template', 'host', 'datastore', 'iso_file', 'vlan'))
+    )
     provisioning_data = {
         'catalog': {'catalog_name': {'name': template, 'provider': provider.name},
                     'vm_name': random_vm_name('service')},
@@ -80,23 +85,54 @@ def catalog_item(appliance, provider, provisioning, tagcontrol_dialog, catalog):
         provisioning_data['catalog']['provision_type'] = 'Native Clone'
     elif provider.type == 'virtualcenter':
         provisioning_data['catalog']['provision_type'] = 'VMware'
-    item_name = fauxfactory.gen_alphanumeric()
+
     catalog_item = appliance.collections.catalog_items.create(
         provider.catalog_item_type,
-        name=item_name,
+        name=fauxfactory.gen_alphanumeric(),
         description="my catalog",
         display_in=True,
         catalog=catalog,
-        dialog=tagcontrol_dialog,
+        dialog=sd,
         prov_data=provisioning_data)
-    return catalog_item
+    yield catalog_item
+    catalog_item.delete_if_exists()
+
+
+@pytest.fixture(scope="function")
+def generic_catalog_item(appliance, service_dialog, catalog):
+    sd, element_data = service_dialog
+    item_name = fauxfactory.gen_alphanumeric()
+    catalog_item = appliance.collections.catalog_items.create(
+        appliance.collections.catalog_items.GENERIC,
+        name=item_name,
+        description=fauxfactory.gen_alphanumeric(),
+        display_in=True,
+        catalog=catalog,
+        dialog=sd)
+    yield catalog_item
+    catalog_item.delete_if_exists()
 
 
 @pytest.mark.rhv2
 @pytest.mark.tier(2)
-@pytest.mark.ignore_stream("upstream")
-def test_tagdialog_catalog_item(appliance, provider, catalog_item, request):
+@pytest.mark.provider(
+    [InfraProvider],
+    selector=ONE_PER_TYPE,
+    required_fields=[
+        ["provisioning", "template"],
+        ["provisioning", "host"],
+        ["provisioning", "datastore"],
+    ],
+    scope="module",
+)
+@pytest.mark.parametrize("widget_name", ["Tag Control"], ids=["tag_control"])
+def test_tagdialog_catalog_item(appliance, setup_provider, provider, catalog_item, request,
+                                service_dialog, widget_name):
     """Tests tag dialog catalog item
+
+    Bugzilla:
+        1633540
+
     Metadata:
         test_flag: provision
 
@@ -106,22 +142,21 @@ def test_tagdialog_catalog_item(appliance, provider, catalog_item, request):
         casecomponent: Services
         tags: service
     """
+    sd, element_data = service_dialog
     vm_name = catalog_item.prov_data['catalog']["vm_name"]
     request.addfinalizer(
         lambda: appliance.collections.infra_vms.instantiate(
-            "{}0001".format(vm_name), provider).cleanup_on_provider()
+            f"{vm_name}0001", provider).cleanup_on_provider()
     )
-    dialog_values = {'service_level': "Gold"}
+    dialog_values = {element_data['element_information']['ele_name']: 'Gold'}
     service_catalogs = ServiceCatalogs(appliance, catalog=catalog_item.catalog,
-                                       name=catalog_item.name,
-                                       dialog_values=dialog_values)
+                                       name=catalog_item.name, dialog_values=dialog_values)
     service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service {}'.format(catalog_item.name))
-    request_description = catalog_item.name
-    provision_request = appliance.collections.requests.instantiate(request_description,
+    logger.info(f'Waiting for cfme provision request for service {catalog_item.name}')
+    provision_request = appliance.collections.requests.instantiate(catalog_item.name,
                                                                    partial_check=True)
     provision_request.wait_for_request()
-    msg = "Request failed with the message {}".format(provision_request.rest.message)
+    msg = f"Request failed with the message {provision_request.rest.message}"
     assert provision_request.is_succeeded(), msg
 
 
@@ -501,12 +536,19 @@ def test_dialog_dropdown_ui_values_in_the_dropdown_should_be_visible_in_edit_mod
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(1)
-@pytest.mark.parametrize('element_type', ['dropdown', 'text_box', 'checkbox', 'text_area',
-                                          'radiobutton', 'date_picker', 'timepicker', 'tagcontrol'])
-def test_dialog_elements_should_display_default_value(element_type):
+@pytest.mark.customer_scenario
+@pytest.mark.meta(automates=[1385898])
+@pytest.mark.parametrize(
+    "widget_name", list(WIDGETS.keys()),
+    ids=["_".join(w.split()).lower() for w in WIDGETS.keys()],
+)
+def test_dialog_elements_should_display_default_value(appliance, generic_catalog_item,
+                                                      service_dialog, widget_name):
     """
+    Bugzilla:
+        1385898
+
     Polarion:
         assignee: nansari
         casecomponent: Services
@@ -521,7 +563,28 @@ def test_dialog_elements_should_display_default_value(element_type):
             1.
             2.
             3. Default values should be shown
-    Bugzilla:
-        1385898
     """
-    pass
+    sd, element_data = service_dialog
+    service_catalogs = ServiceCatalogs(
+        appliance, generic_catalog_item.catalog, generic_catalog_item.name
+    )
+    view = navigate_to(service_catalogs, "Order")
+    ele_name = element_data["element_information"]["ele_name"]
+    wt, value = WIDGETS[widget_name]
+
+    if widget_name in ["Text Box", "Text Area", "Dropdown", "Timepicker", "Check Box"]:
+        value = (date.today().strftime("%Y-%m-%d")
+                 if widget_name == "Timepicker" and appliance.version < "5.11"
+                 else value)
+        assert getattr(view.fields(ele_name), wt).read() == value
+    elif widget_name == "Tag Control":
+        # In case of tag control, we do not have default value feature. But need to select category
+        # to check whether it fetches respective values or not
+        all_options = ["", "<Choose>", "Gold", "Platinum", "Silver"]
+        if appliance.version < "5.11":
+            all_options.remove("")
+
+        for i in range(len(getattr(view.fields(ele_name), wt).all_options)):
+            assert getattr(view.fields(ele_name), wt).all_options[i].text in all_options
+    else:
+        assert getattr(view.fields(ele_name), wt).selected == value


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>
## Purpose or Intent
- Automated scenario: ```Testing default values of dialog widgets```
- Updated test case: ```test_tagdialog_catalog_item```

### PRT Run
{{ pytest: cfme/tests/services/test_different_dialogs_in_catalogs.py -vvvv --long-running }}