### PR TITLE
[1LP][RFR] Automate test case for checking that invalid user cannot login

### DIFF
--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -688,20 +688,3 @@ def test_session_timeout():
         title: Verify session timeout works fine for external auth.
     """
     pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_login_invalid_user():
-    """
-    Login with invalid user
-    Authentication expected to fail, check audit.log and evm.log for
-    correct log messages.
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: low
-        caseposneg: negative
-        initialEstimate: 1/4h
-    """
-    pass


### PR DESCRIPTION
{{ pytest: cfme/tests/integration/test_db_auth.py::test_login_invalid_user }}
