### PR TITLE
[WIPTEST] DRAFT skip/fail on meta blocker resolving that triggers exception

### DIFF
--- a/cfme/markers/meta.py
+++ b/cfme/markers/meta.py
@@ -159,24 +159,42 @@ def run_plugins(item, when):
         logger.info(
             "Calling metaplugin {}({}) with meta signature {} {}".format(
                 plugin_name, plug.function.__name__, str(plug.metas), str(plug.kwargs)))
-        plug.function(**env)
+        try:
+            plug.function(**env)
+        except Exception:
+            # log and raise to let the hook function handle it
+            logger.exception(f'Exception running meta marker plugin function for plugin {plug} '
+                             f'with env {env}')
+            raise
         logger.info(
             "Metaplugin {}({}) with meta signature {} {} has finished".format(
                 plugin_name, plug.function.__name__, str(plug.metas), str(plug.kwargs)))
 
 
 def pytest_runtest_setup(item):
-    run_plugins(item, plugin.SETUP)
+    try:
+        run_plugins(item, plugin.SETUP)
+    except Exception:
+        pytest.skip('Exception while running meta marker plugin in SETUP')
 
 
 def pytest_runtest_teardown(item):
-    run_plugins(item, plugin.TEARDOWN)
+    try:
+        run_plugins(item, plugin.TEARDOWN)
+    except Exception:
+        pytest.fail('Exception while running meta marker plugin in TEARDOWN')
 
 
 @pytest.mark.hookwrapper
 def pytest_runtest_call(item):
-    run_plugins(item, plugin.BEFORE_RUN)
+    try:
+        run_plugins(item, plugin.BEFORE_RUN)
+    except Exception:
+        pytest.skip('Exception while running meta marker plugin in BEFORE_RUN')
     try:
         yield
     finally:
-        run_plugins(item, plugin.AFTER_RUN)
+        try:
+            run_plugins(item, plugin.AFTER_RUN)
+        except Exception:
+            pytest.fail('Exception while running meta marker plugin in AFTER_RUN')

--- a/cfme/utils/blockers.py
+++ b/cfme/utils/blockers.py
@@ -27,6 +27,9 @@ class Blocker(object):
         self.forced_streams = kwargs.pop("forced_streams", [])
         self.__dict__["kwargs"] = kwargs
 
+    def __repr__(self):
+        return f'{self.__module__}{self.__class__.__name__}::{self.bug_id}'
+
     @property
     def url(self):
         raise NotImplementedError('You need to implement .url')
@@ -115,6 +118,12 @@ class GH(Blocker):
         else:
             raise ValueError("GH issue specified wrong")
 
+    def __repr__(self):
+        return f'{self.__module__}.{self.__class__.__name__}::{self.repo}::{self.issue}'
+
+    def __str__(self):
+        return f'GitHub Issue https://github.com/{self.repo}/issues/{self.issue}'
+
     @property
     def data(self):
         identifier = "{}:{}".format(self.repo, self.issue)
@@ -147,9 +156,6 @@ class GH(Blocker):
     def repo(self):
         return self._repo or self.DEFAULT_REPOSITORY
 
-    def __str__(self):
-        return "GitHub Issue https://github.com/{}/issues/{}".format(self.repo, self.issue)
-
     @property
     def url(self):
         return "https://github.com/{}/issues/{}".format(self.repo, self.issue)
@@ -169,6 +175,12 @@ class BZ(Blocker):
         self.ignore_bugs = kwargs.pop("ignore_bugs", [])
         super(BZ, self).__init__(**kwargs)
         self.bug_id = int(bug_id)
+
+    def __repr__(self):
+        return f'{self.__module__}.{self.__class__.__name__}::{self.bug_id}'
+
+    def __str__(self):
+        return f'Bugzilla bug {self.get_bug_url()} (or one of its copies)'
 
     @property
     def data(self):
@@ -253,9 +265,6 @@ class BZ(Blocker):
     def url(self):
         return self.get_bug_url()
 
-    def __str__(self):
-        return "Bugzilla bug {} (or one of its copies)".format(self.get_bug_url())
-
 
 class JIRA(Blocker):
     @classproperty
@@ -271,6 +280,12 @@ class JIRA(Blocker):
     def __init__(self, jira_id, **kwargs):
         super(JIRA, self).__init__(**kwargs)
         self.jira_id = jira_id
+
+    def __repr__(self):
+        return f'{self.__module__}.{self.__class__.__name__}::{self.jira_id}'
+
+    def __str__(self):
+        return f'Jira card {self.url}'
 
     @property
     def url(self):
@@ -288,6 +303,3 @@ class JIRA(Blocker):
             return False
         issue = jira.issue(self.jira_id, fields='status')
         return issue.fields.status.name.lower() != 'done'
-
-    def __str__(self):
-        return 'Jira card {}'.format(self.url)

--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -121,7 +121,9 @@ class Bugzilla(object):
     def get_bug(self, id):
         id = int(id)
         if id not in self.__bug_cache:
-            self.__bug_cache[id] = BugWrapper(self, self.bugzilla.getbug(id))
+            from requests import HTTPError
+            raise HTTPError
+            # self.__bug_cache[id] = BugWrapper(self, self.bugzilla.getbug(id))
         return self.__bug_cache[id]
 
     def get_bug_variants(self, id):


### PR DESCRIPTION
I'd like to handle exceptions during blocker resolution in a better way, not just letting it result in an ERROR state for the marked test item.

Draft state right now, the pytest.skip call in the pytest hook didn't skip the item in local testing...

Also adding a `repr` for the blocker classes so the exception messages are more readable and informative.