### PR TITLE
[1LP][RFR] Fix restore tests part one

### DIFF
--- a/cfme/exceptions.py
+++ b/cfme/exceptions.py
@@ -281,6 +281,11 @@ class RestLookupError(CFMEException):
     """raised when lookup of a rest entity fails"""
 
 
+class SSHExpectTimeoutError(CFMEException):
+    """ Raised when SSHExpect Timeouts when waiting for some input. """
+    pass
+
+
 @property
 def displayed_not_implemented(cls):
     raise NotImplementedError("This view has no unique markers for is_displayed check")

--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -178,6 +178,17 @@ def temp_appliances_unconfig_modscope_rhevm(appliance, pytestconfig):
         yield appliances
 
 
+@pytest.fixture(scope="function")
+def temp_appliances_preconfig_funcscope(appliance, pytestconfig):
+    with sprout_appliances(
+            appliance,
+            config=pytestconfig,
+            count=2,
+            preconfigured=True
+    ) as appliances:
+        yield appliances
+
+
 @pytest.fixture(scope="class")
 def temp_appliances_unconfig_clsscope(appliance, pytestconfig):
     with sprout_appliances(

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -329,31 +329,31 @@ def configure_appliances_ha(appliances, pwd):
 
         wait_for(lambda: apps0.db.is_dedicated_active, num_sec=4 * 60)
 
-        # Configure EVM webui appliance with create region in dedicated database
-        with SSHExpect(apps2) as interaction:
-            interaction.send('ap')
-            interaction.answer('Press any key to continue.', '', timeout=20)
-            interaction.answer('Choose the advanced setting: ',
-                               '5' if apps2.version < '5.10' else '7')  # Configure Database
-            interaction.answer(resc('Choose the encryption key: |1| '), '2')
-            interaction.send(app0_ip)
-            interaction.answer(resc('Enter the appliance SSH login: |root| '), '')
-            interaction.answer('Enter the appliance SSH password: ', pwd)
-            interaction.answer(
-                resc('Enter the path of remote encryption key: |/var/www/miq/vmdb/certs/v2_key| '),
-                '')
-            interaction.answer('Choose the database operation: ', '2', timeout=30)
-            interaction.answer('Enter the database region number: ', '0')
-            # WARNING: Creating a database region will destroy any existing data and
-            # cannot be undone.
-            interaction.answer(resc('Are you sure you want to continue? (Y/N):'), 'y')
-            interaction.answer('Enter the database hostname or IP address: ', app0_ip)
-            interaction.answer(resc('Enter the port number: |5432| '), '')
-            interaction.answer(r'Enter the name of the database on .*: \|vmdb_production\| ', '')
-            interaction.answer(resc('Enter the username: |root| '), '')
-            interaction.answer('Enter the database password on .*: ', pwd)
-            # Configuration activated successfully.
-            interaction.answer('Press any key to continue.', '', timeout=360)
+    # Configure EVM webui appliance with create region in dedicated database
+    with SSHExpect(apps2) as interaction:
+        interaction.send('ap')
+        interaction.answer('Press any key to continue.', '', timeout=20)
+        interaction.answer('Choose the advanced setting: ',
+                           '5' if apps2.version < '5.10' else '7')  # Configure Database
+        interaction.answer(resc('Choose the encryption key: |1| '), '2')
+        interaction.send(app0_ip)
+        interaction.answer(resc('Enter the appliance SSH login: |root| '), '')
+        interaction.answer('Enter the appliance SSH password: ', pwd)
+        interaction.answer(
+            resc('Enter the path of remote encryption key: |/var/www/miq/vmdb/certs/v2_key| '),
+            '')
+        interaction.answer('Choose the database operation: ', '2', timeout=30)
+        interaction.answer('Enter the database region number: ', '0')
+        # WARNING: Creating a database region will destroy any existing data and
+        # cannot be undone.
+        interaction.answer(resc('Are you sure you want to continue? (Y/N):'), 'y')
+        interaction.answer('Enter the database hostname or IP address: ', app0_ip)
+        interaction.answer(resc('Enter the port number: |5432| '), '')
+        interaction.answer(r'Enter the name of the database on .*: \|vmdb_production\| ', '')
+        interaction.answer(resc('Enter the username: |root| '), '')
+        interaction.answer('Enter the database password on .*: ', pwd)
+        # Configuration activated successfully.
+        interaction.answer('Press any key to continue.', '', timeout=360)
 
     apps2.evmserverd.wait_for_running()
     apps2.wait_for_web_ui()

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -369,6 +369,18 @@ def configure_appliances_ha(appliances, pwd):
     return appliances
 
 
+def answer_cluster_related_questions(interaction, node_uid, db_name,
+        db_username, db_password):
+    # It seems like sometimes, the word "Enter " ... dosen't fit to the paramiko-expect buffer.
+    # This seems to happen when (re)configuring the standby replication node.
+    interaction.answer('.* the number uniquely identifying '
+                       'this node in the replication cluster: ', node_uid)
+    interaction.answer(resc('Enter the cluster database name: |vmdb_production| '), db_name)
+    interaction.answer(resc('Enter the cluster database username: |root| '), db_username)
+    interaction.answer('Enter the cluster database password: ', db_password)
+    interaction.answer('Enter the cluster database password: ', db_password)
+
+
 def configure_primary_replication_node(appl, pwd):
     # Configure primary replication node
     with SSHExpect(appl) as interaction:
@@ -378,14 +390,10 @@ def configure_primary_replication_node(appl, pwd):
         interaction.answer('Choose the advanced setting: ',
                            '6' if appl.version < '5.10' else '8')
         interaction.answer('Choose the database replication operation: ', '1')
-        interaction.answer('Enter the number uniquely identifying '
-                           'this node in the replication cluster: ', '1')
-        interaction.answer(resc('Enter the cluster database name: |vmdb_production| '), '')
-        interaction.answer(resc('Enter the cluster database username: |root| '), '')
-        interaction.answer('Enter the cluster database password: ', pwd)
-        interaction.answer('Enter the cluster database password: ', pwd)
+        answer_cluster_related_questions(interaction, node_uid='1',
+            db_name='', db_username='', db_password=pwd)
         interaction.answer(r'Enter the primary database hostname or IP address: \|.*\| ',
-                           appl.hostname)
+                        appl.hostname)
         interaction.answer(resc('Apply this Replication Server Configuration? (Y/N): '), 'y')
         interaction.answer('Press any key to continue.', '')
 
@@ -400,12 +408,8 @@ def reconfigure_primary_replication_node(appl, pwd):
         # 6/8 for Configure Database Replication
 
         interaction.answer('Choose the database replication operation: ', '1')
-        interaction.answer('Enter the number uniquely identifying '
-                           'this node in the replication cluster: ', '1')
-        interaction.answer(resc('Enter the cluster database name: |vmdb_production| '), '')
-        interaction.answer(resc('Enter the cluster database username: |root| '), '')
-        interaction.answer('Enter the cluster database password: ', pwd)
-        interaction.answer('Enter the cluster database password: ', pwd)
+        answer_cluster_related_questions(interaction, node_uid='1',
+            db_name='', db_username='', db_password=pwd)
         interaction.answer(r'Enter the primary database hostname or IP address: \|.*\| ',
                            appl.hostname)
         # Warning: File /etc/repmgr.conf exists. Replication is already configured
@@ -433,14 +437,8 @@ def configure_standby_replication_node(appl, pwd, primary_ip):
                                 '|/var/www/miq/vmdb/certs/v2_key| '), '')
         interaction.answer(resc('Choose the standby database disk: '),
                            '1' if appl.version < '5.10' else '2')
-        # "Enter " ... is on line above.
-        interaction.answer(
-            '.*the number uniquely identifying this '
-            'node in the replication cluster: ', '2')
-        interaction.answer(resc('Enter the cluster database name: |vmdb_production| '), '')
-        interaction.answer(resc('Enter the cluster database username: |root| '), '')
-        interaction.answer('Enter the cluster database password: ', pwd)
-        interaction.answer('Enter the cluster database password: ', pwd)
+        answer_cluster_related_questions(interaction, node_uid='2',
+            db_name='', db_username='', db_password=pwd)
         interaction.answer('Enter the primary database hostname or IP address: ', primary_ip)
         interaction.answer(r'Enter the Standby Server hostname or IP address: \|.*\| ',
                            appl.hostname)
@@ -472,13 +470,8 @@ def reconfigure_standby_replication_node(appl, pwd, primary_ip, repmgr_reconfigu
         interaction.answer(resc(
             "Are you sure you don't want to partition the Standby "
             "database disk? (Y/N): "), 'y')
-        interaction.answer(
-            '.*the number uniquely identifying this '
-            'node in the replication cluster: ', '2')
-        interaction.answer(resc('Enter the cluster database name: |vmdb_production| '), '')
-        interaction.answer(resc('Enter the cluster database username: |root| '), '')
-        interaction.answer('Enter the cluster database password: ', pwd)
-        interaction.answer('Enter the cluster database password: ', pwd)
+        answer_cluster_related_questions(interaction, node_uid='2',
+            db_name='', db_username='', db_password=pwd)
         interaction.answer('Enter the primary database hostname or IP address: ', primary_ip)
         interaction.answer(r'Enter the Standby Server hostname or IP address: \|.*\| ', '')
         interaction.answer(resc(

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -509,7 +509,6 @@ def ha_appliances_with_providers(ha_multiple_preupdate_appliances, app_creds):
     return ha_multiple_preupdate_appliances
 
 
-@pytest.fixture
 def replicated_appliances_with_providers(multiple_preupdate_appliances):
     """Returns two database-owning appliances, configures with providers."""
     appl1, appl2 = multiple_preupdate_appliances

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -17,7 +17,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.test_framework.sprout.client import AuthException
 from cfme.test_framework.sprout.client import SproutClient
 from cfme.utils import conf
-from cfme.utils.blockers import BZ
 from cfme.utils.conf import auth_data
 from cfme.utils.conf import cfme_data
 from cfme.utils.conf import credentials
@@ -25,7 +24,6 @@ from cfme.utils.log import logger
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.providers import list_providers_by_class
 from cfme.utils.ssh_expect import SSHExpect
-from cfme.utils.version import get_stream
 from cfme.utils.version import Version
 from cfme.utils.wait import wait_for
 

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -8,6 +8,7 @@ import fauxfactory
 import pytest
 import requests
 from lxml import etree
+from paramiko_expect import SSHClientInteraction
 
 import cfme.utils.auth as authutil
 from cfme.cloud.provider.ec2 import EC2Provider
@@ -266,8 +267,7 @@ def ha_multiple_preupdate_appliances(appliance, old_version):
         yield apps
 
 
-@pytest.fixture
-def ha_appliances_with_providers(ha_multiple_preupdate_appliances, app_creds):
+def configure_appliances_ha(appliances, pwd):
     """Configure HA environment
 
     Appliance one configuring dedicated database, 'ap' launch appliance_console,
@@ -300,10 +300,8 @@ def ha_appliances_with_providers(ha_multiple_preupdate_appliances, app_creds):
     monitor. wait 30 seconds for service to start '' finish.
 
     """
-    apps0, apps1, apps2 = ha_multiple_preupdate_appliances
+    apps0, apps1, apps2 = appliances
     app0_ip = apps0.hostname
-    app1_ip = apps1.hostname
-    pwd = app_creds["password"]
 
     # Configure first appliance as dedicated database
     interaction = SSHExpect(apps0)
@@ -359,13 +357,31 @@ def ha_appliances_with_providers(ha_multiple_preupdate_appliances, app_creds):
     apps2.evmserverd.wait_for_running()
     apps2.wait_for_web_ui()
 
+    configure_primary_replication_node(apps0, pwd)
+    configure_standby_replication_node(apps1, pwd, app0_ip)
+
+    configure_automatic_failover(apps2, primary_ip=None)
+
+    # Add infra/cloud providers and create db backup
+    provider_app_crud(VMwareProvider, apps2).setup()
+    provider_app_crud(EC2Provider, apps2).setup()
+    return appliances
+
+
+def logging_callback(appliance):
+    def the_logger(m):
+        logger.debug('Appliance %s:\n%s', appliance.hostname, m)
+    return the_logger
+
+
+def configure_primary_replication_node(appl, pwd):
     # Configure primary replication node
-    interaction = SSHExpect(apps0)
+    interaction = SSHExpect(appl)
     interaction.send('ap')
     interaction.answer('Press any key to continue.', '', timeout=20)
     # 6/8 for Configure Database Replication
     interaction.answer('Choose the advanced setting: ',
-                       '6' if apps1.version < '5.10' else '8')
+                       '6' if appl.version < '5.10' else '8')
     interaction.answer('Choose the database replication operation: ', '1')
     interaction.answer('Enter the number uniquely identifying '
                        'this node in the replication cluster: ', '1')
@@ -373,30 +389,63 @@ def ha_appliances_with_providers(ha_multiple_preupdate_appliances, app_creds):
     interaction.answer('Enter the cluster database username: |root| ', '')
     interaction.answer('Enter the cluster database password: ', pwd)
     interaction.answer('Enter the cluster database password: ', pwd)
-    interaction.answer('Enter the primary database hostname or IP address: |.*| ', app0_ip)
+    interaction.answer('Enter the primary database hostname or IP address: |.*| ', appl.hostname)
     interaction.answer(r'Apply this Replication Server Configuration\? \(Y/N\): ', 'y')
     interaction.answer('Press any key to continue.', '')
 
-    if BZ(1732092, forced_streams=get_stream(apps1.version)).blocks:
-        assert apps1.ssh_client.run_command('setenforce 0').success
 
+def reconfigure_primary_replication_node(appl, pwd):
+    # Configure primary replication node
+    interaction = SSHClientInteraction(appl.ssh_client, timeout=10, display=True,
+                                       output_callback=logging_callback(appl))
+    interaction.send('ap')
+    interaction.expect('Press any key to continue.', timeout=20)
+    interaction.send('')
+    interaction.expect('Choose the advanced setting: ')
+    # Configure Database Replication
+    interaction.send('6' if appl.version < '5.10' else '8')
+    interaction.expect('Choose the database replication operation: ')
+    interaction.send('1')
+    interaction.expect('Enter the number uniquely identifying '
+                       'this node in the replication cluster: ')
+    interaction.send('1')
+    interaction.expect('Enter the cluster database name: |vmdb_production| ')
+    interaction.send('')
+    interaction.expect('Enter the cluster database username: |root| ')
+    interaction.send('')
+    interaction.expect('Enter the cluster database password: ')
+    interaction.send(pwd)
+    interaction.expect('Enter the cluster database password: ')
+    interaction.send(pwd)
+    interaction.expect('Enter the primary database hostname or IP address: |.*| ')
+    interaction.send(appl.hostname)
+    # Warning: File /etc/repmgr.conf exists. Replication is already configured
+    interaction.expect(r'Continue with configuration\? \(Y/N\): ')
+    interaction.send('y')
+    interaction.expect(r'Apply this Replication Server Configuration\? \(Y/N\): ')
+    interaction.send('y')
+    interaction.expect('Press any key to continue.')
+    interaction.send('')
+
+
+def configure_standby_replication_node(appl, pwd, primary_ip):
     # Configure secondary (standby) replication node
-    interaction = SSHExpect(apps1)
+    interaction = SSHExpect(appl)
     interaction.send('ap')
     interaction.answer('Press any key to continue.', '', timeout=20)
     interaction.answer('Choose the advanced setting: ',
-                       '6' if apps1.version < '5.10' else '8')
+                       '6' if appl.version < '5.10' else '8')
     # 6/8 for Configure Database Replication
     # Configure Server as Standby
     interaction.answer('Choose the database replication operation: ', '2')
     interaction.answer('Choose the encryption key: |1| ', '2')
-    interaction.send(app0_ip)
+    interaction.send(primary_ip)
     interaction.answer('Enter the appliance SSH login: |root| ', '')
     interaction.answer('Enter the appliance SSH password: ', pwd)
     interaction.answer('Enter the path of remote encryption key: |/var/www/miq/vmdb/certs/v2_key|',
                        '')
     interaction.answer('Choose the standby database disk: |1| ',
-                       '1' if apps1.version < '5.10' else '2')
+                       '1' if appl.version < '5.10' else '2')
     # "Enter " ... is on line above.
     interaction.answer('.*the number uniquely identifying this '
                        'node in the replication cluster: ',
@@ -405,29 +454,80 @@ def ha_appliances_with_providers(ha_multiple_preupdate_appliances, app_creds):
     interaction.answer('Enter the cluster database username: |root| ', '')
     interaction.answer('Enter the cluster database password: ', pwd)
     interaction.answer('Enter the cluster database password: ', pwd)
-    interaction.answer('Enter the primary database hostname or IP address: ', app0_ip)
-    interaction.answer('Enter the Standby Server hostname or IP address: |.*|', app1_ip)
+    interaction.answer('Enter the primary database hostname or IP address: ', primary_ip)
+    interaction.answer('Enter the Standby Server hostname or IP address: |.*|', appl.hostname)
     interaction.answer(r'Configure Replication Manager \(repmgrd\) for automatic '
                        r'failover\? \(Y/N\): ', 'y')
     interaction.answer(r'Apply this Replication Server Configuration\? \(Y/N\): ', 'y')
     interaction.answer('Press any key to continue.', '', timeout=5 * 60)
 
+
+def reconfigure_standby_replication_node(appl, pwd, primary_ip, repmgr_reconfigure=False):
+    # Configure secondary (standby) replication node
+    interaction = SSHClientInteraction(appl.ssh_client, timeout=10, display=True,
+                                       output_callback=logging_callback(appl))
+    interaction.send('ap')
+    # When reconfiguring, the ap command may hang for 60s even.
+    interaction.expect('Press any key to continue.', timeout=120)
+    interaction.send('')
+    interaction.expect('Choose the advanced setting: ')
+    # Configure Database Replication
+    interaction.send('6' if appl.version < '5.10' else '8')
+    interaction.expect('Choose the database replication operation: ')
+    interaction.send('2')  # Configure Server as Standby
+    # Would you like to remove the existing database before configuring as a standby server?
+    # WARNING: This is destructive. This will remove all previous data from this server
+    interaction.expect(r'Continue\? \(Y/N\): ')
+    interaction.send('y')
+    interaction.expect('Choose the standby database disk: |1| ')
+    interaction.send('1' if appl.version < '5.10' else '2')  # Don't partition the disk
+    interaction.expect(r"Are you sure you don't want to partition the Standby "
+                       r"database disk\? \(Y/N\): ")
+    interaction.send('y')
+    interaction.expect('.*the number uniquely identifying this '
+                       'node in the replication cluster: ')
+    interaction.send('2')
+    interaction.expect('Enter the cluster database name: |vmdb_production| ')
+    interaction.send('')
+    interaction.expect('Enter the cluster database username: |root| ')
+    interaction.send('')
+    interaction.expect('Enter the cluster database password: ')
+    interaction.send(pwd)
+    interaction.expect('Enter the cluster database password: ')
+    interaction.send(pwd)
+    interaction.expect('Enter the primary database hostname or IP address: ')
+    interaction.send(primary_ip)
+    interaction.expect('Enter the Standby Server hostname or IP address: |.*|')
+    interaction.send('')
+    interaction.expect(r'Configure Replication Manager \(repmgrd\) for automatic '
+                       r'failover\? \(Y/N\): ')
+    interaction.send('y')
+    # Warning: File /etc/repmgr.conf exists. Replication is already configured
+    interaction.expect(r'Continue with configuration\? \(Y/N\): ')
+    interaction.send('y')
+    interaction.expect(r'Apply this Replication Server Configuration\? \(Y/N\): ')
+    interaction.send('y')
+    interaction.expect('Press any key to continue.', timeout=5 * 60)
+
+
+def configure_automatic_failover(appl, primary_ip):
     # Configure automatic failover on EVM appliance
-    interaction = SSHExpect(apps2)
+    interaction = SSHExpect(appl)
     interaction.send('ap')
     interaction.answer('Press any key to continue.', '', timeout=20)
     interaction.expect('Choose the advanced setting: ')
 
-    with waiting_for_ha_monitor_started(apps2, app1_ip, timeout=300):
+    with waiting_for_ha_monitor_started(appl, primary_ip, timeout=300):
         # Configure Application Database Failover Monitor
-        interaction.send('8' if apps2.version < '5.10' else '10')
+        interaction.send('8' if appl.version < '5.10' else '10')
         interaction.answer('Choose the failover monitor configuration: ', '1')
         # Failover Monitor Service configured successfully
         interaction.answer('Press any key to continue.', '')
 
-    # Add infra/cloud providers and create db backup
-    provider_app_crud(VMwareProvider, apps2).setup()
-    provider_app_crud(EC2Provider, apps2).setup()
+
+@pytest.fixture
+def ha_appliances_with_providers(ha_multiple_preupdate_appliances, app_creds):
+    configure_appliances_ha(ha_multiple_preupdate_appliances, app_creds["password"])
     return ha_multiple_preupdate_appliances
 
 

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -114,31 +114,31 @@ def get_ha_appliances_with_providers(unconfigured_appliances, app_creds):
     """Configure HA environment
 
     Appliance one configuring dedicated database, 'ap' launch appliance_console,
-    '' clear info screen, '5' setup db, '1' Creates v2_key, '1' selects internal db,
-    '1' use partition, 'y' create dedicated db, 'pwd' db password, 'pwd' confirm db password + wait
+    '' clear info screen, '7' setup db, '1' Creates v2_key, '1' selects internal db,
+    '2' use partition, 'y' create dedicated db, 'pwd' db password, 'pwd' confirm db password + wait
     360 secs and '' finish.
 
     Appliance two creating region in dedicated database, 'ap' launch appliance_console, '' clear
-    info screen, '5' setup db, '2' fetch v2_key, 'app0_ip' appliance ip address, '' default user,
+    info screen, '7' setup db, '2' fetch v2_key, 'app0_ip' appliance ip address, '' default user,
     'pwd' appliance password, '' default v2_key location, '2' create region in external db, '0' db
     region number, 'y' confirm create region in external db 'app0_ip', '' ip and default port for
     dedicated db, '' use default db name, '' default username, 'pwd' db password, 'pwd' confirm db
     password + wait 360 seconds and '' finish.
 
     Appliance one configuring primary node for replication, 'ap' launch appliance_console, '' clear
-    info screen, '6' configure db replication, '1' configure node as primary, '1' cluster node
+    info screen, '8' configure db replication, '1' configure node as primary, '1' cluster node
     number set to 1, '' default dbname, '' default user, 'pwd' password, 'pwd' confirm password,
     'app0_ip' primary appliance ip, confirm settings and wait 360 seconds to configure, '' finish.
 
 
     Appliance three configuring standby node for replication, 'ap' launch appliance_console, ''
-    clear info screen, '6' configure db replication, '1' configure node as primary, '1' cluster node
+    clear info screen, '8' configure db replication, '1' configure node as primary, '1' cluster node
     number set to 1, '' default dbname, '' default user, 'pwd' password, 'pwd' confirm password,
     'app0_ip' primary appliance ip, confirm settings and wait 360 seconds to configure, '' finish.
 
 
     Appliance two configuring automatic failover of database nodes, 'ap' launch appliance_console,
-    '' clear info screen '9' configure application database failover monitor, '1' start failover
+    '' clear info screen '10' configure application database failover monitor, '1' start failover
     monitor. wait 30 seconds for service to start '' finish.
 
     """
@@ -147,23 +147,26 @@ def get_ha_appliances_with_providers(unconfigured_appliances, app_creds):
     app1_ip = appl2.hostname
     pwd = app_creds['password']
     # Configure first appliance as dedicated database
-    command_set = ('ap', '', '5', '1', '1', '1', 'y', pwd, TimedCommand(pwd, 360), '')
+    command_set = ('ap', '', '7', '1', '2', 'y', pwd, TimedCommand(pwd, 360), '')
     appl1.appliance_console.run_commands(command_set)
     wait_for(lambda: appl1.db.is_dedicated_active)
     # Configure EVM webui appliance with create region in dedicated database
-    command_set = ('ap', '', '5', '2', app0_ip, '', pwd, '', '2', '0', 'y', app0_ip, '', '', '',
+    command_set = ('ap', '', '7', '2', app0_ip, '', pwd, '', '2', '0', 'y', app0_ip, '', '', '',
         pwd, TimedCommand(pwd, 360), '')
     appl3.appliance_console.run_commands(command_set)
     appl3.evmserverd.wait_for_running()
     appl3.wait_for_web_ui()
     # Configure primary replication node
-    command_set = ('ap', '', '6', '1', '1', '', '', pwd, pwd, app0_ip, 'y',
+    command_set = ('ap', '', '8', '1', '1', '', '', pwd, pwd, app0_ip, 'y',
         TimedCommand('y', 60), '')
     appl1.appliance_console.run_commands(command_set)
     # Configure secondary replication node
-    command_set = ('ap', '', '6', '2', '2', app0_ip, '', pwd, '', '1', '2', '', '', pwd, pwd,
+    command_set = ('ap', '', '8', '2', '2', app0_ip, '', pwd, '', '1', '2', '', '', pwd, pwd,
                    app0_ip, app1_ip, 'y', TimedCommand('y', 60), '')
     appl2.appliance_console.run_commands(command_set)
+    # Configure automatic failover on EVM appliance
+    command_set = ('ap', '', '8', TimedCommand('1', 30), '')
+    appl3.appliance_console.run_commands(command_set)
 
     with waiting_for_ha_monitor_started(appl3, app1_ip, timeout=300):
         # Configure automatic failover on EVM appliance

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -1,3 +1,4 @@
+import re
 from collections import namedtuple
 
 import fauxfactory
@@ -211,6 +212,17 @@ def fetch_db_local(appl1, appl2):
     appl2.ssh_client.put_file(dump_filename, "/tmp/evm_db.backup")
 
 
+@pytest.fixture
+def two_appliances_one_with_providers(temp_appliances_preconfig_funcscope):
+    """Requests two configured appliances from sprout."""
+    appl1, appl2 = temp_appliances_preconfig_funcscope
+
+    # Add infra/cloud providers
+    provider_app_crud(VMwareProvider, appl1).setup()
+    provider_app_crud(EC2Provider, appl1).setup()
+    return appl1, appl2
+
+
 def setup_nfs_samba_backup(appl1):
     # Fetch db from first appliance and push it to nfs/samba server
     connect_kwargs = {
@@ -229,7 +241,7 @@ def logging_callback(appliance):
     # TODO (jhenner) Remove me. This is being defined also in some other PR:
     # Fix minor version update tests. #8521
     def the_logger(m):
-        logger.debug('Appliance %s:\n%s', appliance.hostname, m)
+        logger.info('Appliance %s:\n%s', appliance.hostname, m)
     return the_logger
 
 
@@ -516,7 +528,7 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream('upstream')
-def test_appliance_console_restore_db_nfs(request, get_appliances_with_providers):
+def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_providers):
     """ Test single appliance backup and restore through nfs, configures appliance with providers,
         backs up database, restores it to fresh appliance and checks for matching providers.
 
@@ -526,19 +538,56 @@ def test_appliance_console_restore_db_nfs(request, get_appliances_with_providers
         caseimportance: critical
         initialEstimate: 1h
     """
-    appl1, appl2 = get_appliances_with_providers
+    appl1, appl2 = two_appliances_one_with_providers
     host = cfme_data['network_share']['hostname']
     loc = cfme_data['network_share']['nfs_path']
-    nfs_dump = 'nfs://{}{}share.backup'.format(host, loc)
+    nfs_dump_file_name = '/tmp/backup.{}.dump'.format(fauxfactory.gen_alphanumeric())
+    nfs_restore_dir_path = 'nfs://{}{}'.format(host, loc)
+    nfs_restore_file_path = '{}/db_backup/{}'.format(nfs_restore_dir_path, nfs_dump_file_name)
     # Transfer v2_key and db backup from first appliance to second appliance
     fetch_v2key(appl1, appl2)
-    setup_nfs_samba_backup(appl1)
+
+    # setup_nfs_samba_backup(appl1)
+    interaction = SSHClientInteraction(appl1.ssh_client, timeout=10, display=True,
+                                       output_callback=logging_callback(appl1))
+    interaction.send('ap')
+    interaction.expect('Press any key to continue.', timeout=40)
+    interaction.send('')
+    interaction.expect('Choose the advanced setting: ')
+    interaction.send('4')
+    interaction.expect(r'Choose the backup output file destination: \|1\| ')
+    interaction.send('2')
+    interaction.expect(r'Enter the location to save the backup file to: \|.*\| ')
+    interaction.send(nfs_dump_file_name)
+    # Enter the location to save the remote backup file to
+    interaction.expect(re.escape(
+        'Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '))
+    interaction.send(nfs_restore_dir_path)
+    # Running Database backup to nfs://10.8.198.142/srv/export...
+    interaction.expect('Press any key to continue.', timeout=120)
+
     # Restore DB on the second appliance
     appl2.evmserverd.stop()
     appl2.db.drop()
     appl2.db.create()
-    command_set = ('ap', '', '4', '2', nfs_dump, TimedCommand('y', 60), '')
-    appl2.appliance_console.run_commands(command_set)
+
+    interaction = SSHClientInteraction(appl2.ssh_client, timeout=10, display=True,
+                                       output_callback=logging_callback(appl2))
+    interaction.send('ap')
+    interaction.expect('Press any key to continue.', timeout=40)
+    interaction.send('')
+    interaction.expect('Choose the advanced setting: ')
+    interaction.send('6')
+    interaction.expect(r'Choose the restore database file source: \|1\| ')
+    interaction.send('2')
+    # Enter the location of the remote backup file
+    interaction.expect(re.escape(
+        'Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '))
+    interaction.send(nfs_restore_file_path)
+    interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
+    interaction.send('y')
+    interaction.expect('Press any key to continue.', timeout=40)
+
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
     # Assert providers on the second appliance
@@ -553,7 +602,7 @@ def test_appliance_console_restore_db_nfs(request, get_appliances_with_providers
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream('upstream')
-def test_appliance_console_restore_db_samba(request, get_appliances_with_providers):
+def test_appliance_console_restore_db_samba(request, two_appliances_one_with_providers):
     """ Test single appliance backup and restore through smb, configures appliance with providers,
         backs up database, restores it to fresh appliance and checks for matching providers.
 
@@ -563,21 +612,69 @@ def test_appliance_console_restore_db_samba(request, get_appliances_with_provide
         caseimportance: critical
         initialEstimate: 1h
     """
-    appl1, appl2 = get_appliances_with_providers
+    appl1, appl2 = two_appliances_one_with_providers
     host = cfme_data['network_share']['hostname']
     loc = cfme_data['network_share']['smb_path']
-    smb_dump = 'smb://{}{}share.backup'.format(host, loc)
-    pwd = credentials['depot_credentials']['password']
-    usr = credentials['depot_credentials']['username']
+    smb_dump_file_name = '/tmp/backup.{}.dump'.format(fauxfactory.gen_alphanumeric())
+    smb_restore_dir_path = 'smb://{}{}'.format(host, loc)
+    smb_restore_file_path = '{}/db_backup/{}'.format(smb_restore_dir_path, smb_dump_file_name)
+
+    pwd = credentials['depot_smb_credentials']['password']
+    usr = credentials['depot_smb_credentials']['username']
     # Transfer v2_key and db backup from first appliance to second appliance
     fetch_v2key(appl1, appl2)
-    setup_nfs_samba_backup(appl1)
+
+    # setup_nfs_samba_backup(appl1)
+    interaction = SSHClientInteraction(appl1.ssh_client, timeout=10, display=True,
+                                       output_callback=logging_callback(appl1))
+    interaction.send('ap')
+    interaction.expect('Press any key to continue.', timeout=40)
+    interaction.send('')
+    interaction.expect('Choose the advanced setting: ')
+    interaction.send('4')
+    interaction.expect(r'Choose the backup output file destination: \|1\| ')
+    interaction.send('3')
+    interaction.expect(r'Enter the location to save the backup file to: \|.*\| ')
+    interaction.send(smb_dump_file_name)
+    # Enter the location to save the remote backup file to
+    interaction.expect(re.escape(
+        'Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '))
+    interaction.send(smb_restore_dir_path)
+    # Enter the username with access to this file.
+    interaction.expect(re.escape("Example: 'mydomain.com/user': "))
+    interaction.send(usr)
+    interaction.expect(re.escape('Enter the password for {}: '.format(usr)))
+    interaction.send(pwd)
+    # Running Database backup to nfs://10.8.198.142/srv/export...
+    interaction.expect('Press any key to continue.', timeout=120)
+
     # Restore DB on the second appliance
     appl2.evmserverd.stop()
     appl2.db.drop()
     appl2.db.create()
-    command_set = ('ap', '', '4', '3', smb_dump, usr, pwd, TimedCommand('y', 60), '')
-    appl2.appliance_console.run_commands(command_set)
+
+    interaction = SSHClientInteraction(appl2.ssh_client, timeout=10, display=True,
+                                       output_callback=logging_callback(appl2))
+    interaction.send('ap')
+    interaction.expect('Press any key to continue.', timeout=40)
+    interaction.send('')
+    interaction.expect('Choose the advanced setting: ')
+    interaction.send('6')
+    interaction.expect(r'Choose the restore database file source: \|1\| ')
+    interaction.send('3')
+    # Enter the location of the remote backup file
+    interaction.expect(re.escape(
+        'Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '))
+    interaction.send(smb_restore_file_path)
+    # Enter the username with access to this file.
+    interaction.expect(re.escape("Example: 'mydomain.com/user': "))
+    interaction.send(usr)
+    interaction.expect(re.escape('Enter the password for {}: '.format(usr)))
+    interaction.send(pwd)
+    interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
+    interaction.send('y')
+    interaction.expect('Press any key to continue.', timeout=40)
+
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
     # Assert providers on the second appliance

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -5,6 +5,7 @@ import pytest
 from wait_for import wait_for
 
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.fixtures.cli import replicated_appliances_with_providers
 from cfme.fixtures.cli import waiting_for_ha_monitor_started
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -72,19 +73,7 @@ def get_replicated_appliances_with_providers(temp_appliances_unconfig_funcscope_
     prior to running tests.
 
     """
-    appl1, appl2 = temp_appliances_unconfig_funcscope_rhevm
-    # configure appliances
-    appl1.configure(region=0)
-    appl1.wait_for_web_ui()
-    appl2.configure(region=99)
-    appl2.wait_for_web_ui()
-    # configure replication between appliances
-    appl1.set_pglogical_replication(replication_type=':remote')
-    appl2.set_pglogical_replication(replication_type=':global')
-    appl2.add_pglogical_replication_subscription(appl1.hostname)
-    # Add infra/cloud providers and create db backups
-    provider_app_crud(VMwareProvider, appl1).setup()
-    provider_app_crud(EC2Provider, appl1).setup()
+    appl1, appl2 = replicated_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm)
     appl1.ssh_client.run_command("pg_basebackup -x -Ft -z -D /tmp/backup")
     appl1.db.backup()
     appl2.ssh_client.run_command("pg_basebackup -x -Ft -z -D /tmp/backup")

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -165,7 +165,7 @@ def get_ha_appliances_with_providers(unconfigured_appliances, app_creds):
                    app0_ip, app1_ip, 'y', TimedCommand('y', 60), '')
     appl2.appliance_console.run_commands(command_set)
     # Configure automatic failover on EVM appliance
-    command_set = ('ap', '', '8', TimedCommand('1', 30), '')
+    command_set = ('ap', '', '10', TimedCommand('1', 30), '')
     appl3.appliance_console.run_commands(command_set)
 
     with waiting_for_ha_monitor_started(appl3, app1_ip, timeout=300):
@@ -232,9 +232,9 @@ def restore_db(appl, location=''):
     interaction.send('1')
     interaction.expect('Enter the location of the local restore file: |/tmp/evm_db.backup| ')
     interaction.send(location)
-    interaction.expect('Should this file be deleted after completing the restore\? \(Y\/N\): ')
+    interaction.expect(r'Should this file be deleted after completing the restore\? \(Y\/N\): ')
     interaction.send('N')
-    interaction.expect('Are you sure you would like to restore the database\? \(Y\/N\): ')
+    interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
     interaction.send('Y')
     interaction.expect('Press any key to continue.', timeout=60)
 

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -81,7 +81,7 @@ def get_appliance_with_ansible(temp_appliance_preconfig_funcscope):
     appl1 = temp_appliance_preconfig_funcscope
     # enable embedded ansible and create pg_basebackup
     appl1.enable_embedded_ansible_role()
-    assert appl1.is_embedded_ansible_running
+    appl1.wait_for_embedded_ansible()
     appl1.ssh_client.run_command("pg_basebackup -x -Ft -z -D /tmp/backup")
     return temp_appliance_preconfig_funcscope
 

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -5,6 +5,7 @@ import pytest
 from wait_for import wait_for
 
 from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.fixtures.cli import provider_app_crud
 from cfme.fixtures.cli import replicated_appliances_with_providers
 from cfme.fixtures.cli import waiting_for_ha_monitor_started
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
@@ -20,16 +21,6 @@ from cfme.utils.ssh import SSHClient
 TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
 
 evm_log = '/var/www/miq/vmdb/log/evm.log'
-
-
-def provider_app_crud(provider_class, appliance):
-    try:
-        prov = list_providers_by_class(provider_class)[0]
-        logger.info('using provider {}'.format(prov.name))
-        prov.appliance = appliance
-        return prov
-    except IndexError:
-        pytest.skip("No {} providers available (required)".format(provider_class.type))
 
 
 def provision_vm(request, provider):

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 import fauxfactory
 import pytest
-from paramiko_expect import SSHClientInteraction
 from wait_for import wait_for
 
 from cfme.cloud.provider.ec2 import EC2Provider
@@ -22,6 +21,7 @@ from cfme.utils.conf import credentials
 from cfme.utils.log import logger
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.ssh import SSHClient
+from cfme.utils.ssh_expect import SSHExpect
 
 TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])
 
@@ -237,17 +237,8 @@ def setup_nfs_samba_backup(appl1):
     nfs_smb.put_file(dump_filename, "{}share.backup".format(loc))
 
 
-def logging_callback(appliance):
-    # TODO (jhenner) Remove me. This is being defined also in some other PR:
-    # Fix minor version update tests. #8521
-    def the_logger(m):
-        logger.info('Appliance %s:\n%s', appliance.hostname, m)
-    return the_logger
-
-
 def restore_db(appl, location=''):
-    interaction = SSHClientInteraction(appl.ssh_client, timeout=10, display=True,
-                                       output_callback=logging_callback(appl))
+    interaction = SSHExpect(appl)
     interaction.send('ap')
     interaction.expect('Press any key to continue.', timeout=40)
     interaction.send('')
@@ -314,8 +305,7 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
     appl1, appl2 = two_appliances_one_with_providers
     backup_file_name = '/tmp/backup.{}.dump'.format(fauxfactory.gen_alphanumeric())
 
-    interaction = SSHClientInteraction(appl1.ssh_client, timeout=10, display=True,
-                                       output_callback=logging_callback(appl1))
+    interaction = SSHExpect(appl1)
     interaction.send('ap')
     interaction.expect('Press any key to continue.', timeout=40)
     interaction.send('')
@@ -337,8 +327,7 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
     appl2.db.drop()
     appl2.db.create()
 
-    interaction = SSHClientInteraction(appl2.ssh_client, timeout=10, display=True,
-                                       output_callback=logging_callback(appl2))
+    interaction = SSHExpect(appl2)
     interaction.send('ap')
     interaction.expect('Press any key to continue.', timeout=40)
     interaction.send('')
@@ -620,8 +609,7 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
     fetch_v2key(appl1, appl2)
 
     # setup_nfs_samba_backup(appl1)
-    interaction = SSHClientInteraction(appl1.ssh_client, timeout=10, display=True,
-                                       output_callback=logging_callback(appl1))
+    interaction = SSHExpect(appl1)
     interaction.send('ap')
     interaction.expect('Press any key to continue.', timeout=40)
     interaction.send('')
@@ -643,8 +631,7 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
     appl2.db.drop()
     appl2.db.create()
 
-    interaction = SSHClientInteraction(appl2.ssh_client, timeout=10, display=True,
-                                       output_callback=logging_callback(appl2))
+    interaction = SSHExpect(appl2)
     interaction.send('ap')
     interaction.expect('Press any key to continue.', timeout=40)
     interaction.send('')
@@ -697,8 +684,7 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
     fetch_v2key(appl1, appl2)
 
     # setup_nfs_samba_backup(appl1)
-    interaction = SSHClientInteraction(appl1.ssh_client, timeout=10, display=True,
-                                       output_callback=logging_callback(appl1))
+    interaction = SSHExpect(appl1)
     interaction.send('ap')
     interaction.expect('Press any key to continue.', timeout=40)
     interaction.send('')
@@ -725,8 +711,7 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
     appl2.db.drop()
     appl2.db.create()
 
-    interaction = SSHClientInteraction(appl2.ssh_client, timeout=10, display=True,
-                                       output_callback=logging_callback(appl2))
+    interaction = SSHExpect(appl2)
     interaction.send('ap')
     interaction.expect('Press any key to continue.', timeout=40)
     interaction.send('')

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -386,7 +386,7 @@ def test_appliance_console_restore_db_replicated(
     providers_before_restore = set(appl1.managed_provider_names)
     # Restore DB on the second appliance
     appl2.evmserverd.stop()
-    command_set = ('ap', '', '4', '1', '', TimedCommand('y', 60), '')
+    command_set = ('ap', '', '6', '1', '/tmp/backup/base.tar.gz', TimedCommand('y', 60), '')
     appl2.appliance_console.run_commands(command_set)
     # Restore db on first appliance
     appl1.set_pglogical_replication(replication_type=':none')

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -237,7 +237,7 @@ def restore_db(appl, location=''):
     interaction = SSHClientInteraction(appl.ssh_client, timeout=10, display=True,
                                        output_callback=logging_callback(appl))
     interaction.send('ap')
-    interaction.expect('Press any key to continue.', timeout=20)
+    interaction.expect('Press any key to continue.', timeout=40)
     interaction.send('')
     interaction.expect('Choose the advanced setting: ')
     interaction.send('6')

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 import fauxfactory
 import pytest
+from paramiko_expect import SSHClientInteraction
 from wait_for import wait_for
 
 from cfme.cloud.provider.ec2 import EC2Provider
@@ -208,6 +209,33 @@ def setup_nfs_samba_backup(appl1):
     nfs_smb.put_file(dump_filename, "{}share.backup".format(loc))
 
 
+def logging_callback(appliance):
+    # TODO (jhenner) Remove me. This is being defined also in some other PR:
+    # Fix minor version update tests. #8521
+    def the_logger(m):
+        logger.debug('Appliance %s:\n%s', appliance.hostname, m)
+    return the_logger
+
+
+def restore_db(appl, location=''):
+    interaction = SSHClientInteraction(appl.ssh_client, timeout=10, display=True,
+                                       output_callback=logging_callback(appl))
+    interaction.send('ap')
+    interaction.expect('Press any key to continue.', timeout=20)
+    interaction.send('')
+    interaction.expect('Choose the advanced setting: ')
+    interaction.send('6')
+    interaction.expect('Choose the restore database file source: |1| ')
+    interaction.send('1')
+    interaction.expect('Enter the location of the local restore file: |/tmp/evm_db.backup| ')
+    interaction.send(location)
+    interaction.expect('Should this file be deleted after completing the restore\? \(Y\/N\): ')
+    interaction.send('N')
+    interaction.expect('Are you sure you would like to restore the database\? \(Y\/N\): ')
+    interaction.send('Y')
+    interaction.expect('Press any key to continue.', timeout=60)
+
+
 @pytest.mark.rhel_testing
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream('upstream')
@@ -229,8 +257,7 @@ def test_appliance_console_restore_db_local(request, get_appliances_with_provide
     appl2.evmserverd.stop()
     appl2.db.drop()
     appl2.db.create()
-    command_set = ('ap', '', '4', '1', '', TimedCommand('y', 60), '')
-    appl2.appliance_console.run_commands(command_set)
+    restore_db(appl2)
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
     # Assert providers on the second appliance
@@ -257,8 +284,7 @@ def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansi
     # Restore DB on the second appliance
     appl1.evmserverd.stop()
     appl1.db_service.restart()
-    command_set = ('ap', '', '4', '1', '/tmp/backup/base.tar.gz', TimedCommand('y', 60), '')
-    appl1.appliance_console.run_commands(command_set)
+    restore_db(appl1, '/tmp/backup/base.tar.gz')
     manager.quit()
     appl1.evmserverd.start()
     appl1.wait_for_web_ui()
@@ -306,9 +332,8 @@ def test_appliance_console_restore_pg_basebackup_replicated(
     appl2.evmserverd.stop()
     appl1.db_service.restart()
     appl2.db_service.restart()
-    command_set = ('ap', '', '4', '1', '/tmp/backup/base.tar.gz', TimedCommand('y', 60), '')
-    appl1.appliance_console.run_commands(command_set)
-    appl2.appliance_console.run_commands(command_set)
+    restore_db(appl1, '/tmp/backup/base.tar.gz')
+    restore_db(appl2, '/tmp/backup/base.tar.gz')
     appl1.evmserverd.start()
     appl2.evmserverd.start()
     appl1.wait_for_web_ui()
@@ -349,8 +374,7 @@ def test_appliance_console_restore_db_external(request, get_ext_appliances_with_
     appl1.db_service.restart()
     appl1.db.drop()
     appl1.db.create()
-    command_set = ('ap', '', '4', '1', '', TimedCommand('y', 60), '')
-    appl1.appliance_console.run_commands(command_set)
+    restore_db(appl1)
     appl1.evmserverd.start()
     appl1.wait_for_web_ui()
     appl2.evmserverd.start()
@@ -386,14 +410,14 @@ def test_appliance_console_restore_db_replicated(
     providers_before_restore = set(appl1.managed_provider_names)
     # Restore DB on the second appliance
     appl2.evmserverd.stop()
-    command_set = ('ap', '', '6', '1', '/tmp/backup/base.tar.gz', TimedCommand('y', 60), '')
-    appl2.appliance_console.run_commands(command_set)
+
+    restore_db(appl2)
     # Restore db on first appliance
     appl1.set_pglogical_replication(replication_type=':none')
     appl1.evmserverd.stop()
     appl1.db.drop()
     appl1.db.create()
-    appl1.appliance_console.run_commands(command_set)
+    restore_db(appl1)
     appl1.evmserverd.start()
     appl2.evmserverd.start()
     appl1.wait_for_web_ui()
@@ -439,8 +463,7 @@ def test_appliance_console_restore_db_ha(request, get_ha_appliances_with_provide
     appl1.db.drop()
     appl1.db.create()
     fetch_v2key(appl3, appl1)
-    command_set = ('ap', '', '4', '1', '', TimedCommand('y', 60), '')
-    appl1.appliance_console.run_commands(command_set)
+    restore_db(appl1)
     appl1.ssh_client.run_command("systemctl start rh-postgresql95-repmgr")
     appl2.ssh_client.run_command("systemctl start rh-postgresql95-repmgr")
     appl3.evmserverd.start()

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -16,7 +16,6 @@ from cfme.utils.conf import cfme_data
 from cfme.utils.conf import credentials
 from cfme.utils.log import logger
 from cfme.utils.log_validator import LogValidator
-from cfme.utils.providers import list_providers_by_class
 from cfme.utils.ssh import SSHClient
 
 TimedCommand = namedtuple('TimedCommand', ['command', 'timeout'])

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -258,7 +258,7 @@ def test_update_distributed_webui(ext_appliances_with_providers, appliance,
 
 
 @pytest.mark.ignore_stream("upstream")
-def test_update_replicated_webui(replicated_appliances_with_providers, appliance, request,
+def test_update_replicated_webui(get_replicated_appliances_with_providers, appliance, request,
                                  old_version, soft_assert):
     """ Tests updating an appliance with providers, also confirms that the
             provisioning continues to function correctly after the update has completed
@@ -269,6 +269,7 @@ def test_update_replicated_webui(replicated_appliances_with_providers, appliance
         casecomponent: Appliance
         initialEstimate: 1/4h
     """
+    replicated_appliances_with_providers = get_replicated_appliances_with_providers
     providers_before_upgrade = set(replicated_appliances_with_providers[0].managed_provider_names)
     update_appliance(replicated_appliances_with_providers[0])
     update_appliance(replicated_appliances_with_providers[1])

--- a/cfme/tests/test_db_migrate_manual.py
+++ b/cfme/tests/test_db_migrate_manual.py
@@ -388,8 +388,8 @@ def test_upgrade_multi_replication_inplace():
         caseimportance: medium
         initialEstimate: 1h
         setup: 2 appliances:
-               - Appliance A: internal DB, region 0
-               - Appliance B: external DB, pointed at A, region 0
+               - Appliance A: Replication Global, region 0
+               - Appliance B: Replication Local, region 1
                - Setup LDAP on one of the appliances
                - Login as LDAP user A
                - Setup a provider

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2068,7 +2068,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             self.server_roles = roles
         except TimedOutError:
             wait_for(lambda: self.server_roles == roles, num_sec=600, delay=15)
-        self.wait_for_embedded_ansible(2400)
+        self.wait_for_embedded_ansible()
 
     def disable_embedded_ansible_role(self):
         """disables embbeded ansible role"""

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -316,6 +316,7 @@ class IPAppliance(object):
     merkyl = SystemdService.declare(unit_name='merkyl')
     nginx = SystemdService.declare(unit_name='nginx')
     rabbitmq_server = SystemdService.declare(unit_name='rabbitmq-server')
+    rh_postgresql95_repmgr = SystemdService.declare(unit_name='rh-postgresql95-repmgr')
     sssd = SystemdService.declare(unit_name='sssd')
     sshd = SystemdService.declare(unit_name='sshd')
     supervisord = SystemdService.declare(unit_name='supervisord')

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2068,7 +2068,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             self.server_roles = roles
         except TimedOutError:
             wait_for(lambda: self.server_roles == roles, num_sec=600, delay=15)
-        self.wait_for_embedded_ansible()
+        self.wait_for_embedded_ansible(2400)
 
     def disable_embedded_ansible_role(self):
         """disables embbeded ansible role"""

--- a/cfme/utils/ssh_expect.py
+++ b/cfme/utils/ssh_expect.py
@@ -1,11 +1,15 @@
+import socket
+import textwrap
+
 from paramiko_expect import SSHClientInteraction
 
+from cfme.exceptions import SSHExpectTimeoutError
 from cfme.utils.log import logger
 
 
 def logging_callback(appliance):
     def the_logger(m):
-        logger.debug('Appliance %s:\n%s', appliance.hostname, m)
+        logger.info('Appliance %s:\n%s', appliance.hostname, m)
     return the_logger
 
 
@@ -18,3 +22,12 @@ class SSHExpect(SSHClientInteraction):
     def answer(self, question, answer, timeout=None):
         self.expect(question, timeout=timeout)
         self.send(answer)
+
+    def expect(self, re_string, *args, **kwargs):
+        try:
+            SSHClientInteraction.expect(self, re_string, *args, **kwargs)
+        except socket.timeout:
+            current_output = '""' if not self.current_output else self.current_output
+            raise SSHExpectTimeoutError(
+                f"Timeouted when waiting for '{re_string}'. Current output:\n"
+                + textwrap.indent(current_output, '> '))


### PR DESCRIPTION
This is the first part of my big PR#8655. I was asked to split it. This is not an easy task to do but I did my best. This PR brings:

* Fixing menu option numbers
* some cleanups
* starting using SSHExpect
* increasing some timeouts
* adding some waits

This PR makes these restore tests passed:
test_appliance_console_restore_db_external result
test_appliance_console_restore_pg_basebackup_ansible
test_appliance_console_backup_restore_db_local result
test_appliance_console_dump_restore_db_local
which is an improvement from the state of origin/master. 

Locally I tested also:
cfme/tests/cli/test_appliance_update.py::test_update_distributed_webui
with pass

The further patches will make the other tests (`cfme/tests/cli/test_appliance_console_db_restore.py` and `cfme/tests/configure/test_proxy.py` tests passed). Locally they pass fine so I think I can say that.

{{ py.test: -v cfme/tests/cli/test_appliance_console_db_restore.py cfme/tests/cli/test_appliance_update.py::test_update_ha }}