### PR TITLE
[1LP][WIP] Post upgrade test run support

### DIFF
--- a/cfme/markers/upgrade.py
+++ b/cfme/markers/upgrade.py
@@ -1,0 +1,40 @@
+"""Marker definitions for upgrade testing"""
+from cfme.fixtures.pytest_store import store
+
+
+# Add Marker
+def pytest_configure(config):
+    config.addinivalue_line("markers", "post_upgrade: Mark test for post upgrade testing")
+
+
+# Filtering options
+def pytest_addoption(parser):
+    group = parser.getgroup("cfme")
+    group.addoption(
+        "--upgrade-appliance",
+        dest="upgrade_appliance",
+        action="store_true",
+        default=False,
+        help="Upgrade an appliance before tests are run.",
+    )
+    group.addoption(
+        "--upgrade-to",
+        dest="upgrade_to",
+        action="store",
+        default="5.11.z",
+        help="Supported versions 5.9.z, 5.10.z, 5.11.z (.z means latest and default is 5.11.z)",
+    )
+
+
+def pytest_sessionstart(session):
+    if store.parallelizer_role == "master":
+        return
+    if not session.config.getoption("upgrade_appliance"):
+        return
+    upgrade_to = session.config.getoption("upgrade_to")
+    appliance = store.current_appliance
+    store.write_line(
+        f"Initiating appliance upgrade from '{appliance.version.vstring}' to '{upgrade_to}'"
+    )
+    appliance.upgrade(upgrade_to=upgrade_to, reboot=True)
+    store.write_line("Appliance upgrade finished...")

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -116,6 +116,7 @@ def test_button_group_crud(request, appliance, obj_type):
     assert not buttongroup.exists
 
 
+@pytest.mark.post_upgrade
 @pytest.mark.sauce
 @pytest.mark.tier(1)
 @pytest.mark.uncollectif(

--- a/cfme/tests/automate/custom_button/test_import_export.py
+++ b/cfme/tests/automate/custom_button/test_import_export.py
@@ -77,6 +77,7 @@ def checks(obj_type_conf):
             assert custom_button_group.has_item(button.text)
 
 
+@pytest.mark.post_upgrade
 def test_custom_button_import_export(appliance, setup_groups_buttons):
     """ Test custom button display on a targeted page
 

--- a/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
+++ b/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
@@ -134,6 +134,7 @@ def test_custom_button_display_service_vm(request, appliance, service_vm, button
             assert custom_button_group.has_item(button.text)
 
 
+@pytest.mark.post_upgrade
 @pytest.mark.customer_scenario
 @test_requirements.customer_stories
 @pytest.mark.tier(1)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1573,9 +1573,9 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         self.evmserverd.stop()
 
         logger.info("Running yum update")
-        cmd = "cfme -y " if cfme_only else "-y"
+        cmd = " cfme" if cfme_only else ""
         try:
-            result = self.ssh_client.run_command(f"yum update {cmd}", timeout=3600)
+            result = self.ssh_client.run_command(f"yum -y update{cmd}", timeout=3600)
         except socket.timeout:
             logger.error(f"SSH timed out while updating appliance: {result.output}")
 
@@ -1583,7 +1583,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         self.evmserverd.start()
 
         # May be chance to update kernal with all update.
-        if cmd == "-y" or reboot:
+        if reboot or not cfme_only:
             self.reboot()
 
         self.wait_for_web_ui()

--- a/conftest.py
+++ b/conftest.py
@@ -20,6 +20,7 @@ pytest_plugins = [
     "cfme.markers.skipper",
     "cfme.markers.smoke",
     "cfme.markers.stream_excluder",
+    "cfme.markers.upgrade",
     "cfme.markers.uses",
     "cfme.markers.uncollect",
     # Meta


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- First step towards upgrade testing
- Adding `post-upgrade` support (for now it will support only `Minor` upgrade)
- Tested `5.11.0.25` upgrade to `5.11.z` l.e. latest
- Tested `5.10.10.0` upgrade to `5.10.z` l.e latest

For Reviewer: job `ndhandre-pr-9510`

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
