### PR TITLE
[WIP] Fix uncollectif

### DIFF
--- a/cfme/markers/uncollect.py
+++ b/cfme/markers/uncollect.py
@@ -53,11 +53,7 @@ Note:
 """
 import inspect
 
-import pytest
-
 from cfme.utils.log import logger
-
-MARKDECORATOR_TYPE = type(pytest.mark.skip)
 
 
 def pytest_configure(config):
@@ -69,14 +65,6 @@ def pytest_configure(config):
         'markers',
         'uncollect: Uncollect a test with a direct call'
     )
-
-
-# work around https://github.com/pytest-dev/pytest/issues/2400
-def get_uncollect_function(marker_or_markdecorator):
-    if isinstance(marker_or_markdecorator, MARKDECORATOR_TYPE):
-        return marker_or_markdecorator.args[0]
-    else:
-        return list(marker_or_markdecorator)[0].args[0]
 
 
 def uncollectif(item):
@@ -93,8 +81,9 @@ def uncollectif(item):
             item.name,
             mark.kwargs.get('reason', 'No reason given'))
         logger.debug(log_msg)
+
         try:
-            arg_names = inspect.getargspec(get_uncollect_function(mark)).args
+            arg_names = inspect.getfullargspec(mark.args[0]).args
         except TypeError:
             logger.debug(log_msg)
             return not bool(mark.args[0]), mark.kwargs.get('reason', 'No reason given')


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- remove workaround completely
- moved `getargspec` to `getfullargspec` as its deprecated
Note: This is what solution i found for now.  @mshriver will add commit for better solution. 
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/automate/custom_button/test_buttons.py::test_button_group_crud[Load_balancer] -vv}}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
