### PR TITLE
[1LP][RFR] Updates to test_catalog.py and Remove Flash Assert in Catalog Entity

### DIFF
--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -17,7 +17,10 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.version import LOWEST
+from cfme.utils.version import VersionPicker
 from widgetastic_manageiq import MultiBoxSelect
+from widgetastic_manageiq import ReactTextInput
 
 
 class CatalogsMultiBoxSelect(MultiBoxSelect):
@@ -34,8 +37,14 @@ class CatalogsMultiBoxSelect(MultiBoxSelect):
 class CatalogForm(ServicesCatalogView):
     title = Text('#explorer_title_text')
 
-    name = Input(name='name')
-    description = Input(name="description")
+    name = VersionPicker({
+        "5.11": ReactTextInput(name='name'),
+        LOWEST: Input(name='name')
+    })
+    description = VersionPicker({
+        "5.11": ReactTextInput(name="description"),
+        LOWEST: Input(name='description')
+    })
     assign_catalog_items = CatalogsMultiBoxSelect(
         move_into="Move Selected buttons right",
         move_from="Move Selected buttons left",

--- a/cfme/services/catalogs/catalog.py
+++ b/cfme/services/catalogs/catalog.py
@@ -111,20 +111,12 @@ class Catalog(BaseEntity, Updateable, Pretty, Taggable):
             view.cancel_button.click()
         view = self.create_view(DetailsCatalogView, override=updates, wait='10s')
         view.flash.assert_no_error()
-        if changed:
-            view.flash.assert_message(
-                'Catalog "{}" was saved'.format(updates.get('name', self.name)))
-        else:
-            view.flash.assert_message(
-                'Edit of Catalog "{}" was cancelled by the user'.format(self.name))
 
     def delete(self):
         view = navigate_to(self, "Details")
         view.configuration.item_select('Remove Catalog', handle_alert=True)
         view = self.create_view(CatalogsView, wait='10s')
         view.flash.assert_no_error()
-        view.flash.assert_success_message(
-            'Catalog "{}": Delete successful'.format(self.description or self.name))
 
 
 @attr.s

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -5,14 +5,18 @@ import pytest
 import cfme.tests.configure.test_access_control as tac
 from cfme import test_requirements
 from cfme.services.catalogs.catalog import CatalogsView
+from cfme.services.catalogs.catalog import DetailsCatalogView
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.update import update
+
 
 pytestmark = [test_requirements.service, pytest.mark.tier(2)]
 
 
 @pytest.mark.rhel_testing
 @pytest.mark.sauce
-def test_catalog_crud(appliance):
+def test_catalog_crud(request, appliance):
     """
     Polarion:
         assignee: nansari
@@ -20,16 +24,46 @@ def test_catalog_crud(appliance):
         initialEstimate: 1/8h
         tags: service
     """
+    # Create Catalog
     catalog_name = fauxfactory.gen_alphanumeric()
     cat = appliance.collections.catalogs.create(name=catalog_name, description='my catalog')
+    request.addfinalizer(cat.delete_if_exists)
 
-    view = cat.create_view(CatalogsView)
+    view = cat.create_view(CatalogsView, wait="10s")
     assert view.is_displayed
-    view.flash.assert_success_message('Catalog "{}" was saved'.format(catalog_name))
+    if BZ(1766276, forced_streams=['5.11']).blocks:
+        saved_message = f"Catalog was saved"
+    else:
+        saved_message = f'Catalog "{catalog_name}" was saved'
+    view.flash.assert_success_message(saved_message)
+    assert cat.exists
 
+    # Edit Catalog
+    update_descr = 'my edited description'
     with update(cat):
-        cat.description = 'my edited description'
+        cat.description = update_descr
+
+    assert cat.description == update_descr
+
+    view.flash.assert_success_message(saved_message)
+
+    view = navigate_to(cat, 'Edit')
+    view.fill(value={'description': 'test_cancel'})
+    view.cancel_button.click()
+    view = cat.create_view(DetailsCatalogView, wait="10s")
+    assert view.is_displayed
+    view.flash.assert_message(f'Edit of Catalog "{catalog_name}" was cancelled by the user')
+    assert cat.description == update_descr
+
+    # Delete Catalog
     cat.delete()
+    view = cat.create_view(CatalogsView, wait="10s")
+    if BZ(1765107).blocks:
+        delete_message = f'Catalog "{cat.description}": Delete successful'
+    else:
+        delete_message = f'Catalog "{catalog_name}": Delete successful'
+    view.flash.assert_success_message(delete_message)
+    assert not cat.exists
 
 
 @pytest.mark.sauce

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -4547,6 +4547,32 @@ class LineChart(Widget, ClickableMixin):
         return tooltip_data
 
 
+class ReactTextInput(TextInput):
+
+    # The clear method from the WebElement class in the Selenium package was not clearing the react
+    # text field. arguments[0] is the widget name
+    clear_text_field = """\
+        (function(elem){
+            var elem_name = document.getElementsByName(elem);
+            var elem_id = elem_name[0].id;
+            document.getElementById(elem_id).value = "";
+        }(arguments[0]));
+    """
+
+    def clear(self):
+        self.browser.execute_script(self.clear_text_field, self.name)
+
+    def fill(self, value):
+        current_value = self.value
+        if value == current_value:
+            return False
+        # Clear and type everything
+        self.browser.click(self)
+        self.clear()
+        self.browser.send_keys(value, self)
+        return True
+
+
 # Widget and its form views for Infra Planning Wizard
 
 


### PR DESCRIPTION
This PR addresses two updates:
1) Updating test_catalog.py
2) Removing the flash message success assertions from the catalog entity and moves them to the crud test

{{ pytest: cfme/tests/services/test_catalog.py::test_catalog_crud }}