### PR TITLE
[1LP][WIPTEST] Allow dummy appliances to be used with the parallelizer

### DIFF
--- a/cfme/fixtures/parallelizer/remote.py
+++ b/cfme/fixtures/parallelizer/remote.py
@@ -227,16 +227,21 @@ if __name__ == '__main__':
 
     # TODO: clean the logic up here
 
-    from cfme.utils.appliance import IPAppliance, stack
+    from cfme.utils.appliance import IPAppliance, stack, DummyAppliance
 
     # overwrite the default logger before anything else is imported,
     # to get our best chance at having everything import the replaced logger
     import cfme.utils.log
     cfme.utils.log.setup_for_worker(args.worker)
     slave_log = cfme.utils.log.logger
+    is_dummy = json.loads(args.appliance).get("is_dummy")
 
     try:
-        appliance = IPAppliance.from_json(args.appliance)
+        if is_dummy:
+            slave_log.info("Loading dummy appliance...")
+            appliance = DummyAppliance.from_json(args.appliance)
+        else:
+            appliance = IPAppliance.from_json(args.appliance)
     except ValueError:
         slave_log.error("Error parsing appliance json")
         raise

--- a/cfme/test_framework/appliance.py
+++ b/cfme/test_framework/appliance.py
@@ -18,6 +18,7 @@ def pytest_addoption(parser):
     parser.addoption('--dummy-appliance', action='store_true')
     parser.addoption('--dummy-appliance-version', default=None)
     parser.addoption('--appliance-version', default=None)
+    parser.addoption('--num-dummies', default=1, type=int)
 
 
 def appliances_from_cli(cli_appliances, appliance_version):
@@ -49,7 +50,9 @@ def pytest_configure(config):
         return
     reporter = terminalreporter.reporter()
     if config.getoption('--dummy-appliance'):
-        appliances = [DummyAppliance.from_config(config)]
+        appliances = [
+            DummyAppliance.from_config(config) for _ in range(config.getoption('--num-dummies'))
+        ]
         reporter.write_line('Retrieved Dummy Appliance', red=True)
     elif stack.top:
         appliances = [stack.top]

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -3179,6 +3179,8 @@ class DummyAppliance(object):
     build = 'dummyappliance'
     managed_known_providers = []
     collections = attr.ib(default=attr.Factory(collections_for_appliance, takes_self=True))
+    url = 'http://dummies.r.us'
+    is_dummy = attr.ib(default=True)
 
     @property
     def is_downstream(self):
@@ -3188,6 +3190,23 @@ class DummyAppliance(object):
     def from_config(cls, pytest_config):
         version = pytest_config.getoption('--dummy-appliance-version')
         return cls(version=(version or attr.NOTHING))
+
+    @classmethod
+    def from_json(cls, json_string):
+        return cls(**json.loads(json_string))
+
+    @property
+    def as_json(self):
+        """Dumps the arguments that can create this appliance as a JSON. None values are ignored."""
+        def _version_tostr(x):
+            if isinstance(x, Version):
+                return str(x)
+            else:
+                return x
+
+        return json.dumps({
+            k: _version_tostr(getattr(self, k))
+            for k in self.__dict__ if k != "collections"})
 
     def set_session_timeout(self, *k):
         pass


### PR DESCRIPTION
This helps to see what slaves get which tests during a parallelized run. To use it you can do 

```pytest --collect-only --dummy-appliance --num-dummies N cfme/tests```

{{ pytest: --collect-only --dummy-appliance --num-dummies 4 cfme/tests/ }}