### PR TITLE
[WIPTEST] Restore accidentally-removed module scope for provider fixture.

### DIFF
--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -273,7 +273,8 @@ def metering_report(appliance, vm_ownership, provider):
 # usage estimated in the resource_usage fixture, therefore a small deviation is fine.
 @pytest.mark.provider(gen_func=providers,
                       filters=[cloud_and_infra, not_scvmm, not_cloud],
-                      override=True)
+                      override=True,
+                      scope='module')
 def test_validate_cpu_usage(resource_usage, metering_report):
     """Test to validate CPU usage.This metric is not collected for cloud providers.
 
@@ -297,7 +298,8 @@ def test_validate_cpu_usage(resource_usage, metering_report):
 
 @pytest.mark.provider(gen_func=providers,
                       filters=[cloud_and_infra, not_scvmm, not_ec2_gce],
-                      override=True)
+                      override=True,
+                      scope='module')
 def test_validate_memory_usage(resource_usage, metering_report):
     """Test to validate memory usage.This metric is not collected for GCE, EC2.
 

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -516,7 +516,8 @@ def new_compute_rate(appliance):
 # costs estimated in the chargeback_costs_default/chargeback_costs_custom fixtures.
 @pytest.mark.provider(gen_func=providers,
                       filters=[cloud_and_infra, not_scvmm, not_cloud],
-                      override=True)
+                      override=True,
+                      scope='module')
 def test_validate_default_rate_cpu_usage_cost(chargeback_costs_default, chargeback_report_default):
     """Test to validate CPU usage cost.
        Calculation is based on default Chargeback rate.
@@ -539,7 +540,8 @@ def test_validate_default_rate_cpu_usage_cost(chargeback_costs_default, chargeba
 @pytest.mark.rhv2
 @pytest.mark.provider(gen_func=providers,
                       filters=[cloud_and_infra, not_scvmm, not_ec2_gce],
-                      override=True)
+                      override=True,
+                      scope='module')
 def test_validate_default_rate_memory_usage_cost(chargeback_costs_default,
         chargeback_report_default):
     """Test to validate memory usage cost.
@@ -622,7 +624,8 @@ def test_validate_default_rate_storage_usage_cost(chargeback_costs_default,
 @pytest.mark.rhv3
 @pytest.mark.provider(gen_func=providers,
                       filters=[cloud_and_infra, not_scvmm, not_cloud],
-                      override=True)
+                      override=True,
+                      scope='module')
 def test_validate_custom_rate_cpu_usage_cost(chargeback_costs_custom, chargeback_report_custom):
     """Test to validate CPU usage cost.
        Calculation is based on custom Chargeback rate.
@@ -645,7 +648,8 @@ def test_validate_custom_rate_cpu_usage_cost(chargeback_costs_custom, chargeback
 @pytest.mark.rhv1
 @pytest.mark.provider(gen_func=providers,
                       filters=[cloud_and_infra, not_scvmm, not_ec2_gce],
-                      override=True)
+                      override=True,
+                      scope='module')
 def test_validate_custom_rate_memory_usage_cost(chargeback_costs_custom, chargeback_report_custom):
     """Test to validate memory usage cost.
        Calculation is based on custom Chargeback rate.


### PR DESCRIPTION
This PR restores module scope to provider fixtures where it was accidentally removed by the changes introduced in:

[1LP][RFR] Remove uses of uncollectif where provider markers should be used
https://github.com/ManageIQ/integration_tests/pull/9419

Those changes resulted in errors like the following:

```
____ ERROR at setup of test_validate_custom_rate_memory_usage_cost[virtualcenter-6.5] ____
ScopeMismatch: You tried to access the 'function' scoped fixture 'provider' with a 'module' scoped request object, involved factories
cfme/fixtures/provider.py:282:  def setup_provider_modscope(request, provider)
[...]
```

{{ pytest: cfme/tests/intelligence/reports/test_metering_report.py::test_validate_memory_usage cfme/tests/intelligence/reports/test_validate_chargeback_report.py::test_validate_default_rate_memory_usage_cost --use-provider vsphere67-nested -v }}
