### PR TITLE
[1LP][RFR] Create a fixture to monitor logs for passwords for auth tests

### DIFF
--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -6,21 +6,6 @@ pytestmark = [test_requirements.auth]
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_auth_password_plaintext():
-    """
-    Test that auth passwords are not logged in plaintext in logs
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Configuration
-        caseimportance: high
-        initialEstimate: 1/3h
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(1)
 def test_appliance_console_ipa_ntp():
     """


### PR DESCRIPTION
Creating a fixture to check logs for plaintext passwords during auth tests. Automates the test case `test_auth_password_plaintext`