### PR TITLE
[RFR] recovering lost sprout's ipv6 patch

### DIFF
--- a/sprout/appliances/tasks/provisioning.py
+++ b/sprout/appliances/tasks/provisioning.py
@@ -394,7 +394,7 @@ def retrieve_appliance_ip(self, appliance_id):
                 )
                 self.retry(args=(appliance_id,), countdown=2, max_retries=10)
 
-            ip_address = wait_pingable(appliance.vm_mgmt)
+            ip_address = wait_pingable(appliance.vm_mgmt, allow_ipv6=False)
         self.logger.info('Updating with reachable IP %s for appliance %s',
                          ip_address, appliance_id)
 


### PR DESCRIPTION
it seems I lost this ipv6 patch during one of recent rebase operation. this led to providing appliances with ipv6 ips and screwing up some tests.