### PR TITLE
[1LP][RFR] Use temp_appliance_preconfig for auth tests

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -112,6 +112,15 @@ def temp_appliance_preconfig_funcscope_upgrade(appliance, pytestconfig):
         yield appliances[0]
 
 
+@pytest.fixture(scope="module")
+def temp_appliance_preconfig_long(appliance, pytestconfig):
+    """ temp appliance with 24h lease for auth tests """
+    with sprout_appliances(
+            appliance, config=pytestconfig, preconfigured=True, lease_time=1440
+    ) as appliances:
+        yield appliances[0]
+
+
 # Single appliance, unconfigured
 @pytest.fixture(scope="module")
 def temp_appliance_unconfig(temp_appliance_unconfig_modscope):

--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -116,7 +116,8 @@ def temp_appliance_preconfig_funcscope_upgrade(appliance, pytestconfig):
 def temp_appliance_preconfig_long(appliance, pytestconfig):
     """ temp appliance with 24h lease for auth tests """
     with sprout_appliances(
-            appliance, config=pytestconfig, preconfigured=True, lease_time=1440
+            appliance, config=pytestconfig, preconfigured=True, lease_time=1440,
+            provider_type='rhevm'
     ) as appliances:
         yield appliances[0]
 

--- a/cfme/fixtures/authentication.py
+++ b/cfme/fixtures/authentication.py
@@ -23,6 +23,19 @@ def ipa_auth_provider():
 
 
 @pytest.fixture(scope='function')
+def setup_ipa_auth_provider(temp_appliance_preconfig, ipa_auth_provider):
+    """Add/Remove IPA auth provider"""
+    original_config = temp_appliance_preconfig.server.authentication.auth_settings
+    temp_appliance_preconfig.server.authentication.configure(auth_mode='external',
+                                              auth_provider=ipa_auth_provider)
+    yield
+
+    temp_appliance_preconfig.server.authentication.auth_settings = original_config
+    temp_appliance_preconfig.server.login_admin()
+    temp_appliance_preconfig.server.authentication.configure(auth_mode='database')
+
+
+@pytest.fixture(scope='function')
 def ldap_auth_provider():
     try:
         return authutil.get_auth_crud('ad_bos')
@@ -30,19 +43,6 @@ def ldap_auth_provider():
         pytest.skip(
             'ldap auth provider ad_bos not found in auth_data.auth_providers, skipping test'
         )
-
-
-@pytest.fixture(scope='function')
-def setup_ipa_auth_provider(appliance, ipa_auth_provider):
-    """Add/Remove IPA auth provider"""
-    original_config = appliance.server.authentication.auth_settings
-    appliance.server.authentication.configure(auth_mode='external',
-                                              auth_provider=ipa_auth_provider)
-    yield
-
-    appliance.server.authentication.auth_settings = original_config
-    appliance.server.login_admin()
-    appliance.server.authentication.configure(auth_mode='database')
 
 
 @pytest.fixture(scope='function')
@@ -59,17 +59,17 @@ def setup_ldap_auth_provider(appliance, ldap_auth_provider):
 
 
 @pytest.fixture(scope='module')
-def setup_aws_auth_provider(appliance, amazon_auth_provider):
+def setup_aws_auth_provider(temp_appliance_preconfig, amazon_auth_provider):
     """Configure AWS IAM authentication mode"""
-    original_config = appliance.server.authentication.auth_settings
-    appliance.server.authentication.configure(auth_mode='amazon',
+    original_config = temp_appliance_preconfig.server.authentication.auth_settings
+    temp_appliance_preconfig.server.authentication.configure(auth_mode='amazon',
                                               auth_provider=amazon_auth_provider)
     sleep(60)  # wait for MIQ to update, no trigger to look for, but if you try too soon it fails
     yield
 
-    appliance.server.authentication.auth_settings = original_config
-    appliance.server.login_admin()
-    appliance.server.authentication.configure(auth_mode='database')
+    temp_appliance_preconfig.server.authentication.auth_settings = original_config
+    temp_appliance_preconfig.server.login_admin()
+    temp_appliance_preconfig.server.authentication.configure(auth_mode='database')
 
 
 @pytest.fixture(scope='function')
@@ -78,17 +78,19 @@ def auth_provider(prov_key):
 
 
 @pytest.fixture(scope='module')
-def ensure_resolvable_hostname(appliance):
+def ensure_resolvable_hostname(temp_appliance_preconfig):
     """
     Intended for use with freeipa configuration, ensures a resolvable hostname on the appliance
 
     Tries to resolve the appliance hostname property and skips the test if it can't
     """
-    assert appliance.set_resolvable_hostname()
+    assert temp_appliance_preconfig.set_resolvable_hostname()
 
 
 @pytest.fixture(scope='function')
-def configure_auth(appliance, auth_mode, auth_provider, user_type, request, fix_missing_hostname):
+def configure_auth(
+    temp_appliance_preconfig, auth_mode, auth_provider, user_type, request, fix_missing_hostname
+):
     """Given auth_mode, auth_provider, user_type parametrization, configure auth for login
     testing.
 
@@ -97,28 +99,28 @@ def configure_auth(appliance, auth_mode, auth_provider, user_type, request, fix_
     Separate freeipa / openldap config methods and finalizers
     Restores original auth settings after yielding
     """
-    original_config = appliance.server.authentication.auth_settings
+    original_config = temp_appliance_preconfig.server.authentication.auth_settings
     logger.debug('Original auth settings before configure_auth fixture: %r', original_config)
     if auth_mode.lower() != 'external':
-        appliance.server.authentication.configure(auth_mode=auth_mode,
+        temp_appliance_preconfig.server.authentication.configure(auth_mode=auth_mode,
                                                   auth_provider=auth_provider,
                                                   user_type=user_type)
     elif auth_mode.lower() == 'external':  # extra explicit
         if auth_provider.auth_type == 'freeipa':
-            appliance.configure_freeipa(auth_provider)
-            request.addfinalizer(appliance.disable_freeipa)
+            temp_appliance_preconfig.configure_freeipa(auth_provider)
+            request.addfinalizer(temp_appliance_preconfig.disable_freeipa)
         elif auth_provider.auth_type == 'openldaps':
-            appliance.configure_openldap(auth_provider)
-            request.addfinalizer(appliance.disable_openldap)
+            temp_appliance_preconfig.configure_openldap(auth_provider)
+            request.addfinalizer(temp_appliance_preconfig.disable_openldap)
 
     # Auth reconfigure is super buggy and sensitive to timing
     # Just waiting on sssd to be running, or an httpd restart isn't sufficient
     sleep(30)
     yield
     # return to original auth config
-    appliance.server.authentication.auth_settings = original_config
-    appliance.evmserverd.restart()
-    appliance.wait_for_web_ui()
+    temp_appliance_preconfig.server.authentication.auth_settings = original_config
+    temp_appliance_preconfig.evmserverd.restart()
+    temp_appliance_preconfig.wait_for_web_ui()
     # After evmserverd restart, we need to logout from the appliance in the UI.
     # Otherwise the UI would be in a bad state and produce errors while testing.
-    appliance.server.logout()
+    temp_appliance_preconfig.server.logout()

--- a/cfme/fixtures/authentication.py
+++ b/cfme/fixtures/authentication.py
@@ -23,16 +23,16 @@ def ipa_auth_provider():
 
 
 @pytest.fixture(scope='function')
-def setup_ipa_auth_provider(temp_appliance_preconfig, ipa_auth_provider):
+def setup_ipa_auth_provider(temp_appliance_preconfig_long, ipa_auth_provider):
     """Add/Remove IPA auth provider"""
-    original_config = temp_appliance_preconfig.server.authentication.auth_settings
-    temp_appliance_preconfig.server.authentication.configure(auth_mode='external',
+    original_config = temp_appliance_preconfig_long.server.authentication.auth_settings
+    temp_appliance_preconfig_long.server.authentication.configure(auth_mode='external',
                                               auth_provider=ipa_auth_provider)
     yield
 
-    temp_appliance_preconfig.server.authentication.auth_settings = original_config
-    temp_appliance_preconfig.server.login_admin()
-    temp_appliance_preconfig.server.authentication.configure(auth_mode='database')
+    temp_appliance_preconfig_long.server.authentication.auth_settings = original_config
+    temp_appliance_preconfig_long.server.login_admin()
+    temp_appliance_preconfig_long.server.authentication.configure(auth_mode='database')
 
 
 @pytest.fixture(scope='function')
@@ -59,17 +59,17 @@ def setup_ldap_auth_provider(appliance, ldap_auth_provider):
 
 
 @pytest.fixture(scope='module')
-def setup_aws_auth_provider(temp_appliance_preconfig, amazon_auth_provider):
+def setup_aws_auth_provider(temp_appliance_preconfig_long, amazon_auth_provider):
     """Configure AWS IAM authentication mode"""
-    original_config = temp_appliance_preconfig.server.authentication.auth_settings
-    temp_appliance_preconfig.server.authentication.configure(auth_mode='amazon',
+    original_config = temp_appliance_preconfig_long.server.authentication.auth_settings
+    temp_appliance_preconfig_long.server.authentication.configure(auth_mode='amazon',
                                               auth_provider=amazon_auth_provider)
     sleep(60)  # wait for MIQ to update, no trigger to look for, but if you try too soon it fails
     yield
 
-    temp_appliance_preconfig.server.authentication.auth_settings = original_config
-    temp_appliance_preconfig.server.login_admin()
-    temp_appliance_preconfig.server.authentication.configure(auth_mode='database')
+    temp_appliance_preconfig_long.server.authentication.auth_settings = original_config
+    temp_appliance_preconfig_long.server.login_admin()
+    temp_appliance_preconfig_long.server.authentication.configure(auth_mode='database')
 
 
 @pytest.fixture(scope='function')
@@ -78,18 +78,19 @@ def auth_provider(prov_key):
 
 
 @pytest.fixture(scope='module')
-def ensure_resolvable_hostname(temp_appliance_preconfig):
+def ensure_resolvable_hostname(temp_appliance_preconfig_long):
     """
     Intended for use with freeipa configuration, ensures a resolvable hostname on the appliance
 
     Tries to resolve the appliance hostname property and skips the test if it can't
     """
-    assert temp_appliance_preconfig.set_resolvable_hostname()
+    assert temp_appliance_preconfig_long.set_resolvable_hostname()
 
 
 @pytest.fixture(scope='function')
 def configure_auth(
-    temp_appliance_preconfig, auth_mode, auth_provider, user_type, request, fix_missing_hostname
+    temp_appliance_preconfig_long,
+    auth_mode, auth_provider, user_type, request, fix_missing_hostname
 ):
     """Given auth_mode, auth_provider, user_type parametrization, configure auth for login
     testing.
@@ -99,28 +100,28 @@ def configure_auth(
     Separate freeipa / openldap config methods and finalizers
     Restores original auth settings after yielding
     """
-    original_config = temp_appliance_preconfig.server.authentication.auth_settings
+    original_config = temp_appliance_preconfig_long.server.authentication.auth_settings
     logger.debug('Original auth settings before configure_auth fixture: %r', original_config)
     if auth_mode.lower() != 'external':
-        temp_appliance_preconfig.server.authentication.configure(auth_mode=auth_mode,
+        temp_appliance_preconfig_long.server.authentication.configure(auth_mode=auth_mode,
                                                   auth_provider=auth_provider,
                                                   user_type=user_type)
     elif auth_mode.lower() == 'external':  # extra explicit
         if auth_provider.auth_type == 'freeipa':
-            temp_appliance_preconfig.configure_freeipa(auth_provider)
-            request.addfinalizer(temp_appliance_preconfig.disable_freeipa)
+            temp_appliance_preconfig_long.configure_freeipa(auth_provider)
+            request.addfinalizer(temp_appliance_preconfig_long.disable_freeipa)
         elif auth_provider.auth_type == 'openldaps':
-            temp_appliance_preconfig.configure_openldap(auth_provider)
-            request.addfinalizer(temp_appliance_preconfig.disable_openldap)
+            temp_appliance_preconfig_long.configure_openldap(auth_provider)
+            request.addfinalizer(temp_appliance_preconfig_long.disable_openldap)
 
     # Auth reconfigure is super buggy and sensitive to timing
     # Just waiting on sssd to be running, or an httpd restart isn't sufficient
     sleep(30)
     yield
     # return to original auth config
-    temp_appliance_preconfig.server.authentication.auth_settings = original_config
-    temp_appliance_preconfig.evmserverd.restart()
-    temp_appliance_preconfig.wait_for_web_ui()
+    temp_appliance_preconfig_long.server.authentication.auth_settings = original_config
+    temp_appliance_preconfig_long.evmserverd.restart()
+    temp_appliance_preconfig_long.wait_for_web_ui()
     # After evmserverd restart, we need to logout from the appliance in the UI.
     # Otherwise the UI would be in a bad state and produce errors while testing.
-    temp_appliance_preconfig.server.logout()
+    temp_appliance_preconfig_long.server.logout()

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -38,11 +38,12 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.mark.tier(2)
-@pytest.mark.uncollectif(lambda appliance: appliance.is_dev, reason="Is a rails server")
+@pytest.mark.uncollectif(lambda appliance: appliance.is_dev,
+                         reason="Is a rails server")
 @pytest.mark.meta(automates=[BZ(1530683)])
 @test_requirements.auth
-def test_group_roles(appliance, setup_aws_auth_provider, group_name, role_access, context,
-                     soft_assert):
+def test_group_roles(temp_appliance_preconfig, setup_aws_auth_provider, group_name, role_access,
+                     context, soft_assert):
     """Basic default AWS_IAM group role auth + RBAC test
 
     Validates expected menu and submenu names are present for default
@@ -67,13 +68,17 @@ def test_group_roles(appliance, setup_aws_auth_provider, group_name, role_access
     except KeyError:
         pytest.fail('No match in credentials file for group "{}"'.format(iam_group_name))
 
-    with appliance.context.use(context):
+    with temp_appliance_preconfig.context.use(context):
         # fullname overrides user.name attribute, but doesn't impact login with username credential
-        user = appliance.collections.users.simple_user(username, password, fullname=fullname)
+        user = temp_appliance_preconfig.collections.users.simple_user(
+            username, password, fullname=fullname
+        )
         with user:
-            view = navigate_to(appliance.server, 'LoggedIn')
-            assert appliance.server.current_full_name() == user.name
-            assert group_name.lower() in [name.lower() for name in appliance.server.group_names()]
+            view = navigate_to(temp_appliance_preconfig.server, 'LoggedIn')
+            assert temp_appliance_preconfig.server.current_full_name() == user.name
+            assert group_name.lower() in [
+                name.lower() for name in temp_appliance_preconfig.server.group_names()
+            ]
             nav_visible = view.navigation.nav_item_tree()
 
             # RFE BZ 1526495 shows up as an extra requests link in nav
@@ -86,5 +91,5 @@ def test_group_roles(appliance, setup_aws_auth_provider, group_name, role_access
                 soft_assert(diff == {}, '{g} RBAC mismatch (expected first) for {a}: {d}'
                                         .format(g=group_name, a=area, d=diff))
 
-        appliance.server.login_admin()
+        temp_appliance_preconfig.server.login_admin()
         assert user.exists

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -42,8 +42,8 @@ def pytest_generate_tests(metafunc):
                          reason="Is a rails server")
 @pytest.mark.meta(automates=[BZ(1530683)])
 @test_requirements.auth
-def test_group_roles(temp_appliance_preconfig, setup_aws_auth_provider, group_name, role_access,
-                     context, soft_assert):
+def test_group_roles(temp_appliance_preconfig_long, setup_aws_auth_provider, group_name,
+                     role_access, context, soft_assert):
     """Basic default AWS_IAM group role auth + RBAC test
 
     Validates expected menu and submenu names are present for default
@@ -68,16 +68,16 @@ def test_group_roles(temp_appliance_preconfig, setup_aws_auth_provider, group_na
     except KeyError:
         pytest.fail('No match in credentials file for group "{}"'.format(iam_group_name))
 
-    with temp_appliance_preconfig.context.use(context):
+    with temp_appliance_preconfig_long.context.use(context):
         # fullname overrides user.name attribute, but doesn't impact login with username credential
-        user = temp_appliance_preconfig.collections.users.simple_user(
+        user = temp_appliance_preconfig_long.collections.users.simple_user(
             username, password, fullname=fullname
         )
         with user:
-            view = navigate_to(temp_appliance_preconfig.server, 'LoggedIn')
-            assert temp_appliance_preconfig.server.current_full_name() == user.name
+            view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
+            assert temp_appliance_preconfig_long.server.current_full_name() == user.name
             assert group_name.lower() in [
-                name.lower() for name in temp_appliance_preconfig.server.group_names()
+                name.lower() for name in temp_appliance_preconfig_long.server.group_names()
             ]
             nav_visible = view.navigation.nav_item_tree()
 
@@ -91,5 +91,5 @@ def test_group_roles(temp_appliance_preconfig, setup_aws_auth_provider, group_na
                 soft_assert(diff == {}, '{g} RBAC mismatch (expected first) for {a}: {d}'
                                         .format(g=group_name, a=area, d=diff))
 
-        temp_appliance_preconfig.server.login_admin()
+        temp_appliance_preconfig_long.server.login_admin()
         assert user.exists

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -20,7 +20,8 @@ from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda temp_appliance_preconfig: temp_appliance_preconfig.is_pod),
+    pytest.mark.uncollectif(
+        lambda temp_appliance_preconfig_long: temp_appliance_preconfig_long.is_pod),
     pytest.mark.meta(blockers=[
         GH('ManageIQ/integration_tests:6465',
            # need SSL openldap server
@@ -100,28 +101,28 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope='function')
-def user_obj(temp_appliance_preconfig, auth_user, user_type):
+def user_obj(temp_appliance_preconfig_long, auth_user, user_type):
     """return a simple user object, see if it exists and delete it on teardown"""
     # Replace spaces with dashes in UPN type usernames for login compatibility
     username = auth_user.username.replace(' ', '-') if user_type == 'upn' else auth_user.username
-    user = temp_appliance_preconfig.collections.users.simple_user(
+    user = temp_appliance_preconfig_long.collections.users.simple_user(
         username,
         credentials[auth_user.password].password,
         fullname=auth_user.fullname or auth_user.username)  # fullname could be empty
     yield user
 
-    temp_appliance_preconfig.browser.widgetastic.refresh()
-    temp_appliance_preconfig.server.login_admin()
+    temp_appliance_preconfig_long.browser.widgetastic.refresh()
+    temp_appliance_preconfig_long.server.login_admin()
     if user.exists:
         user.delete()
 
 
 @pytest.fixture
-def log_monitor(user_obj, temp_appliance_preconfig):
+def log_monitor(user_obj, temp_appliance_preconfig_long):
     """Search evm.log for any plaintext password"""
     result = LogValidator(
         "/var/www/miq/vmdb/log/evm.log", failure_patterns=[f"{user_obj.credential.secret}"],
-        hostname=temp_appliance_preconfig.hostname
+        hostname=temp_appliance_preconfig_long.hostname
     )
     result.start_monitoring()
     yield result
@@ -134,7 +135,9 @@ def log_monitor(user_obj, temp_appliance_preconfig):
 @pytest.mark.uncollectif(lambda auth_user: not any([True for g in auth_user.groups or []
                                                    if 'evmgroup' in g.lower()]),
                          reason='No evm group available for user')
-def test_login_evm_group(temp_appliance_preconfig, auth_user, user_obj, soft_assert, log_monitor):
+def test_login_evm_group(
+        temp_appliance_preconfig_long, auth_user, user_obj, soft_assert, log_monitor
+):
     """This test checks whether a user can login while assigned a default EVM group
         Prerequisities:
             * ``auth_data.yaml`` file
@@ -151,7 +154,7 @@ def test_login_evm_group(temp_appliance_preconfig, auth_user, user_obj, soft_ass
     evm_group_names = [group for group in auth_user.groups if 'evmgroup' in group.lower()]
     with user_obj:
         logger.info('Logging in as user %s, member of groups %s', user_obj, evm_group_names)
-        view = navigate_to(temp_appliance_preconfig.server, 'Dashboard')
+        view = navigate_to(temp_appliance_preconfig_long.server, 'Dashboard')
         assert view.is_displayed, 'user {} failed login'.format(user_obj)
         soft_assert(user_obj.name == view.current_fullname,
                     'user {} is not in view fullname'.format(user_obj))
@@ -160,23 +163,23 @@ def test_login_evm_group(temp_appliance_preconfig, auth_user, user_obj, soft_ass
                         'user {} evm group {} not in view group_names'.format(user_obj, name))
 
     # split loop to reduce number of logins
-    temp_appliance_preconfig.server.login_admin()
+    temp_appliance_preconfig_long.server.login_admin()
     assert user_obj.exists, 'user record should have been created for "{}"'.format(user_obj)
 
     # assert no pwd in logs
     assert log_monitor.validate()
 
 
-def retrieve_group(temp_appliance_preconfig, auth_mode, username, groupname, auth_provider):
+def retrieve_group(temp_appliance_preconfig_long, auth_mode, username, groupname, auth_provider):
     """Retrieve group from ext/ldap auth provider through UI
 
     Args:
-        temp_appliance_preconfig: temp_appliance_preconfig object
+        temp_appliance_preconfig_long: temp_appliance_preconfig_long object
         auth_mode: key from cfme.configure.configuration.server_settings.AUTH_MODES, parametrization
         user_data: user_data AttrDict from yaml, with username, groupname, password fields
 
     """
-    group = temp_appliance_preconfig.collections.groups.instantiate(
+    group = temp_appliance_preconfig_long.collections.groups.instantiate(
         description=groupname,
         role='EvmRole-user',
         user_to_lookup=username,
@@ -199,7 +202,7 @@ def retrieve_group(temp_appliance_preconfig, auth_mode, username, groupname, aut
                                                    if 'evmgroup' not in g.lower()]),
                          reason='Only groups available for user are evm built-in')
 def test_login_retrieve_group(
-        temp_appliance_preconfig, request, log_monitor,
+        temp_appliance_preconfig_long, request, log_monitor,
         auth_mode, auth_provider, soft_assert, auth_user, user_obj
 ):
     """This test checks whether different cfme auth modes are working correctly.
@@ -221,11 +224,11 @@ def test_login_retrieve_group(
     non_evm_group = [g for g in auth_user.groups or [] if 'evmgroup' not in g.lower()][0]
     # retrieving in test call and not fixture, getting the group from auth provider is part of test
     group = retrieve_group(
-        temp_appliance_preconfig, auth_mode, auth_user.username, non_evm_group, auth_provider
+        temp_appliance_preconfig_long, auth_mode, auth_user.username, non_evm_group, auth_provider
     )
 
     with user_obj:
-        view = navigate_to(temp_appliance_preconfig.server, 'LoggedIn')
+        view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
         soft_assert(view.current_fullname == user_obj.name,
                     'user full name "{}" did not match UI display name "{}"'
                     .format(user_obj.name, view.current_fullname))
@@ -233,7 +236,7 @@ def test_login_retrieve_group(
                     u'user group "{}" not displayed in UI groups list "{}"'
                     .format(group.description, view.group_names))
 
-    temp_appliance_preconfig.server.login_admin()  # context should get us back to admin
+    temp_appliance_preconfig_long.server.login_admin()  # context should get us back to admin
     assert user_obj.exists, 'User record for "{}" should exist after login'.format(user_obj)
 
     # assert no pwd in logs
@@ -261,10 +264,10 @@ def format_user_principal(username, user_type, auth_provider):
 
 
 @pytest.fixture(scope='function')
-def local_group(temp_appliance_preconfig):
+def local_group(temp_appliance_preconfig_long):
     """Helper method to check for existance of a group and delete if need be"""
     group_name = 'test-group-{}'.format(gen_alphanumeric(length=5))
-    group = temp_appliance_preconfig.collections.groups.create(
+    group = temp_appliance_preconfig_long.collections.groups.create(
         description=group_name, role='EvmRole-desktop'
     )
     assert group.exists
@@ -275,9 +278,9 @@ def local_group(temp_appliance_preconfig):
 
 
 @pytest.fixture(scope='function')
-def local_user(temp_appliance_preconfig, auth_user, user_type, auth_provider, local_group):
+def local_user(temp_appliance_preconfig_long, auth_user, user_type, auth_provider, local_group):
     # list of created users, instantiating the Credential and formatting the user name in loop
-    user = temp_appliance_preconfig.collections.users.create(
+    user = temp_appliance_preconfig_long.collections.users.create(
         name=auth_user.fullname or auth_user.username,  # fullname could be empty
         credential=Credential(
             principal=format_user_principal(auth_user.username, user_type, auth_provider),
@@ -293,7 +296,7 @@ def local_user(temp_appliance_preconfig, auth_user, user_type, auth_provider, lo
 @pytest.mark.tier(1)
 @pytest.mark.uncollectif(lambda auth_mode: auth_mode == 'amazon',
                          'Amazon auth_data needed for local group testing')
-def test_login_local_group(temp_appliance_preconfig, local_user, local_group, soft_assert):
+def test_login_local_group(temp_appliance_preconfig_long, local_user, local_group, soft_assert):
     """
     Test remote authentication with a locally created group.
     Group is NOT retrieved from or matched to those on authentication provider
@@ -305,12 +308,12 @@ def test_login_local_group(temp_appliance_preconfig, local_user, local_group, so
         casecomponent: Auth
     """
     # modify auth settings to not get groups
-    temp_appliance_preconfig.server.authentication.auth_settings = {
+    temp_appliance_preconfig_long.server.authentication.auth_settings = {
         'auth_settings': {'get_groups': False}
     }
 
     with local_user:
-        view = navigate_to(temp_appliance_preconfig.server, 'LoggedIn')
+        view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
         soft_assert(view.current_fullname == local_user.name,
                     'user full name "{}" did not match UI display name "{}"'
                     .format(local_user.name, view.current_fullname))
@@ -327,7 +330,7 @@ def test_login_local_group(temp_appliance_preconfig, local_user, local_group, so
                          reason='User does not have multiple groups')
 @pytest.mark.meta(blockers=[BZ(1759291)], automates=[1759291])
 def test_user_group_switching(
-        temp_appliance_preconfig, auth_user, auth_mode, auth_provider,
+        temp_appliance_preconfig_long, auth_user, auth_mode, auth_provider,
         soft_assert, request, user_obj, log_monitor
 ):
     """Test switching groups on a single user, between retreived group and built-in group
@@ -346,7 +349,7 @@ def test_user_group_switching(
         if 'evmgroup' not in group.lower():
             # create group in CFME via retrieve_group which looks it up on auth_provider
             logger.info(u'Retrieving a user group that is non evm built-in: {}'.format(group))
-            retrieved_groups.append(retrieve_group(temp_appliance_preconfig,
+            retrieved_groups.append(retrieve_group(temp_appliance_preconfig_long,
                                                    auth_mode,
                                                    auth_user.username,
                                                    group,
@@ -356,7 +359,7 @@ def test_user_group_switching(
                     .format(auth_user.groups))
 
     with user_obj:
-        view = navigate_to(temp_appliance_preconfig.server, 'LoggedIn')
+        view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
         # Check there are multiple groups displayed
         assert len(view.group_names) > 1, 'Only a single group is displayed for the user'
         display_other_groups = [g for g in view.group_names if g != view.current_groupname]
@@ -383,7 +386,7 @@ def test_user_group_switching(
                         u'After switching to group {}, its not displayed as active'
                         .format(other_group))
 
-    temp_appliance_preconfig.server.login_admin()
+    temp_appliance_preconfig_long.server.login_admin()
     assert user_obj.exists, 'User record for "{}" should exist after login'.format(auth_user)
 
     # assert no pwd in log

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -30,6 +30,7 @@ pytestmark = [
                auth_data.auth_providers[prov_key].type == 'openldaps')),
         BZ(1593171)]),  # 510z groups page doesn't load
     pytest.mark.browser_isolation,
+    pytest.mark.long_running,
     pytest.mark.usefixtures(
         'prov_key', 'auth_mode', 'auth_provider', 'configure_auth', 'auth_user'
     ),

--- a/cfme/tests/integration/test_ldap_auth_and_roles.py
+++ b/cfme/tests/integration/test_ldap_auth_and_roles.py
@@ -12,8 +12,7 @@ pytest_generate_tests = generate(gen_func=auth_groups, auth_mode='ldap')
 @pytest.mark.uncollect('Needs to be fixed after menu removed')
 @test_requirements.auth
 @pytest.mark.tier(2)
-def test_group_roles(
-        request, appliance, configure_ldap_auth_mode, group_name, group_data, infra_provider):
+def test_group_roles(request, temp_appliance_preconfig, group_name, group_data):
     """Basic default LDAP group role RBAC test
 
     Validates expected menu and submenu names are present for default
@@ -27,6 +26,7 @@ def test_group_roles(
         initialEstimate: 1/4h
         tags: rbac
     """
+    appliance = temp_appliance_preconfig
     request.addfinalizer(appliance.server.login_admin)
 
     # This should be removed but currently these roles are subject to a bug

--- a/cfme/tests/integration/test_ldap_auth_and_roles.py
+++ b/cfme/tests/integration/test_ldap_auth_and_roles.py
@@ -12,7 +12,7 @@ pytest_generate_tests = generate(gen_func=auth_groups, auth_mode='ldap')
 @pytest.mark.uncollect('Needs to be fixed after menu removed')
 @test_requirements.auth
 @pytest.mark.tier(2)
-def test_group_roles(request, temp_appliance_preconfig, group_name, group_data):
+def test_group_roles(request, temp_appliance_preconfig_long, group_name, group_data):
     """Basic default LDAP group role RBAC test
 
     Validates expected menu and submenu names are present for default
@@ -26,7 +26,7 @@ def test_group_roles(request, temp_appliance_preconfig, group_name, group_data):
         initialEstimate: 1/4h
         tags: rbac
     """
-    appliance = temp_appliance_preconfig
+    appliance = temp_appliance_preconfig_long
     request.addfinalizer(appliance.server.login_admin)
 
     # This should be removed but currently these roles are subject to a bug


### PR DESCRIPTION
{{ pytest: --long-running cfme/tests/integration/test_cfme_auth.py }} 