### PR TITLE
[1LP][RFR] Automate test case for db user in ldap configured appliance

### DIFF
--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -451,40 +451,6 @@ def test_verify_the_trusted_forest_settings_table_display_in_auth_page():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_authentication_user_not_in_ldap_but_in_db():
-    """
-    User is not able to authenticate if he has account in CFME DB but not
-    in LDAP.
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: medium
-        caseposneg: negative
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_verify_database_user_login_fails_with_external_auth_configured():
-    """
-    Login with user registered to cfme internal database.
-    Authentication expected to fail, check audit.log and evm.log for
-    correct log messages.
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_external_auth_openldap_proxy_to_3_domains():
     """

--- a/cfme/tests/integration/test_ldap_auth.py
+++ b/cfme/tests/integration/test_ldap_auth.py
@@ -79,6 +79,9 @@ def test_verify_database_user_login_fails_with_external_auth_configured(
     Login with user registered to cfme internal database.
     Authentication expected to fail
 
+    Bugzilla:
+        1632718
+
     Polarion:
         assignee: jdupuy
         casecomponent: Configuration

--- a/cfme/tests/integration/test_ldap_auth.py
+++ b/cfme/tests/integration/test_ldap_auth.py
@@ -1,20 +1,37 @@
+import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.base.credential import Credential
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 
 
 # Specific tests concerning ldap authentication
 pytestmark = [
     test_requirements.auth,
-    pytest.mark.provider([VMwareProvider], override=True, scope="module", selector=ONE),
-    pytest.mark.usefixtures('setup_provider')
 ]
 
 
+@pytest.fixture
+def db_user(appliance):
+    name = f"test-user-{fauxfactory.gen_alpha()}"
+    creds = Credential(principal=name, secret=fauxfactory.gen_alpha())
+    user_group = appliance.collections.groups.instantiate(description="EvmGroup-vm_user")
+    user = appliance.collections.users.create(
+        name=name,
+        credential=creds,
+        groups=user_group,
+    )
+    yield user
+    user.delete_if_exists()
+
+
 @pytest.mark.tier(2)
+@pytest.mark.provider([VMwareProvider], override=True, scope="function", selector=ONE)
+@pytest.mark.usefixtures('setup_provider')
 def test_validate_lookup_button_provisioning(
         appliance, provider, small_template, setup_ldap_auth_provider
 ):
@@ -51,3 +68,25 @@ def test_validate_lookup_button_provisioning(
     # now get the first and last name
     assert view.form.request.first_name.read() == user.fullname.split(" ")[0].lower()
     assert view.form.request.last_name.read() == user.fullname.split(" ")[1].lower()
+
+
+@pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[BZ(1632718)])
+def test_verify_database_user_login_fails_with_external_auth_configured(
+        appliance, setup_ldap_auth_provider, db_user
+):
+    """
+    Login with user registered to cfme internal database.
+    Authentication expected to fail
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: Configuration
+        caseimportance: medium
+        caseposneg: negative
+        initialEstimate: 1/4h
+    """
+    with db_user:
+        # we expect authentication to fail and to raise an AssertionError
+        with pytest.raises(AssertionError):
+            navigate_to(appliance.server, "LoggedIn")

--- a/cfme/tests/integration/test_ldap_auth.py
+++ b/cfme/tests/integration/test_ldap_auth.py
@@ -17,7 +17,7 @@ pytestmark = [
 
 @pytest.fixture
 def db_user(appliance):
-    name = f"test-user-{fauxfactory.gen_alpha()}"
+    name = fauxfactory.gen_alpha(15, start="test-user-")
     creds = Credential(principal=name, secret=fauxfactory.gen_alpha())
     user_group = appliance.collections.groups.instantiate(description="EvmGroup-vm_user")
     user = appliance.collections.users.create(
@@ -71,7 +71,7 @@ def test_validate_lookup_button_provisioning(
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(blockers=[BZ(1632718)])
+@pytest.mark.meta(blockers=[BZ(1632718)], automates=[1632718])
 def test_verify_database_user_login_fails_with_external_auth_configured(
         appliance, setup_ldap_auth_provider, db_user
 ):


### PR DESCRIPTION
Automating manual test case that asserts that authentication fails if we try to login with a DB user on a ldap-configured appliance. 

{{ pytest: --use-provider vsphere65-nested cfme/tests/integration/test_ldap_auth.py }}