### PR TITLE
[1LP][RFR] New Test: Testing  handle alert while editing dialog

### DIFF
--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -164,18 +164,17 @@ def test_dynamic_dialog_fields_ansible_tower_templates():
     pass
 
 
-@pytest.mark.meta(coverage=[1707961])
-@pytest.mark.manual
+@pytest.mark.meta(automates=[1707961])
 @pytest.mark.tier(2)
-def test_dialog_editor_modify_field():
+@pytest.mark.ignore_stream("5.10")
+def test_dialog_editor_modify_field(dialog):
     """
-
     Bugzilla:
         1707961
 
     Polarion:
         assignee: nansari
-        startsin: 5.10
+        startsin: 5.11
         casecomponent: Services
         initialEstimate: 1/16h
         testSteps:
@@ -189,7 +188,12 @@ def test_dialog_editor_modify_field():
             3.
             4. The UI should confirm that you want to exit without saving your dialog
     """
-    pass
+    view = navigate_to(dialog, "Edit")
+    view.description.fill(fauxfactory.gen_alpha())
+    view.cancel_button.click(handle_alert=True)
+    view = navigate_to(dialog, "Edit")
+    assert view.description.read() == dialog.description
+    view.cancel_button.click(handle_alert=False)
 
 
 @pytest.mark.meta(coverage=[1706848])


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

## Purpose or Intent
- Testing handle alert while editing dialog. This feature is introduced in 5.11
### PRT Run
{{ pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_dialog_editor_modify_field --use-template-cache -qsvv --long-running }}