### PR TITLE
[1LP][RFR] Automate test-pwd tests, delete manual cases

### DIFF
--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -723,93 +723,16 @@ def test_session_timeout():
 
 @pytest.mark.manual
 @pytest.mark.tier(2)
-def test_pwd_trailing_whitespace():
-    """
-    Test changing password to one with trailing whitespace.
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: medium
-        initialEstimate: 1/8h
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_pwd_special_chars():
-    """
-    Test password with special characters.
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: medium
-        initialEstimate: 1/8h
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_pwd_blank():
-    """
-    Test changing password to a blank one.
-    Test creating user with a blank password.
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: medium
-        initialEstimate: 1/8h
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_pwd_16_chars():
-    """
-    Password > 16 char
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: medium
-        initialEstimate: 1/8h
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
 def test_login_invalid_user():
     """
     Login with invalid user
     Authentication expected to fail, check audit.log and evm.log for
     correct log messages.
-
     Polarion:
         assignee: jdupuy
         casecomponent: Auth
         caseimportance: low
         caseposneg: negative
         initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_pwd_leading_whitespace():
-    """
-    Password with leading whitespace
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: medium
-        initialEstimate: 1/8h
     """
     pass

--- a/cfme/tests/integration/test_db_auth.py
+++ b/cfme/tests/integration/test_db_auth.py
@@ -1,0 +1,71 @@
+import fauxfactory
+import pytest
+
+from cfme import test_requirements
+from cfme.base.credential import Credential
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.update import update
+
+# Tests concerning database authentication
+
+pytestmark = [test_requirements.auth]
+
+
+TEST_PASSWORDS = [
+    f"{fauxfactory.gen_alpha()} ",  # trailing whitespace
+    f" {fauxfactory.gen_alpha()}",  # leading whitespace
+    f"$#!{fauxfactory.gen_alpha()}",  # spec char
+    f"{fauxfactory.gen_alpha(17)}",  # pw > 16 char
+    "",  # blank
+]
+
+
+@pytest.fixture(scope="module")
+def user(appliance):
+    name = f"test-user-{fauxfactory.gen_alpha()}"
+    creds = Credential(principal=name, secret=fauxfactory.gen_alpha())
+    user_group = appliance.collections.groups.instantiate(description="EvmGroup-vm_user")
+    user = appliance.collections.users.create(
+        name=name,
+        credential=creds,
+        groups=user_group,
+    )
+    yield user
+    user.delete_if_exists()
+
+
+@pytest.mark.parametrize(
+    "pwd",
+    TEST_PASSWORDS,
+    ids=["trailing_whitspace", "leading_whitespace", "spec_char", "gt_16char", "blank"]
+)
+def test_db_user_pwd(appliance, user, pwd, soft_assert):
+    """
+    Polarion:
+        assignee: jdupuy
+        casecomponent: Appliance
+        initialEstimate: 1/6h
+    """
+    new_credential = Credential(principal=user.credential.principal, secret=pwd)
+    if pwd:
+        with update(user):
+            user.credential = new_credential
+        with user:
+            # now make sure the user can login
+            view = navigate_to(appliance.server, "LoggedIn")
+            soft_assert(view.current_fullname == user.name,
+                        'user full name "{}" did not match UI display name "{}"'
+                        .format(user.name, view.current_fullname))
+            soft_assert(user.groups[0].description in view.group_names,
+                        'local group "{}" not displayed in UI groups list "{}"'
+                        .format(user.groups[0].description, view.group_names))
+    else:
+        # blank pwd doesn't allow you to click save
+        view = navigate_to(user, 'Edit')
+        user.change_stored_password()
+        view.fill({
+            'password_txt': new_credential.secret,
+            'password_verify_txt': new_credential.verify_secret
+        })
+        assert view.save_button.disabled
+        view.cancel_button.click()


### PR DESCRIPTION
Automating some manual test cases that test password types for db auth users. Deleting a manual case that is covered by `test_login.py`

{{ pytest: cfme/tests/integration/test_db_auth.py }}