### PR TITLE
[1LP][RFR] OSP flavor and security group

### DIFF
--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -571,7 +571,8 @@ def test_migration_with_no_conversion(appliance, delete_conversion_hosts, source
     assert "no conversion host" in view.progress_card.get_error_text(migration_plan.name)
 
 
-@pytest.mark.provider([OpenStackProvider], scope='function')
+@pytest.mark.provider([OpenStackProvider], selector=ONE_PER_VERSION,
+                      required_flags=["v2v"], override=True, scope='module')
 @pytest.mark.parametrize("attribute", ["flavor", "security_group"])
 @pytest.mark.parametrize(
     "mapping_data_vm_obj_single_datastore", [["nfs", "nfs", rhel7_minimal]], indirect=True)

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -571,7 +571,7 @@ def test_migration_with_no_conversion(appliance, delete_conversion_hosts, source
     assert "no conversion host" in view.progress_card.get_error_text(migration_plan.name)
 
 
-@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider))
+@pytest.mark.provider([OpenStackProvider], scope='function')
 @pytest.mark.parametrize("attribute", ["flavor", "security_group"])
 @pytest.mark.parametrize(
     "mapping_data_vm_obj_single_datastore", [["nfs", "nfs", rhel7_minimal]], indirect=True)


### PR DESCRIPTION
Added a test to migrate a VM with different flavor and security group in a different project in OSP and check if the migrated VM got the correct flavor and security group.

{{ pytest: cfme/tests/v2v/test_v2v_migrations_ui.py --use-provider osp13-ims --use-provider vsphere65-nested --provider-limit 2 -vvvv --long-running -k test_v2v_custom_attribute }}
