### PR TITLE
[1LP][RFR] Automate tenant switching of LDAP user

### DIFF
--- a/cfme/configure/access_control/__init__.py
+++ b/cfme/configure/access_control/__init__.py
@@ -308,10 +308,10 @@ class UserCollection(BaseCollection):
 
     ENTITY = User
 
-    def simple_user(self, userid, password, fullname=None):
+    def simple_user(self, userid, password, groups=None, fullname=None):
         """If a fullname is not supplied, userid is used for credential principal and user name"""
         creds = Credential(principal=userid, secret=password)
-        return self.instantiate(name=fullname or userid, credential=creds)
+        return self.instantiate(name=fullname or userid, credential=creds, groups=groups)
 
     def create(self, name=None, credential=None, email=None, groups=None, cost_center=None,
                value_assign=None, cancel=False):

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -546,7 +546,7 @@ def test_group_crud(appliance):
     role = 'EvmRole-administrator'
     group_collection = appliance.collections.groups
     group = group_collection.create(
-        description='grp{}'.format(fauxfactory.gen_alphanumeric()), role=role)
+        description='grp{}'.format(fauxfactory.genalphanumeric()), role=role)
     with update(group):
         group.description = "{}edited".format(group.description)
     group.delete()
@@ -1961,10 +1961,10 @@ def test_tenant_visibility_vms_all_childs():
     pass
 
 
-@pytest.mark.manual
+# @pytest.mark.manual
 @pytest.mark.ignore_stream("upstream")
 @test_requirements.multi_tenancy
-def test_tenant_ldap_group_switch_between_tenants():
+def test_tenant_ldap_group_switch_between_tenants(appliance, openldap_auth_provider):
     """
     User who is member of 2 or more LDAP groups can switch between tenants
 
@@ -1994,9 +1994,27 @@ def test_tenant_ldap_group_switch_between_tenants():
             to Classic UI and switch to desired group. Afterthat he is able login
             via Self Service UI to desired tenant
 
-    """
-    pass
 
+    auth_provider = get_auth_crud("cfme_openldap")
+    appliance.server.authentication.configure(auth_mode='ldap',
+                                             auth_provider=auth_provider,
+                                             user_type='uid')
+    """
+    with test_user:
+        view = navigate_to(appliance.server, 'LoggedIn')
+
+        orig_group = view.current_groupname
+
+        # Set the group list order so that we change to the original group last
+        group_test_list = [name for name in group_names if name != orig_group] + [orig_group]
+
+        for group in group_test_list:
+            view.change_group(group)
+
+            assert group == view.current_groupname, (
+                "User failed to change current group from {} to {}".format(
+                    view.current_groupname, group))
+    
 
 @pytest.mark.manual
 @pytest.mark.ignore_stream("upstream")

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -16,8 +16,8 @@ from cfme.markers.env_markers.provider import ONE
 from cfme.services.myservice import MyService
 from cfme.tests.integration.test_cfme_auth import retrieve_group
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.auth.authutil import auth_user_data
-from cfme.utils.auth.authutil import get_auth_crud
+from cfme.utils.auth import auth_user_data
+from cfme.utils.auth import get_auth_crud
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
 from cfme.utils.log import logger

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -171,7 +171,8 @@ def test_login_evm_group(
     assert log_monitor.validate()
 
 
-def retrieve_group(temp_appliance_preconfig_long, auth_mode, username, groupname, auth_provider):
+def retrieve_group(temp_appliance_preconfig_long, auth_mode, username, groupname, auth_provider,
+        tenant=None):
     """Retrieve group from ext/ldap auth provider through UI
 
     Args:
@@ -183,6 +184,7 @@ def retrieve_group(temp_appliance_preconfig_long, auth_mode, username, groupname
     group = temp_appliance_preconfig_long.collections.groups.instantiate(
         description=groupname,
         role='EvmRole-user',
+        tenant=tenant,
         user_to_lookup=username,
         ldap_credentials=Credential(principal=auth_provider.bind_dn,
                                     secret=auth_provider.bind_password))


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{py.test: cfme/tests/configure/test_access_control.py -k 'switch_between_tenants'}}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
