### PR TITLE
[1LP][RFR] New Test: Test input values of dialog input after refresh

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -249,8 +249,8 @@ def import_dialog(appliance, file_name):
         # It returns list of dicts
         ele_label = dialog[0]['dialog_tabs'][0]['dialog_groups'][0]['dialog_fields'][0]['name']
 
-    # File name contains 'yml' , replacing it
-    sd = appliance.collections.service_dialogs.instantiate(label=file_name.replace(".yml", ""))
+    # File name contains '.yml' or '.yaml', Hence replacing it.
+    sd = appliance.collections.service_dialogs.instantiate(label=file_name.split(".")[0])
     yield sd, ele_label
     sd.delete_if_exists()
 

--- a/cfme/services/service_catalogs/__init__.py
+++ b/cfme/services/service_catalogs/__init__.py
@@ -63,6 +63,11 @@ class BaseOrderForm(View):
         param_dropdown = BootstrapSelect(locator=ParametrizedLocator(
             ".//div[contains(@class, 'bootstrap-select')]/select[@id='param_{key}']/.."))
         checkbox = Checkbox(id=Parameter("key"))
+        refresh = Text(
+            locator=ParametrizedLocator(
+                '//label[contains(text(), "{key}")]/following-sibling::div/button'
+            )
+        )
 
         @property
         def visible_widget(self):

--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -3,6 +3,7 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.fixtures.automate import DatastoreImport
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
@@ -218,12 +219,15 @@ def test_specific_dates_and_time_in_timepicker():
     pass
 
 
-@pytest.mark.meta(coverage=[1706693])
-@pytest.mark.manual
+@pytest.mark.customer_scenario
+@pytest.mark.meta(automates=[1706693])
 @pytest.mark.tier(2)
-def test_dynamic_field_on_refresh_button():
+@pytest.mark.parametrize("import_data", [DatastoreImport("bz_1706693.zip", "bz_1706693", None)],
+                         ids=["datastore"])
+@pytest.mark.parametrize("file_name", ["bz_1706693.yaml"], ids=["refresh_dialog"])
+def test_dynamic_field_on_refresh_button(request, appliance, import_datastore, import_data,
+                                         import_dialog, file_name, catalog):
     """
-
     Bugzilla:
         1706693
 
@@ -243,7 +247,26 @@ def test_dynamic_field_on_refresh_button():
             3.
             4. dynamic field shouldn't be blank
     """
-    pass
+    sd, ele_label = import_dialog
+    # These are the labels(keys) and names(values) of widgets appeared while ordering catalog item.
+    # We can not access these values from imported dialog. Hence created dict of these static values
+    label_element_map = {'var_1 - copied': 'var_2', 'var_2 - copied': 'var_3',
+                         'merged': 'var_2_var_3'}
+    catalog_item = appliance.collections.catalog_items.create(
+        appliance.collections.catalog_items.GENERIC,
+        name=fauxfactory.gen_alpha(),
+        description=fauxfactory.gen_alpha(),
+        display_in=True,
+        catalog=catalog,
+        dialog=sd)
+    request.addfinalizer(catalog_item.delete_if_exists)
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    view = navigate_to(service_catalogs, "Order")
+    for label, ele_name in label_element_map.items():
+        before_refresh = view.fields(ele_name).input.read()
+        view.fields(ele_name).input.fill(fauxfactory.gen_alphanumeric())
+        view.fields(label).refresh.click()
+        assert view.fields(ele_name).input.read() == before_refresh
 
 
 @pytest.mark.meta(coverage=[1702343])


### PR DESCRIPTION
## Purpose or Intent
- Test input values of dialog input after refresh while ordering catalog item

### PRT Run
{{ pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_dynamic_field_on_refresh_button --use-template-cache -qsvvv}}