### PR TITLE
[RFR] Removing rhel_testing marker from test_appliance_update.py

### DIFF
--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -119,7 +119,6 @@ def do_yum_update(appliance):
     appliance.wait_for_web_ui()
 
 
-@pytest.mark.rhel_testing
 def test_update_yum(appliance_preupdate, appliance):
     """Tests appliance update between versions
 


### PR DESCRIPTION
Uses `appliance_preupdate` fixture, pointless for testing new rhel packages. 