### PR TITLE
[1LP][RFR] Fix fixture scope mismatches

### DIFF
--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -189,6 +189,7 @@ def test_raw_metric_vm_network(metrics_collection, appliance, provider):
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider, GCEProvider],
     required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    scope='module',
     override=True
 )
 @pytest.mark.meta(automates=[BZ(1671580)])
@@ -214,6 +215,7 @@ def test_raw_metric_vm_disk(metrics_collection, appliance, provider):
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider],
     required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    scope='module',
     override=True
 )
 def test_raw_metric_host_cpu(metrics_collection, appliance, provider):
@@ -237,6 +239,7 @@ def test_raw_metric_host_cpu(metrics_collection, appliance, provider):
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider],
     required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    scope='module',
     override=True
 )
 def test_raw_metric_host_memory(metrics_collection, appliance, provider):
@@ -261,6 +264,7 @@ def test_raw_metric_host_memory(metrics_collection, appliance, provider):
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider],
     required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    scope='module',
     override=True
 )
 def test_raw_metric_host_network(metrics_collection, appliance, provider):
@@ -284,6 +288,7 @@ def test_raw_metric_host_network(metrics_collection, appliance, provider):
 @pytest.mark.provider(
     [VMwareProvider, RHEVMProvider],
     required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
+    scope='module',
     override=True
 )
 def test_raw_metric_host_disk(metrics_collection, appliance, provider):

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -29,7 +29,8 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     pytest.mark.tier(3),
     pytest.mark.provider([InfraProvider],
-                         required_fields=['hosts'], scope='module',
+                         required_fields=['hosts'],
+                         scope='module',
                          selector=ONE_PER_TYPE),
 ]
 
@@ -96,6 +97,7 @@ def navigate_and_select_quads(provider):
 @pytest.mark.provider([VMwareProvider],
                       required_fields=['hosts'],
                       selector=ONE_PER_VERSION,
+                      scope='module',
                       override=True)
 def test_discover_host(request, provider, appliance, host_ips):
     """Tests hosts discovery.

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -71,7 +71,7 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
     return result
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope='module')
 def provision_data(appliance, provider, small_template_modscope):
     return get_provision_data(appliance.rest_api, provider, small_template_modscope.name)
 
@@ -120,7 +120,8 @@ def test_provision(request, appliance, provider, provision_data):
 
 
 @pytest.mark.rhv2
-@pytest.mark.provider([RHEVMProvider], override=True)  # These profile names are RHV specific
+# These profile names are RHV specific
+@pytest.mark.provider([RHEVMProvider], override=True, scope='module')
 @pytest.mark.parametrize('vnic_profile', ['empty_vnic_profile', 'specific_vnic_profile'])
 def test_provision_vlan(request, appliance, provision_data, vnic_profile, provider):
     """Tests provision via REST API for vlan Empty/Specific vNic profile.


### PR DESCRIPTION
fixture scope mismatches from provider markers.

PRT results: 

Showing test execution for those tests impacted by the scope mismatch. Not trying to resolve every test failure within these tests, just the scope mismatch.