### PR TITLE
[1LP][RFR] Automate tests for C&U data rollup in Availability zones

### DIFF
--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -354,7 +354,7 @@ def generic_test_azone_rollup(appliance, provider, metric):
     query = query_metric_rollup_table(appliance, provider, metric, azone_name)
 
     for record in query:
-        if hasattr(record, metric) and int(getattr(record, metric, 0)):
+        if int(getattr(record, metric, 0)):
             return True
         else:
             raise ValueError('The record had a zero in it!')
@@ -363,7 +363,7 @@ def generic_test_azone_rollup(appliance, provider, metric):
 @pytest.mark.provider(
     [EC2Provider, AzureProvider],
     required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
-    override=True, scope="module"
+    scope="module"
 )
 @pytest.mark.meta(
     blockers=[BZ(1744845, forced_streams=['5.10'],

--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -37,7 +37,6 @@ def clean_setup_provider(request, provider):
 
 
 def vm_count(appliance, metrics_tbl, mgmt_system_id):
-    pytest.set_trace()
     return bool(appliance.db.client.session.query(metrics_tbl).filter(
         metrics_tbl.parent_ems_id == mgmt_system_id).filter(
         metrics_tbl.resource_type == "VmOrTemplate").count()


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
Added tests for  C&U data rollup in Availability zones. The tests check if the hourly rollup records are available in the DB.
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{py.test: cfme/tests/candu/test_utilization_metrics.py --use-provider complete -k "azone"}}

### PRT Results:
510 - PASS
511 - PASS