### PR TITLE
[1LP][RFR]Automate: test_vm_right_size_recommendation_back_button

### DIFF
--- a/cfme/cloud/instance/openstack.py
+++ b/cfme/cloud/instance/openstack.py
@@ -11,7 +11,6 @@ from widgetastic_patternfly import Button
 from cfme.cloud.instance import CloudInstanceView
 from cfme.cloud.instance import Instance
 from cfme.cloud.instance import InstanceCollection
-from cfme.common.vm_views import RightSizeView
 from cfme.exceptions import DestinationNotFound
 from cfme.exceptions import displayed_not_implemented
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -288,16 +287,3 @@ class Reconfigure(CFMENavigateStep):
             configuration.item_select('Reconfigure this Instance')
         except NoSuchElementException:
             raise DestinationNotFound('Reconfigure option not available for instance')
-
-
-@navigator.register(OpenStackInstance, 'RightSize')
-class RightSize(CFMENavigateStep):
-    VIEW = RightSizeView
-    prerequisite = NavigateToSibling('Details')
-
-    def step(self, *args, **kwargs):
-        configuration = self.prerequisite_view.toolbar.configuration
-        try:
-            configuration.item_select('Right-Size Recommendations')
-        except NoSuchElementException:
-            raise DestinationNotFound('Right Size option not available for instance')

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -8,7 +8,9 @@ from datetime import timedelta
 import attr
 from cached_property import cached_property
 from manageiq_client.filters import Q
+from navmazing import NavigateToSibling
 from riggerlib import recursive_update
+from widgetastic.exceptions import NoSuchElementException
 
 from cfme.base.login import BaseLoggedInPage
 from cfme.common import CustomButtonEventsMixin
@@ -17,8 +19,10 @@ from cfme.common import Taggable
 from cfme.common.vm_console import ConsoleMixin
 from cfme.common.vm_views import DriftAnalysis
 from cfme.common.vm_views import DriftHistory
+from cfme.common.vm_views import RightSizeView
 from cfme.common.vm_views import VMPropertyDetailView
 from cfme.exceptions import CFMEException
+from cfme.exceptions import DestinationNotFound
 from cfme.exceptions import ItemNotFound
 from cfme.exceptions import OptionNotAvailable
 from cfme.exceptions import RestLookupError
@@ -26,6 +30,7 @@ from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.services.requests import RequestsView
 from cfme.utils import ParamClassName
+from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.blockers import BZ
@@ -1025,3 +1030,16 @@ class Template(BaseVM, _TemplateMixin):
 @attr.s
 class TemplateCollection(BaseVMCollection):
     ENTITY = Template
+
+
+@navigator.register(VM, "RightSize")
+class RightSize(CFMENavigateStep):
+    VIEW = RightSizeView
+    prerequisite = NavigateToSibling("Details")
+
+    def step(self, *args, **kwargs):
+        configuration = self.prerequisite_view.toolbar.configuration
+        try:
+            configuration.item_select("Right-Size Recommendations")
+        except NoSuchElementException:
+            raise DestinationNotFound("Right Size option not available.")

--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -593,11 +593,32 @@ class RightSizeView(BaseLoggedInPage):
     """
     Right Size recommendations page for vms/instances
     """
-    # TODO new table widget for right-size tables
-    # They're H3 headers with the table as following-sibling
 
-    # Only name is displayed
-    is_displayed = displayed_not_implemented
+    title = Text("#explorer_title_text")
+    nor_table = Table(
+        '//*[contains(normalize-space(.), "Normal Operating Range")]/following-sibling::table[1]'
+    )
+    aggressive_table = Table(
+        '//*[contains(normalize-space(.), "Aggressive")]/following-sibling::table[1]'
+    )
+    conservative_table = Table(
+        '//*[contains(normalize-space(.), "Conservative")]/following-sibling::table[1]'
+    )
+    moderate_table = Table(
+        '//*[contains(normalize-space(.), "Moderate")]/following-sibling::table[1]'
+    )
+    back_button = Button("Back")
+
+    @property
+    def is_displayed(self):
+        return (
+            self.title.text
+            == f'Right Size Recommendation for Virtual Machine "{self.context["object"].name}"'
+            and self.nor_table.is_displayed
+            and self.aggressive_table.is_displayed
+            and self.conservative_table.is_displayed
+            and self.moderate_table.is_displayed
+        )
 
 
 class DriftHistory(BaseLoggedInPage):

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -8,6 +8,7 @@ from cfme.common.provider_views import InfraProviderAddView
 from cfme.common.provider_views import InfraProvidersView
 from cfme.common.provider_views import PhysicalProviderAddView
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+from cfme.infrastructure.virtual_machines import InfraVmDetailsView
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.wait import wait_for
@@ -337,6 +338,32 @@ def test_tls_openssl_verify_mode(temp_appliance_preconfig, request):
     appliance.server.settings.update_smtp_server({"start_tls": old_tls})
     assert view.smtp_server.start_tls.read() == old_tls
     assert appliance.advanced_settings["smtp"]["openssl_verify_mode"] == "none"
+
+
+@pytest.mark.tier(1)
+@pytest.mark.meta(automates=[1733207])
+@pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE)
+def test_vm_right_size_recommendation_back_button(appliance, setup_provider, full_template_vm):
+    """
+    Bugzilla:
+        1733207
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Infra
+        caseimportance: medium
+        initialEstimate: 1/18h
+        setup:
+            1. Add provider to appliance.
+        testSteps:
+            1. Navigate to a VM's details page.
+            2. From `Configuration` dropdown, select `Right Size Recommendations`.
+            3. Click on `Back` button and check if you're brought to Details Page.
+    """
+    view = navigate_to(full_template_vm, "RightSize")
+    view.back_button.click()
+    view = full_template_vm.create_view(InfraVmDetailsView)
+    assert view.is_displayed
 
 
 @pytest.mark.ignore_stream('5.10')

--- a/cfme/tests/webui/test_general_ui_manual.py
+++ b/cfme/tests/webui/test_general_ui_manual.py
@@ -166,32 +166,6 @@ def test_provider_documentation():
 
 
 @pytest.mark.tier(1)
-@pytest.mark.meta(coverage=[1733207])
-def test_vm_right_size_recommendation_back_button():
-    """
-    Bugzilla:
-        1733207
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Infra
-        caseimportance: medium
-        initialEstimate: 1/18h
-        setup:
-            1. Add provider to appliance.
-        testSteps:
-            1. Navigate to a VM's details page.
-            2. From `Configuration` dropdown, select `Right Size Recommendations`.
-            3. Click on `Back` button.
-        expectedResults:
-            1.
-            2.
-            3. Back button must bring back to the details page.
-    """
-    pass
-
-
-@pytest.mark.tier(1)
 @pytest.mark.meta(coverage=[1745660])
 def test_compliance_column_header():
     """


### PR DESCRIPTION
## Purpose or Intent

- __Extending__ 
    1. `RightSizeView`  by adding widgets and `is_displayed` property to it.
- __Adding tests__ 
    1. `test_vm_right_size_recommendation_back_button`
- __Enhancement__ 
    1. Add navigator for `RightSizeView` by removing existing navigator registered against `OpenstackInstance` and writing a common one registered against `VM`.

### PRT Run
{{ pytest: cfme/tests/webui/test_general_ui.py -k "test_vm_right_size_recommendation_back_button" -vvvv }}