### PR TITLE
[1LP][RFR] automated BZ 1726590

### DIFF
--- a/cfme/common/vm_views.py
+++ b/cfme/common/vm_views.py
@@ -236,7 +236,7 @@ class BasicProvisionFormView(View):
         vm_filter = BootstrapSelect('service__vm_filter')
         num_vms = BootstrapSelect('service__number_of_vms')
         provision_type = BootstrapSelect('service__provision_type')
-        linked_clone = Input(name='service__linked_clone')
+        linked_clone = Checkbox(name='service__linked_clone')
         pxe_server = BootstrapSelect('service__pxe_server_id')
         pxe_image = SelectTable('//div[@id="prov_pxe_img_div"]/table')
         iso_file = SelectTable('//div[@id="prov_iso_img_div"]/table')


### PR DESCRIPTION
## Purpose or Intent
Automated BZ https://bugzilla.redhat.com/show_bug.cgi?id=1726590 for provisioning with the selected "Linked Clone" option from the template with preallocated disks. 
~Requires wrapanapi PR https://github.com/ManageIQ/wrapanapi/pull/424~

Requires yaml update.

### PRT Run
{{ pytest: -v cfme/tests/infrastructure/test_provisioning_dialog.py::test_linked_clone_default }}

### Notes
Actually, PRT run is useless because the BZ is still on dev. I tested locally and the test currently fails as expected.