### PR TITLE
[1LP][RFR] Test case for setting up external auth when ntpd is off on IPA server

### DIFF
--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -7,33 +7,6 @@ pytestmark = [test_requirements.auth]
 
 @pytest.mark.manual
 @pytest.mark.tier(1)
-def test_appliance_console_ipa_ntp():
-    """
-    Try to setup IPA on appliance when NTP daemon is stopped on server.
-
-    Polarion:
-        assignee: jdupuy
-        casecomponent: Auth
-        caseimportance: medium
-        initialEstimate: 1/4h
-        caseposneg: negative
-        setup:
-            1. Have IPA server configured and running
-                - https://mojo.redhat.com/docs/DOC-1058778
-        testSteps:
-            1. ssh into IPA server stop NTP daemon
-            2. ssh to appliance and try to setup IPA
-                - appliance_console_cli --ipaserver <IPA_URL> --ipaprincipal <LOGIN>
-                    --ipapassword <PASS> --ipadomain <DOMAIN> --iparealm <REALM>
-        expectedResults:
-            1. NTP daemon stopped
-            2. Command should fail; setting up IPA unsuccessful
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(1)
 def test_appliance_console_ipa():
     """
     Test setting up IPA authentication with invalid host settings

--- a/cfme/tests/integration/test_external_auth.py
+++ b/cfme/tests/integration/test_external_auth.py
@@ -1,0 +1,16 @@
+import pytest
+
+from cfme import test_requirements
+from cfme.utils.auth import get_auth_crud
+
+pytestmark = [test_requirements.auth]
+
+# External auth specific test cases (e.g. freeipa)
+
+
+@pytest.fixture
+def freeipa_provider():
+    auth_prov = get_auth_crud("freeipa03")
+    # turn off ntp
+    auth_prov.ssh_client.run_command("systemctl stop ntpd")
+    yield auth_prov

--- a/cfme/tests/integration/test_external_auth.py
+++ b/cfme/tests/integration/test_external_auth.py
@@ -3,6 +3,7 @@ from gevent.timeout import Timeout
 
 from cfme import test_requirements
 from cfme.utils.auth import get_auth_crud
+from cfme.utils.blockers import BZ
 
 pytestmark = [test_requirements.auth]
 
@@ -23,9 +24,13 @@ def freeipa_provider():
 
 
 @pytest.mark.tier(1)
+@pytest.mark.meta(blockers=[BZ(1767082, forced_streams=['5.10'])], automates=[1767082])
 def test_appliance_console_ipa_ntp(request, appliance, freeipa_provider):
     """
     Try to setup IPA on appliance when NTP daemon is stopped on server.
+
+    Bugzilla:
+        1767082
 
     Polarion:
         assignee: jdupuy

--- a/cfme/tests/integration/test_external_auth.py
+++ b/cfme/tests/integration/test_external_auth.py
@@ -1,4 +1,5 @@
 import pytest
+from gevent.timeout import Timeout
 
 from cfme import test_requirements
 from cfme.utils.auth import get_auth_crud
@@ -10,7 +11,42 @@ pytestmark = [test_requirements.auth]
 
 @pytest.fixture
 def freeipa_provider():
+    # run this on freeipa03 as to not affect tests running on freeipa01
     auth_prov = get_auth_crud("freeipa03")
-    # turn off ntp
-    auth_prov.ssh_client.run_command("systemctl stop ntpd")
+    # turn off ntpd
+    cmd = auth_prov.ssh_client.run_command("systemctl stop ntpd")
+    assert cmd.success
     yield auth_prov
+    # turn ntpd back on
+    cmd = auth_prov.ssh_client.run_command("systemctl start ntpd")
+    assert cmd.success
+
+
+@pytest.mark.tier(1)
+def test_appliance_console_ipa_ntp(request, appliance, freeipa_provider):
+    """
+    Try to setup IPA on appliance when NTP daemon is stopped on server.
+
+    Polarion:
+        assignee: jdupuy
+        casecomponent: Auth
+        caseimportance: medium
+        initialEstimate: 1/4h
+        caseposneg: negative
+        setup:
+            1. Have IPA server configured and running
+                - https://mojo.redhat.com/docs/DOC-1058778
+        testSteps:
+            1. ssh into IPA server stop NTP daemon
+            2. ssh to appliance and try to setup IPA
+                - appliance_console_cli --ipaserver <IPA_URL> --ipaprincipal <LOGIN>
+                    --ipapassword <PASS> --ipadomain <DOMAIN> --iparealm <REALM>
+        expectedResults:
+            1. NTP daemon stopped
+            2. Command should fail; setting up IPA unsuccessful
+    """
+    request.addfinalizer(appliance.disable_freeipa)
+
+    # we expect configuration to fail because ntpd is off on freeipa03
+    with pytest.raises((Timeout, AssertionError)):
+        appliance.configure_freeipa(freeipa_provider)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2451,6 +2451,8 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         """Switch UI back to database authentication, and run --uninstall-ipa on appliance"""
         self.appliance_console_cli.uninstall_ipa_client()
         self.server.authentication.configure(auth_mode='database')
+        # reset ntp servers
+        self.server.settings.update_ntp_servers({'ntp_server_1': 'clock.corp.redhat.com'})
         self.wait_for_web_ui()  # httpd restart in uninstall-ipa
 
     @logger_wrap('Configuring SAML external auth provider')

--- a/cfme/utils/auth/__init__.py
+++ b/cfme/utils/auth/__init__.py
@@ -13,6 +13,7 @@ from cfme.exceptions import UnknownProviderType
 from cfme.utils.conf import auth_data
 from cfme.utils.conf import credentials
 from cfme.utils.log import logger
+from cfme.utils.ssh import SSHClient
 
 auth_prov_data = auth_data.get("auth_providers", {})  # setup on module import
 
@@ -269,6 +270,15 @@ class FreeIPAAuthProvider(MIQAuthProvider):
                 external.update({att: getattr(self, att)})
 
         return external
+
+    @property
+    def ssh_client(self):
+        ssh_kwargs = dict(
+            hostname=self.host1,
+            username="root",
+            password=self.bind_password,
+        )
+        return SSHClient(**ssh_kwargs)
 
 
 @attr.s


### PR DESCRIPTION
We run this on `freeipa03` instead of `freeipa01` so that `test_cfme_auth` tests are not affected by `ntpd` being turned off. 

{{ pytest: cfme/tests/integration/test_external_auth.py }}