### PR TITLE
[1LP][RFR] New Test: Checking dialog export flash message on while editing dialog

### DIFF
--- a/cfme/automate/dialog_import_export.py
+++ b/cfme/automate/dialog_import_export.py
@@ -19,6 +19,7 @@ class DialogImportExportView(BaseLoggedInPage):
     title = Text("#explorer_title_text")
     upload_file = FileInput(id="upload_file")
     upload = Button(id="upload_service_dialog_import")
+    export = Text('//button[text()="Export" and @name="button"]')
 
     def in_import_export(self):
         return (

--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -381,7 +381,7 @@ def test_service_retire_automate():
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(automates=[1740796])
+@pytest.mark.meta(automates=[1740796], blockers=[BZ(1740796, forced_streams=["5.10"])])
 def test_import_dialog_file_without_selecting_file(appliance, dialog):
     """
     Bugzilla:
@@ -404,5 +404,4 @@ def test_import_dialog_file_without_selecting_file(appliance, dialog):
     view = navigate_to(import_export, "DialogImportExport")
     view.export.click()
     view.flash.assert_message("At least 1 item must be selected for export")
-    if not BZ(1740796, forced_streams=['5.10']).blocks:
-        dialog.update({'label': fauxfactory.gen_alphanumeric()})
+    dialog.update({'label': fauxfactory.gen_alphanumeric()})

--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -404,6 +404,5 @@ def test_import_dialog_file_without_selecting_file(appliance, dialog):
     view = navigate_to(import_export, "DialogImportExport")
     view.export.click()
     view.flash.assert_message("At least 1 item must be selected for export")
-    if BZ(1740796).blocks:
-        with pytest.raises(AssertionError, match="At least 1 item must be selected for export"):
-            dialog.update({'label': fauxfactory.gen_alphanumeric()})
+    if not BZ(1740796, forced_streams=['5.10']).blocks:
+        dialog.update({'label': fauxfactory.gen_alphanumeric()})

--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -5,10 +5,13 @@ import fauxfactory
 import pytest
 
 from cfme import test_requirements
+from cfme.automate.dialog_import_export import DialogImportExport
 from cfme.base.credential import Credential
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.provisioning import do_vm_provisioning
 from cfme.services.service_catalogs import ServiceCatalogs
+from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log_validator import LogValidator
 
@@ -378,8 +381,8 @@ def test_service_retire_automate():
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1740796])
-def test_import_dialog_file_without_selecting_file():
+@pytest.mark.meta(automates=[1740796])
+def test_import_dialog_file_without_selecting_file(appliance, dialog):
     """
     Bugzilla:
         1740796
@@ -397,4 +400,10 @@ def test_import_dialog_file_without_selecting_file():
             1. Flash message: "At least 1 item must be selected for export"
             2. Error flash message should not appear
     """
-    pass
+    import_export = DialogImportExport(appliance)
+    view = navigate_to(import_export, "DialogImportExport")
+    view.export.click()
+    view.flash.assert_message("At least 1 item must be selected for export")
+    if BZ(1740796).blocks:
+        with pytest.raises(AssertionError, match="At least 1 item must be selected for export"):
+            dialog.update({'label': fauxfactory.gen_alphanumeric()})


### PR DESCRIPTION
## Purpose or Intent
- Checking flash message on wrong page
### PRT Run
{{ pytest: cfme/tests/automate/test_service_automate.py -k 'test_import_dialog_file_without_selecting_file' --use-template-cache -qsvvv}}