### PR TITLE
[1LP][RFR] New Test: Checking details of catalog item via list

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -38,6 +38,7 @@ from widgetastic_manageiq import EntryPoint
 from widgetastic_manageiq import FonticonPicker
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import SummaryFormItem
+from widgetastic_manageiq import Table
 from widgetastic_manageiq import WaitTab
 from widgetastic_manageiq.expression_editor import ExpressionEditor
 
@@ -140,6 +141,7 @@ class ButtonForm(ServicesCatalogView):
 
 class AllCatalogItemView(ServicesCatalogView):
     title = Text('#explorer_title_text')
+    table = Table('//*[@id="miq-gtl-view"]/miq-data-table/div/table')
 
     @property
     def is_displayed(self):

--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -5,6 +5,7 @@ import pytest
 from cfme import test_requirements
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for
 
 pytestmark = [
@@ -246,12 +247,10 @@ def test_dynamic_field_on_refresh_button():
     pass
 
 
-@pytest.mark.meta(coverage=[1702343])
-@pytest.mark.manual
+@pytest.mark.meta(automates=[1702343])
 @pytest.mark.tier(2)
-def test_clicking_created_catalog_item_in_the_list():
+def test_clicking_created_catalog_item_in_the_list(appliance, generic_catalog_item):
     """
-
     Bugzilla:
         1702343
 
@@ -271,7 +270,14 @@ def test_clicking_created_catalog_item_in_the_list():
             3.
             4. Catalog Item's summary screen should appear
     """
-    pass
+    with LogValidator("/var/www/miq/vmdb/log/evm.log", failure_patterns=[".*ERROR.*"]).waiting(
+            timeout=120):
+        view = navigate_to(appliance.collections.catalog_items, "All")
+        for cat_item in view.table:
+            if cat_item[2].text == generic_catalog_item.name:
+                cat_item[2].click()
+                break
+        assert view.title.text == f'Service Catalog Item "{generic_catalog_item.name}"'
 
 
 @pytest.mark.meta(coverage=[1698439])


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

## Purpose or Intent
- Testing details page of newly created catalog item via list of catalog items
- This PR automates BZ(1702343)
### PRT Run
{{ pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_clicking_created_catalog_item_in_the_list -vvv --long-running }}