### PR TITLE
[1LP][RFR] Prevent AttributeError in provider endpoints

### DIFF
--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -1221,7 +1221,7 @@ class DefaultEndpoint(object):
 
     @property
     def view_value_mapping(self):
-        return {'hostname': self.hostname}
+        return {'hostname': getattr(self, 'hostname', None)}
 
 
 class CANDUEndpoint(DefaultEndpoint):
@@ -1230,9 +1230,9 @@ class CANDUEndpoint(DefaultEndpoint):
 
     @property
     def view_value_mapping(self):
-        return {'hostname': self.hostname,
+        return {'hostname': getattr(self, 'hostname', None),
                 'api_port': getattr(self, 'api_port', None),
-                'database_name': self.database}
+                'database_name': getattr(self, 'database', None)}
 
 
 class SmartStateDockerEndpoint(DefaultEndpoint):
@@ -1250,11 +1250,10 @@ class EventsEndpoint(DefaultEndpoint):
 
     @property
     def view_value_mapping(self):
-        return {'event_stream': self.event_stream,
+        return {'event_stream': getattr(self, 'event_stream', None),
                 'security_protocol': getattr(self, 'security_protocol', None),
-                'hostname': self.hostname,
-                'api_port': getattr(self, 'api_port', None),
-                }
+                'hostname': getattr(self, 'hostname', None),
+                'api_port': getattr(self, 'api_port', None)}
 
 
 class SSHEndpoint(DefaultEndpoint):

--- a/cfme/infrastructure/provider/openstack_infra.py
+++ b/cfme/infrastructure/provider/openstack_infra.py
@@ -29,10 +29,9 @@ from widgetastic_manageiq import WaitTab
 class RHOSEndpoint(DefaultEndpoint):
     @property
     def view_value_mapping(self):
-        return {'security_protocol': self.security_protocol,
-                'hostname': self.hostname,
-                'api_port': getattr(self, 'api_port', None)
-                }
+        return {'security_protocol': getattr(self, 'security_protocol', None),
+                'hostname': getattr(self, 'hostname', None),
+                'api_port': getattr(self, 'api_port', None)}
 
 
 class OpenStackInfraEndpointForm(View):

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -22,11 +22,10 @@ from widgetastic_manageiq import WaitTab
 class RHEVMEndpoint(DefaultEndpoint):
     @property
     def view_value_mapping(self):
-        return {'hostname': self.hostname,
+        return {'hostname': getattr(self, 'hostname', None),
                 'api_port': getattr(self, 'api_port', None),
                 'verify_tls': getattr(self, 'verify_tls', None),
-                'ca_certs': getattr(self, 'ca_certs', None)
-                }
+                'ca_certs': getattr(self, 'ca_certs', None)}
 
 
 class RHEVMEndpointForm(View):

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -12,7 +12,7 @@ from cfme.services.catalogs.catalog_items import SCVMMCatalogItem
 class SCVMMEndpoint(DefaultEndpoint):
     @property
     def view_value_mapping(self):
-        return {'hostname': self.hostname,
+        return {'hostname': getattr(self, 'hostname', None),
                 'security_protocol': getattr(self, 'security_protocol', None),
                 'realm': getattr(self, 'security_realm', None)
                 }


### PR DESCRIPTION
AttributeError triggered by references to endpoint attributes that don't exist.

There's no clean way to refer back to the default endpoint via the provider, that is an enhancement that can be handled separately.

This, ~~combined with a YAML change to restore the hostname for the openstack events endpoint~~, should prevent AttributeError error results in tests.