### PR TITLE
[1LP][RFR] Update the test_db_migrate.

### DIFF
--- a/cfme/tests/services/test_service_performance.py
+++ b/cfme/tests/services/test_service_performance.py
@@ -17,7 +17,7 @@ def appliance_with_performance_db(temp_appliance_extended_db):
         performance_db = db_backups['performance_510']
     except KeyError as e:
         pytest.skip(f"Couldn't find the performance DB in the cfme_data: {e}")
-    download_and_migrate_db(app, performance_db.url, db_format='pg_dump')
+    download_and_migrate_db(app, performance_db.url)
     yield app
 
 

--- a/cfme/tests/services/test_service_performance.py
+++ b/cfme/tests/services/test_service_performance.py
@@ -17,7 +17,7 @@ def appliance_with_performance_db(temp_appliance_extended_db):
         performance_db = db_backups['performance_510']
     except KeyError as e:
         pytest.skip(f"Couldn't find the performance DB in the cfme_data: {e}")
-    download_and_migrate_db(app, performance_db.url)
+    download_and_migrate_db(app, performance_db.url, db_format='pg_dump')
     yield app
 
 

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -98,6 +98,11 @@ def download_and_migrate_db(app, db_url):
 
     # Stop EVM service and drop vmdb_production DB
     app.evmserverd.stop()
+    # Invalidate some of the cache
+    # as it was be causing problems
+    # when running more than one test with
+    # the same vm.
+    app.__dict__.pop('rest_api', None)
     app.db.drop()
     app.db.create()
     # restore new DB

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -9,6 +9,7 @@ from cfme.utils.appliance import ApplianceException
 from cfme.utils.conf import cfme_data
 from cfme.utils.conf import credentials
 from cfme.utils.log import logger
+from cfme.utils.version import Version
 
 pytestmark = [
     test_requirements.db_migration,
@@ -23,7 +24,7 @@ def pytest_generate_tests(metafunc):
                              test_upgrade_single_sidebyside}:
         return
 
-    argnames, argvalues, idlist = ['db_url', 'db_version', 'db_desc'], [], []
+    argnames, argvalues, idlist = ['db_url', 'db_version', 'db_desc', 'db_format'], [], []
     db_backups = cfme_data.get('db_backups', {})
     if not db_backups:
         pytest.skip('No db backup information available!')
@@ -32,7 +33,7 @@ def pytest_generate_tests(metafunc):
         # if data.version >= appliance.version or \
         #         get_stream(data.version) == get_stream(appliance.version):
         #     continue
-        argvalues.append((data.url, data.version, data.desc))
+        argvalues.append((data.url, data.version, data.desc, data.format))
         idlist.append(key)
     return metafunc.parametrize(argnames=argnames, argvalues=argvalues, ids=idlist)
 
@@ -70,38 +71,63 @@ def appliance_preupdate(temp_appliance_preconfig_funcscope_upgrade, appliance):
     return temp_appliance_preconfig_funcscope_upgrade
 
 
-def download_and_migrate_db(app, db_url):
+def download_and_migrate_db(app, db_url, db_format):
+    def fetch(src, dst):
+        result = app.ssh_client.run_command(
+            f'curl  --fail -S -o "{dst}" "{src}"', timeout=15)
+        assert result.success, f"Failed to download {src}:\n{result.output}"
+
     # Download the database
     logger.info("Downloading database: {}".format(db_url))
     url_basename = os_path.basename(db_url)
     loc = "/tmp/"
-    result = app.ssh_client.run_command(
-        'curl -o "{}{}" "{}"'.format(loc, url_basename, db_url), timeout=30)
-    assert result.success, "Failed to download database: {}".format(result.output)
-    # The v2_key is potentially here
     v2key_url = os_path.join(os_path.dirname(db_url), "v2_key")
+    database_yml_url = os_path.join(os_path.dirname(db_url), "database.yml")
+
+    fetch(db_url, f'{loc}{url_basename}')
+
     # Stop EVM service and drop vmdb_production DB
     app.evmserverd.stop()
     app.db.drop()
     app.db.create()
     # restore new DB
-    result = app.ssh_client.run_command(
-        'pg_restore -v --dbname=vmdb_production {}{}'.format(loc, url_basename), timeout=600)
+    if db_format == "pg_dump":
+        result = app.ssh_client.run_command(
+            'pg_restore -v --dbname=vmdb_production {}{}'.format(loc, url_basename), timeout=600)
+    elif db_format == "pg_dumpall":
+        result = app.ssh_client.run_command(
+            'psql postgres < {}{}'.format(loc, url_basename), timeout=600)
+    else:
+        raise Exception(f'Unknown db format: {db_format}')
     assert result.success, "Failed to restore new database: {}".format(result.output)
-    app.db.migrate()
-    # fetch v2_key
+
+    # fetch the files needed for decrypt the db
     try:
-        result = app.ssh_client.run_command(
-            'curl "{}"'.format(v2key_url), timeout=15)
-        assert result.success, "Failed to download v2_key: {}".format(result.output)
-        assert ":key:" in result.output, "Not a v2_key file: {}".format(result.output)
-        result = app.ssh_client.run_command(
-            'curl -o "/var/www/miq/vmdb/certs/v2_key" "{}"'.format(v2key_url), timeout=15)
-        assert result.success, "Failed to download v2_key: {}".format(result.output)
-    # or change all invalid (now unavailable) passwords to 'invalid'
+        fetch(v2key_url, '/var/www/miq/vmdb/certs/v2_key')
+        fetch(database_yml_url, '/var/www/miq/vmdb/conf/database.yml')
+        v2_key_available = True
     except AssertionError:
-        app.db.fix_auth_key()
-    app.db.fix_auth_dbyml()
+        v2_key_available = False
+        logger.info("Failed to download the v2_key or database_yml. "
+                    "Will have to use the fix_auth tool.")
+
+    if app.version < '5.11':
+        app.db.migrate()
+        if not v2_key_available:
+            app.db.fix_auth_key()
+            app.db.fix_auth_dbyml()
+    else:
+        if not v2_key_available:
+            app.db.fix_auth_key()
+            app.db.fix_auth_dbyml()
+            # To migrate the keys to CFME 5.11 the migration
+            # needs to reencrypt them. This won't work when the fix_auth was
+            # used before as it resets the credentials needed to decrypt the
+            # ansible keys. See BZ 1755553.
+            app.db.migrate(env_vars=["HARDCODE_ANSIBLE_PASSWORD=bogus"])
+        else:
+            app.db.migrate()
+
     # start evmserverd, wait for web UI to start and try to log in
     try:
         app.evmserverd.start()
@@ -117,7 +143,10 @@ def download_and_migrate_db(app, db_url):
 @pytest.mark.ignore_stream('upstream')
 @pytest.mark.tier(2)
 @pytest.mark.meta(automates=[1734076])
-def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
+@pytest.mark.uncollectif(
+    lambda appliance, db_version: appliance.version >= '5.11' and Version(db_version) < '5.6',
+    reason='upgrade from CFME<5.6 to >=5.11 not supported: BZ#1765549')
+def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc, db_format):
     """
     Polarion:
         assignee: jhenner
@@ -126,7 +155,7 @@ def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
     Bugzilla:
         1734076
     """
-    download_and_migrate_db(temp_appliance_extended_db, db_url)
+    download_and_migrate_db(temp_appliance_extended_db, db_url, db_format)
 
 
 @pytest.mark.parametrize('dbversion',

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -158,7 +158,7 @@ def download_and_migrate_db(app, db_url):
 
 @pytest.mark.ignore_stream('upstream')
 @pytest.mark.tier(2)
-@pytest.mark.meta(automates=[1734076])
+@pytest.mark.meta(automates=[1734076, 1755553])
 @pytest.mark.uncollectif(
     lambda appliance, db_version: appliance.version >= '5.10' and Version(db_version) < '5.6',
     reason='upgrade from CFME<5.6 to >=5.10 not supported: BZ#1765549')
@@ -170,6 +170,7 @@ def test_db_migrate(temp_appliance_extended_db, db_url, db_version, db_desc):
         casecomponent: Appliance
     Bugzilla:
         1734076
+        1755553
     """
     download_and_migrate_db(temp_appliance_extended_db, db_url)
 

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -114,10 +114,11 @@ class ApplianceDB(AppliancePlugin):
         result = self.appliance.ssh_client.run_command('createdb vmdb_production', timeout=30)
         assert result.success, "Failed to create clean database: {}".format(result.output)
 
-    def migrate(self):
+    def migrate(self, env_vars=None):
         """migrates a given database and updates REGION/GUID files"""
+        env_vars = env_vars if env_vars else []
         ssh = self.ssh_client
-        result = ssh.run_rake_command("db:migrate", timeout=300)
+        result = ssh.run_rake_command("db:migrate", rake_cmd_prefix=' '.join(env_vars), timeout=300)
         assert result.success, "Failed to migrate new database: {}".format(result.output)
         result = ssh.run_rake_command(
             r'db:migrate:status 2>/dev/null | grep "^\s*down"', timeout=30)

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -490,12 +490,11 @@ class SSHClient(paramiko.SSHClient):
         return self.run_command('cd /var/www/miq/vmdb; echo \"{}\" '
             '| bundle exec bin/rails c 2> /dev/null'.format(command), timeout=timeout)
 
-    def run_rake_command(self, command, timeout=RUNCMD_TIMEOUT, disable_db_check=False, **kwargs):
+    def run_rake_command(self, command, timeout=RUNCMD_TIMEOUT, rake_cmd_prefix='', **kwargs):
         logger.info("Running rake command %r", command)
-        prefix = 'DISABLE_DATABASE_ENVIRONMENT_CHECK=1 ' if disable_db_check else ''
         return self.run_command(
-            'cd /var/www/miq/vmdb; {pre}bin/rake -f /var/www/miq/vmdb/Rakefile {command}'.format(
-                command=command, pre=prefix), timeout=timeout, **kwargs)
+            'cd /var/www/miq/vmdb; {pre} bin/rake -f /var/www/miq/vmdb/Rakefile {command}'.format(
+                command=command, pre=rake_cmd_prefix), timeout=timeout, **kwargs)
 
     def put_file(self, local_file, remote_file='.', **kwargs):
         ensure_host = kwargs.pop('ensure_host', False)

--- a/scripts/clean_appliance.py
+++ b/scripts/clean_appliance.py
@@ -65,7 +65,8 @@ def main():
             db_connections = int(response.output.strip())
             return db_connections == 0
 
-        ssh_client.run_rake_command('evm:db:reset', disable_db_check=True)
+        ssh_client.run_rake_command('evm:db:reset',
+                                    rake_cmd_prefix='DISABLE_DATABASE_ENVIRONMENT_CHECK=1')
         ssh_client.run_command('systemctl start evmserverd')
 
         # SSHClient has the smarts to get our hostname if none was provided


### PR DESCRIPTION
 * Add support for resetting the password of AWS credentials when migrating the DB and v2_key is not available. .../cfme-qe-yamls/merge_requests/893 is needed to test this.
 * Add guessing of the db dump format based on the file suffix
 * Add invalidating the cache to resolve:
```
        @property
        def _rest_api_server(self):
            shref = self.appliance.rest_api.server_info['server_href']
            logger.info(f'server_href: {shref}')
            results = self.appliance.rest_api.collections.servers.all
            logger.info(f'all servers: {results}')
    >       server, = (r for r in results if r.href == shref)
    E       ValueError: not enough values to unpack (expected 1, got 0)
```
 * Add fixing `database.yml` using fixauth when the file was not available.

{{pytest: cfme/tests/test_db_migrate.py::test_db_migrate -v}}
