### PR TITLE
[1LP][RFR] Remove rhel_testing mark from test_rh_updates

### DIFF
--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -222,7 +222,6 @@ def test_rhsm_registration_check_repo_names(
         soft_assert(view.repo_name.read() == repo_names)
 
 
-@pytest.mark.rhel_testing
 def test_rh_updates(appliance_preupdate, appliance):
     """ Tests whether the update button in the webui functions correctly
 


### PR DESCRIPTION
Removing rhel_testing pytest mark from test_rh_updates because:
1) Uses `appliance_preupdate` so not using the appliance that was upgraded during test run
2) After RHEL upgrade, appliance will not have any updates. 