### PR TITLE
[1LP][RFR] New test: test_embedded_ansible_cat_item_edit_rest

### DIFF
--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -2407,10 +2407,11 @@ def test_edit_service_request_task(appliance, request_task):
 @pytest.mark.tier(1)
 @pytest.mark.meta(automates=[1716847])
 @pytest.mark.customer_scenario
-def test_edit_ansible_playbook_cat_item_rest(appliance, request, ansible_catalog_item):
+def test_embedded_ansible_cat_item_edit_rest(appliance, request, ansible_catalog_item):
     """
     Bugzilla:
         1716847
+        1732117
 
     Polarion:
         assignee: pvala

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -2402,3 +2402,35 @@ def test_edit_service_request_task(appliance, request_task):
     request_task.reload()
     assert request_task.options["request_param_a"] == "value_a"
     assert request_task.options["request_param_b"] == "value_b"
+
+
+@pytest.mark.tier(1)
+@pytest.mark.meta(automates=[1716847])
+@pytest.mark.customer_scenario
+def test_edit_ansible_playbook_cat_item_rest(appliance, request, ansible_catalog_item):
+    """
+    Bugzilla:
+        1716847
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Rest
+        initialEstimate: 1/4h
+        setup:
+            1. Create an Ansible Playbook Catalog Item
+        testSteps:
+            1. Edit the Catalog Item via REST and check if it is updated.
+    """
+    service_template = appliance.rest_api.collections.service_templates.get(
+        name=ansible_catalog_item.name
+    )
+    new_data = {
+        "name": fauxfactory.gen_alphanumeric(),
+        "description": fauxfactory.gen_alphanumeric(),
+    }
+    service_template.action.edit(**new_data)
+    assert_response(appliance)
+
+    service_template.reload()
+    assert service_template.name == new_data["name"]
+    assert service_template.description == new_data["description"]


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__ 
    1. `test_embedded_ansible_cat_item_edit_rest` automating customer BZ 1716847.

### PRT Run
{{ pytest: cfme/tests/services/test_rest_services.py -k "test_embedded_ansible_cat_item_edit_rest" --long-running -vvv }}