### PR TITLE
[1LP][RFR] Require uncollect reason

### DIFF
--- a/cfme/markers/stream_excluder.py
+++ b/cfme/markers/stream_excluder.py
@@ -64,7 +64,9 @@ def pytest_itemcollected(item):
                     else:
                         add_mark = False
             if add_mark:
-                item.add_marker(pytest.mark.uncollect)
+                item.add_marker(pytest.mark.uncollect(
+                    reason='Appliance stream excluded via ignore_stream')
+                )
 
 
 def pytest_sessionstart(session):

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -393,9 +393,9 @@ def test_service_ansible_retirement_remove_resources(
 
 
 @pytest.mark.tier(3)
-@pytest.mark.uncollectif(
-    lambda host_type, action: host_type == "blank" and action == "retirement"
-)
+@pytest.mark.uncollectif(lambda host_type, action:
+                         host_type == "blank" and action == "retirement",
+                         reason='Blank host type not valid for retirement action')
 @pytest.mark.parametrize(
     "host_type,order_value,result",
     SERVICE_CATALOG_VALUES,
@@ -639,21 +639,17 @@ def test_ansible_group_id_in_payload(
     assert "group" in result_dict["manageiq"]
 
 
-@pytest.mark.parametrize(
-    "credential", CREDENTIALS, ids=[cred[0] for cred in CREDENTIALS]
-)
-@pytest.mark.provider(
-    [RHEVMProvider, EC2Provider, VMwareProvider, AzureProvider], selector=ONE_PER_TYPE
-)
+@pytest.mark.parametrize("credential", CREDENTIALS, ids=[cred[0] for cred in CREDENTIALS])
+@pytest.mark.provider([RHEVMProvider, EC2Provider, VMwareProvider, AzureProvider],
+                      selector=ONE_PER_TYPE)
 @pytest.mark.uncollectif(
     lambda credential, provider: not (
         (credential[0] == "Amazon" and provider.one_of(EC2Provider))
         or (credential[0] == "VMware" and provider.one_of(VMwareProvider))
-        or (
-            credential[0] == "Red Hat Virtualization" and provider.one_of(RHEVMProvider)
-        )
+        or (credential[0] == "Red Hat Virtualization" and provider.one_of(RHEVMProvider))
         or (credential[0] == "Azure" and provider.one_of(AzureProvider))
-    )
+    ),
+    reason='Credential type not valid for parametrized provider'
 )
 def test_embed_tower_exec_play_against(
     appliance,
@@ -916,21 +912,17 @@ ansible_service_catalog, ansible_service_funcscope, ansible_service_request_func
 
 
 @pytest.mark.meta(automates=[1444092, 1515561])
-@pytest.mark.parametrize(
-    "credential", CREDENTIALS, ids=[cred[0] for cred in CREDENTIALS]
-)
-@pytest.mark.provider(
-    [RHEVMProvider, EC2Provider, VMwareProvider, AzureProvider], selector=ONE_PER_TYPE
-)
+@pytest.mark.parametrize("credential", CREDENTIALS, ids=[cred[0] for cred in CREDENTIALS])
+@pytest.mark.provider([RHEVMProvider, EC2Provider, VMwareProvider, AzureProvider],
+                      selector=ONE_PER_TYPE)
 @pytest.mark.uncollectif(
     lambda credential, provider: not (
         (credential[0] == "Amazon" and provider.one_of(EC2Provider))
         or (credential[0] == "VMware" and provider.one_of(VMwareProvider))
-        or (
-            credential[0] == "Red Hat Virtualization" and provider.one_of(RHEVMProvider)
-        )
+        or (credential[0] == "Red Hat Virtualization" and provider.one_of(RHEVMProvider))
         or (credential[0] == "Azure" and provider.one_of(AzureProvider))
-    )
+    ),
+    reason='Credential type not valid for parametrized provider'
 )
 @pytest.mark.tier(3)
 def test_ansible_service_cloud_credentials(appliance, request, ansible_catalog_item,

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -41,10 +41,9 @@ def button_group(appliance, obj_type):
 # IMPORTANT: This is a canonical test. It shows how a proper test should look like under new order.
 @pytest.mark.sauce
 @pytest.mark.tier(1)
-@pytest.mark.uncollectif(
-    lambda appliance, obj_type: appliance.version >= "5.11" and obj_type == "LOAD_BALANCER",
-    reason="Load Balancer not supported from version 5.11",
-)
+@pytest.mark.uncollectif(lambda appliance, obj_type:
+                         appliance.version >= "5.11" and obj_type == "LOAD_BALANCER",
+                         reason="Load Balancer not supported from version 5.11")
 @pytest.mark.parametrize("obj_type", OBJ_TYPE, ids=[obj.capitalize() for obj in OBJ_TYPE])
 def test_button_group_crud(request, appliance, obj_type):
     """Test crud operation for Button Group
@@ -118,13 +117,11 @@ def test_button_group_crud(request, appliance, obj_type):
 
 @pytest.mark.sauce
 @pytest.mark.tier(1)
-@pytest.mark.uncollectif(
-    lambda appliance, obj_type: appliance.version >= "5.11" and obj_type == "LOAD_BALANCER",
-    reason="Load Balancer not supported from version 5.11",
-)
-@pytest.mark.parametrize(
-    "obj_type", OBJ_TYPE, ids=[obj.capitalize() for obj in OBJ_TYPE], scope="module"
-)
+@pytest.mark.uncollectif(lambda appliance, obj_type:
+                         appliance.version >= "5.11" and obj_type == "LOAD_BALANCER",
+                         reason="Load Balancer not supported from version 5.11")
+@pytest.mark.parametrize("obj_type", OBJ_TYPE, ids=[obj.capitalize() for obj in OBJ_TYPE],
+                         scope="module")
 def test_button_crud(appliance, dialog, request, button_group, obj_type):
     """Test crud operation for Custom Button
 
@@ -750,10 +747,9 @@ def test_simulated_object_copy_on_button(appliance, provider, setup_provider, bu
 
 @pytest.mark.tier(1)
 @pytest.mark.meta(blockers=[BZ(1755229)], automates=[1755229])
-@pytest.mark.uncollectif(
-    lambda appliance, obj_type: appliance.version >= "5.11" and "LOAD_BALANCER" == obj_type,
-    reason="Load Balancer not supported from version 5.11",
-)
+@pytest.mark.uncollectif(lambda appliance, obj_type:
+                         appliance.version >= "5.11" and "LOAD_BALANCER" == obj_type,
+                         reason="Load Balancer not supported from version 5.11")
 @pytest.mark.parametrize(
     "obj_type", OBJ_TYPE, ids=[obj.capitalize() for obj in OBJ_TYPE], scope="module"
 )

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -417,7 +417,8 @@ def test_custom_button_expression_infra_obj(
             assert button.text in custom_button_group.items
 
 
-@pytest.mark.uncollectif(lambda button_group: "VM_INSTANCE" not in button_group)
+@pytest.mark.uncollectif(lambda button_group: "VM_INSTANCE" not in button_group,
+                         reason='Test only valid for VM_INSTANCE button group type')
 def test_custom_button_open_url_infra_obj(request, setup_obj, button_group, method):
     """ Test Open url functionality of custom button.
 

--- a/cfme/tests/automate/custom_button/test_infra_objects_ansible.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects_ansible.py
@@ -74,12 +74,10 @@ def setup_obj(button_group, provider):
 
 @pytest.mark.meta(blockers=[BZ(1685555, unblock=lambda button_group: "SWITCH" not in button_group)])
 @pytest.mark.parametrize("inventory", INVENTORY, ids=["_".join(item.split()) for item in INVENTORY])
-@pytest.mark.uncollectif(
-    lambda appliance, button_group, inventory: (
-        "VM_INSTANCE" not in button_group and inventory == "Target Machine"
-    )
-    or (appliance.version < "5.11" and inventory == "Localhost")
-)
+@pytest.mark.uncollectif(lambda appliance, button_group, inventory:
+                         ("VM_INSTANCE" not in button_group and inventory == "Target Machine") or
+                         appliance.version < "5.11" and inventory == "Localhost",
+                         reason='Invalid combo of button group, inventory, and appliance version')
 def test_custom_button_ansible_automate_infra_obj(
     request, appliance, inventory, setup_obj, button_group, ansible_catalog_item_create_empty_file,
     target_machine, target_machine_ansible_creds,

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -24,6 +24,8 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [pytest.mark.tier(2), test_requirements.custom_button]
 
+GENERIC_SSUI_UNCOLLECT = "Generic object custom button not supported by SSUI"
+
 OBJECTS = ["SERVICE", "GENERIC"]
 
 DISPLAY_NAV = {
@@ -165,10 +167,9 @@ def user_self_service_role(appliance):
     list(DISPLAY_NAV.keys()),
     ids=[item.replace(" ", "_") for item in DISPLAY_NAV.keys()]
 )
-@pytest.mark.uncollectif(
-    lambda context, button_group: context == ViaSSUI and "GENERIC" in button_group,
-    reason="Generic object custom button not supported by SSUI",
-)
+@pytest.mark.uncollectif(lambda context, button_group:
+                         context == ViaSSUI and "GENERIC" in button_group,
+                         reason=GENERIC_SSUI_UNCOLLECT)
 @pytest.mark.meta(
     automates=[1650066],
     blockers=[
@@ -233,10 +234,9 @@ def test_custom_button_display_service_obj(
 
 @pytest.mark.parametrize("context", [ViaUI, ViaSSUI])
 @pytest.mark.parametrize("submit", SUBMIT, ids=[item.replace(" ", "_") for item in SUBMIT])
-@pytest.mark.uncollectif(
-    lambda context, button_group: context == ViaSSUI and "GENERIC" in button_group,
-    reason="Generic object custom button not supported by SSUI",
-)
+@pytest.mark.uncollectif(lambda context, button_group:
+                         context == ViaSSUI and "GENERIC" in button_group,
+                         reason=GENERIC_SSUI_UNCOLLECT)
 def test_custom_button_automate_service_obj(
     request, appliance, context, submit, objects, button_group
 ):
@@ -421,10 +421,9 @@ def vis_enb_button(request, appliance, button_group):
 
 @pytest.mark.tier(0)
 @pytest.mark.parametrize("context", [ViaUI, ViaSSUI])
-@pytest.mark.uncollectif(
-    lambda context, button_group: "GENERIC" in button_group,
-    reason="Generic object custom button not supported by SSUI",
-)
+@pytest.mark.uncollectif(lambda button_group:
+                         "GENERIC" in button_group,
+                         reason='Generic button group type not valid for test')
 def test_custom_button_expression_service_obj(
     appliance, context, objects, button_group, vis_enb_button
 ):
@@ -573,7 +572,9 @@ def test_custom_button_role_access_service(
 @test_requirements.customer_stories
 @pytest.mark.meta(automates=[BZ(1439883)])
 @pytest.mark.provider([VMwareProvider], override=True)
-@pytest.mark.uncollectif(lambda button_group: "GENERIC" in button_group)
+@pytest.mark.uncollectif(lambda button_group:
+                         "GENERIC" in button_group,
+                         reason='Generic button group type not valid for test')
 def test_custom_button_dialog_service_archived(
     request, appliance, provider, setup_provider, service_vm, button_group, dialog
 ):
@@ -656,10 +657,9 @@ def test_custom_button_dialog_service_archived(
 
 
 @pytest.mark.parametrize("context", [ViaUI, ViaSSUI])
-@pytest.mark.uncollectif(
-    lambda context, button_group: context == ViaSSUI and "GENERIC" in button_group,
-    reason="Generic object custom button not supported by SSUI",
-)
+@pytest.mark.uncollectif(lambda context, button_group:
+                         context == ViaSSUI and "GENERIC" in button_group,
+                         reason=GENERIC_SSUI_UNCOLLECT)
 def test_custom_button_dialog_service_obj(
     appliance, dialog, request, context, objects, button_group
 ):

--- a/cfme/tests/automate/test_file_import.py
+++ b/cfme/tests/automate/test_file_import.py
@@ -43,10 +43,13 @@ def test_domain_import_file(import_datastore, import_data):
 
 @pytest.mark.tier(2)
 @pytest.mark.meta(automates=[1720611])
-@pytest.mark.parametrize("upload_file", ["datastore_blank.zip", "dialog_blank.yml"],
+@pytest.mark.parametrize("upload_file",
+                         ["datastore_blank.zip", "dialog_blank.yml"],
                          ids=["datastore", "dialog"])
-@pytest.mark.uncollectif(lambda upload_file: upload_file == "dialog_blank.yml" and
-                         BZ(1720611, forced_streams=['5.10']).blocks)
+@pytest.mark.uncollectif(lambda upload_file:
+                         upload_file == "dialog_blank.yml" and BZ(1720611,
+                                                                  forced_streams=['5.10']).blocks,
+                         reason='Blank dialog import blocked by BZ 1720611')
 def test_upload_blank_file(appliance, upload_file):
     """
     Bugzilla:

--- a/cfme/tests/automate/test_provisioning_dialogs.py
+++ b/cfme/tests/automate/test_provisioning_dialogs.py
@@ -60,9 +60,9 @@ for name in ProvisioningDialogsCollection.ALLOWED_TYPES:
 @test_requirements.general_ui
 @pytest.mark.tier(3)
 @pytest.mark.parametrize(("name", "by", "order"), sort_by_params)
-@pytest.mark.uncollectif(
-    lambda appliance, name: appliance.version >= "5.10" and name == "Host Provision",
-    reason='Host Provisioning was deprecated and doesnt exist in 5.10')
+@pytest.mark.uncollectif(lambda appliance, name:
+                         appliance.version >= "5.10" and name == "Host Provision",
+                         reason='Host Provisioning was deprecated and doesnt exist in 5.10')
 def test_provisioning_dialogs_sorting(appliance, name, by, order):
     """
     Polarion:

--- a/cfme/tests/candu/test_cluster_graph.py
+++ b/cfme/tests/candu/test_cluster_graph.py
@@ -52,10 +52,10 @@ def host(appliance, provider):
         return collection.instantiate(name=test_host.name, provider=provider)
 
 
-@pytest.mark.uncollectif(
-    lambda provider, interval: provider.one_of(RHEVMProvider) and interval == "Daily",
-    reason="RHEVM not supporting historical data collection, Need to wait for one day at least"
-)
+@pytest.mark.uncollectif(lambda provider, interval:
+                         provider.one_of(RHEVMProvider) and interval == "Daily",
+                         reason="RHEVM not supporting historical data collection, "
+                                "Need to wait for one day at least")
 @pytest.mark.parametrize("interval", INTERVAL)
 @pytest.mark.parametrize("graph_type", GRAPHS)
 def test_cluster_graph_screen(provider, cluster, host, graph_type, interval, enable_candu):

--- a/cfme/tests/candu/test_vm_graph.py
+++ b/cfme/tests/candu/test_vm_graph.py
@@ -38,7 +38,7 @@ INTERVAL = ['Hourly', 'Daily']
     lambda provider, graph_type:
         (provider.one_of(RHEVMProvider, AzureProvider) and graph_type == "vm_cpu_state") or
         (provider.one_of(EC2Provider) and graph_type in ["vm_cpu_state", "vm_memory", "vm_disk"]),
-    reason='Invalid graph_type and provider type combination'
+    reason='Invalid combination of graph_type and provider type'
 )
 @pytest.mark.parametrize('graph_type', VM_GRAPHS)
 def test_vm_most_recent_hour_graph_screen(graph_type, provider, enable_candu):
@@ -101,7 +101,7 @@ def test_vm_most_recent_hour_graph_screen(graph_type, provider, enable_candu):
         (provider.one_of(RHEVMProvider, AzureProvider) and graph_type == "vm_cpu_state") or
         (provider.one_of(EC2Provider) and graph_type in ["vm_cpu_state", "vm_memory", "vm_disk"]) or
         (provider.one_of(CloudProvider, RHEVMProvider) and interval == 'Daily'),
-    reason='Invalid combintation of graph_type or interval and provider type'
+    reason='Invalid combination of graph_type or interval and provider type'
 )
 @pytest.mark.parametrize('interval', INTERVAL)
 @pytest.mark.parametrize('graph_type', VM_GRAPHS)

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -48,7 +48,6 @@ ext_auth_options = [
 
 
 @pytest.mark.rhel_testing
-@pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
 @pytest.mark.smoke
 @pytest.mark.tier(2)
 def test_appliance_console(appliance):

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -45,22 +45,22 @@ def pytest_generate_tests(metafunc):
             z_version = int(split_ver[2])
         except (IndexError, ValueError) as e:
             logger.exception("Couldn't parse version: %s, skipping", e)
-            versions.append(pytest.param("bad:{!r}".format(version), marks=pytest.mark.uncollect(
-                reason='Could not parse z_version from: {}'.format(version)
-            )))
+            versions.append(
+                pytest.param(
+                    f"bad:{version}",
+                    marks=pytest.mark.uncollect(reason=f'Could not parse z_version from: {version}')
+                )
+            )
         else:
             z_version = z_version - 1
             if z_version < 0:
-                reason_str = ('No previous z-stream version to update from: {}'
-                    .format(version))
+                reason_str = (f'No previous z-stream version to update from: {version}')
                 logger.debug(reason_str)
-                versions.append(pytest.param(
-                    "bad:{!r}".format(version),
-                    marks=pytest.mark.uncollect(reason=reason_str)
-                ))
+                versions.append(
+                    pytest.param(f"bad:{version}", marks=pytest.mark.uncollect(reason=reason_str))
+                )
             else:
-                versions.append("{split_ver[0]}.{split_ver[1]}.{z_version}".format(
-                    split_ver=split_ver, z_version=z_version))
+                versions.append(f"{split_ver[0]}.{split_ver[1]}.{z_version}")
     else:
         versions.append(old_version_pytest_arg)
     metafunc.parametrize('old_version', versions, indirect=True)

--- a/cfme/tests/cli/test_evmserverd.py
+++ b/cfme/tests/cli/test_evmserverd.py
@@ -15,7 +15,8 @@ def start_evmserverd_after_module(appliance):
 
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda appliance: appliance.is_pod),
+    pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                            reason='CLI tests not valid on podified'),
     pytest.mark.usefixtures("start_evmserverd_after_module")
 ]
 

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -19,12 +19,14 @@ from cfme.utils.wait import RefreshTimer
 from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for
 
+PROVIDER_FIELDS = ['test_power_control']
+
 pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.long_running,
     test_requirements.power,
     pytest.mark.provider([CloudProvider], scope='function',
-                         required_fields=['test_power_control']),
+                         required_fields=PROVIDER_FIELDS),
     pytest.mark.usefixtures('setup_provider'),
 ]
 
@@ -357,7 +359,7 @@ def test_power_on_or_off_multiple(provider, testing_instance, testing_instance2,
     wait_for_instance_state(soft_assert, testing_instance2, state="started")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+@pytest.mark.provider([OpenStackProvider], required_fields=PROVIDER_FIELDS)
 def test_hard_reboot(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance hard reboot
 
@@ -380,7 +382,7 @@ def test_hard_reboot(appliance, provider, testing_instance, ensure_vm_running, s
     wait_for_instance_state(soft_assert, testing_instance, state="started")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider))
+@pytest.mark.provider([AzureProvider], required_fields=PROVIDER_FIELDS)
 def test_hard_reboot_unsupported(appliance, testing_instance):
     """
     Tests that hard reboot throws an 'unsupported' error message on an Azure instance
@@ -403,7 +405,7 @@ def test_hard_reboot_unsupported(appliance, testing_instance):
     appliance.browser.create_view(BaseLoggedInPage).flash.assert_message(message)
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
+@pytest.mark.provider([AzureProvider, OpenStackProvider], required_fields=PROVIDER_FIELDS)
 def test_suspend(appliance, provider, testing_instance, ensure_vm_running, soft_assert):
     """ Tests instance suspend
 
@@ -425,7 +427,7 @@ def test_suspend(appliance, provider, testing_instance, ensure_vm_running, soft_
     wait_for_instance_state(soft_assert, testing_instance, state="suspended")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+@pytest.mark.provider([OpenStackProvider], required_fields=PROVIDER_FIELDS)
 def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_assert):
     """ Tests instance unpause
 
@@ -445,7 +447,7 @@ def test_unpause(appliance, provider, testing_instance, ensure_vm_paused, soft_a
     wait_for_instance_state(soft_assert, testing_instance, state="started")
 
 
-@pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
+@pytest.mark.provider([AzureProvider, OpenStackProvider], required_fields=PROVIDER_FIELDS)
 def test_resume(appliance, provider, testing_instance, ensure_vm_suspended, soft_assert):
     """ Tests instance resume
 
@@ -616,7 +618,7 @@ class TestInstanceRESTAPI(object):
         # check if the power state change is reflected on UI and provider
         wait_for_instance_state(soft_assert, testing_instance, state="started")
 
-    @pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+    @pytest.mark.provider([OpenStackProvider], required_fields=PROVIDER_FIELDS)
     @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
     def test_hard_reboot(self, provider, testing_instance,
             soft_assert, ensure_vm_running, appliance, from_detail):
@@ -646,7 +648,7 @@ class TestInstanceRESTAPI(object):
         # check if the power state change is reflected on UI and provider
         wait_for_instance_state(soft_assert, testing_instance, state="started")
 
-    @pytest.mark.uncollectif(lambda provider: not provider.one_of(AzureProvider, OpenStackProvider))
+    @pytest.mark.provider([AzureProvider, OpenStackProvider], required_fields=PROVIDER_FIELDS)
     @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
     def test_suspend_resume(self, provider, testing_instance,
             soft_assert, ensure_vm_running, appliance, from_detail):
@@ -692,7 +694,7 @@ class TestInstanceRESTAPI(object):
         # check if the power state change is reflected on UI and provider
         wait_for_instance_state(soft_assert, testing_instance, state="started")
 
-    @pytest.mark.uncollectif(lambda provider: not provider.one_of(OpenStackProvider))
+    @pytest.mark.provider([OpenStackProvider], required_fields=PROVIDER_FIELDS)
     @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
     def test_pause_unpause(self, provider, testing_instance,
             soft_assert, ensure_vm_running, appliance, from_detail):

--- a/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
+++ b/cfme/tests/cloud_infra_common/test_custom_attributes_rest.py
@@ -121,9 +121,13 @@ def _uncollect(provider, collection_name):
     )
 
 
+GENERIC_UNCOLLECT = 'Invalid combination of collection_name and provider type'
+
+
 class TestCustomAttributesRESTAPI(object):
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.rhv2
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
     def test_add(self, request, collection_name, get_resource):
@@ -146,7 +150,8 @@ class TestCustomAttributesRESTAPI(object):
             assert record.value == attr.value
 
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
     def test_delete_from_detail_post(self, request, collection_name, get_resource):
         """Test deleting custom attributes from detail using POST method.
@@ -164,7 +169,8 @@ class TestCustomAttributesRESTAPI(object):
         delete_resources_from_detail(attributes, method='POST')
 
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
     def test_delete_from_detail_delete(self, request, collection_name, get_resource):
         """Test deleting custom attributes from detail using DELETE method.
@@ -182,7 +188,8 @@ class TestCustomAttributesRESTAPI(object):
         delete_resources_from_detail(attributes, method='DELETE')
 
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
     def test_delete_from_collection(self, request, collection_name, get_resource):
         """Test deleting custom attributes from collection using REST API.
@@ -202,7 +209,8 @@ class TestCustomAttributesRESTAPI(object):
         delete_resources_from_collection(attributes, collection=collection, not_found=True)
 
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
     def test_delete_single_from_collection(self, request, collection_name, get_resource):
         """Test deleting single custom attribute from collection using REST API.
@@ -223,7 +231,8 @@ class TestCustomAttributesRESTAPI(object):
         delete_resources_from_collection([attribute], collection=collection, not_found=True)
 
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
     @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
     def test_edit(self, request, from_detail, collection_name, appliance, get_resource):
@@ -267,7 +276,8 @@ class TestCustomAttributesRESTAPI(object):
             assert edited[i].section == body[i]['section'] == attributes[i].section
 
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
     @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
     def test_bad_section_edit(self, request, from_detail, collection_name, appliance, get_resource):
@@ -301,7 +311,8 @@ class TestCustomAttributesRESTAPI(object):
             assert_response(appliance, http_status=400)
 
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.parametrize("collection_name", COLLECTIONS)
     def test_bad_section_add(self, request, collection_name, appliance, get_resource):
         """Test adding custom attributes with invalid section to resource using REST API.
@@ -328,7 +339,8 @@ class TestCustomAttributesRESTAPI(object):
         assert_response(appliance, http_status=400)
 
     @pytest.mark.uncollectif(lambda provider, collection_name:
-                             _uncollect(provider, collection_name))
+                             _uncollect(provider, collection_name),
+                             reason=GENERIC_UNCOLLECT)
     @pytest.mark.parametrize('collection_name', COLLECTIONS)
     def test_add_duplicate(self, request, collection_name, get_resource):
         """Tests that adding duplicate custom attribute updates the existing one.

--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -35,8 +35,9 @@ def vm_crud(provider, small_template):
 @pytest.mark.meta(blockers=["GH#ManageIQ/manageiq:473"])
 @pytest.mark.parametrize("from_edit", [True, False], ids=["via_edit", "via_summary"])
 @test_requirements.genealogy
-@pytest.mark.uncollectif(
-    lambda provider, from_edit: provider.one_of(CloudProvider) and not from_edit)
+@pytest.mark.uncollectif(lambda provider, from_edit:
+                         provider.one_of(CloudProvider) and not from_edit,
+                         reason='Cloud provider genealogy only shown on edit')
 def test_vm_genealogy_detected(
         request, setup_provider, provider, small_template, soft_assert, from_edit, vm_crud):
     """Tests vm genealogy from what CFME can detect.

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -92,10 +92,9 @@ def test_default_view_infra_reset(appliance):
 
 @pytest.mark.parametrize('group_name', list(GTL_PARAMS.keys()), scope="module")
 @pytest.mark.parametrize('view', ['List View', 'Tile View', 'Grid View'])
-@pytest.mark.uncollectif(
-    lambda view, group_name: view == "Grid View" and group_name == "Service Catalogs",
-    reason='Incompatible combination of grid view and service catalogs'
-)
+@pytest.mark.uncollectif(lambda view, group_name:
+                         view == "Grid View" and group_name == "Service Catalogs",
+                         reason='Invalid combination of grid view and service catalogs')
 def test_infra_default_view(appliance, group_name, view):
     """This test case changes the default view of an infra related page and asserts the change.
 

--- a/cfme/tests/configure/test_landing_page.py
+++ b/cfme/tests/configure/test_landing_page.py
@@ -169,13 +169,10 @@ def set_landing_page(appliance, my_settings, start_page):
 
 
 @pytest.mark.parametrize("start_page", ALL_LANDING_PAGES, scope="module")
-@pytest.mark.uncollectif(
-    lambda start_page, appliance: (
-        (appliance.version < "5.11" and start_page in PAGES_NOT_IN_510)
-        or (appliance.version > "5.11" and start_page in PAGES_NOT_IN_511)
-    ),
-    reason='Start page not available on the appliance version under test'
-)
+@pytest.mark.uncollectif(lambda start_page, appliance:
+                         (appliance.version < "5.11" and start_page in PAGES_NOT_IN_510) or
+                         (appliance.version > "5.11" and start_page in PAGES_NOT_IN_511),
+                         reason='Start page not available on the appliance version under test')
 @test_requirements.settings
 def test_landing_page_admin(
     appliance, request, set_default_page, set_landing_page, start_page

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -45,7 +45,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize(argnames, [
             pytest.param(
                 None, None, None, None,
-                marks=pytest.mark.uncollect("Could not find rhsm data for stream in yaml"))])
+                marks=pytest.mark.skip("Could not find rhsm data for stream in yaml"))])
         return
 
     if 'reg_method' in metafunc.fixturenames:

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -363,12 +363,10 @@ class TestTagsViaREST(object):
     )
     @pytest.mark.parametrize("collection_name", INFRA_COLLECTION + CLOUD_COLLECTION)
     @pytest.mark.uncollectif(
-        lambda appliance, collection_name, provider: (
-            provider.one_of(CloudProvider) and collection_name in INFRA_COLLECTION
-        )
-        or (
-            provider.one_of(InfraProvider) and collection_name in CLOUD_COLLECTION
-        )
+        lambda appliance, collection_name, provider:
+            (provider.one_of(CloudProvider) and collection_name in INFRA_COLLECTION) or
+            (provider.one_of(InfraProvider) and collection_name in CLOUD_COLLECTION),
+        reason='Invalid combination of provider type and collection name'
     )
     def test_assign_and_unassign_tag(self, appliance, tags_mod, provider, services_mod,
             service_templates, tenants, vm, collection_name, users):

--- a/cfme/tests/containers/test_chargeback.py
+++ b/cfme/tests/containers/test_chargeback.py
@@ -272,7 +272,10 @@ def abstract_test_chargeback_cost(
 #
 #
 # Workaround:
-@pytest.mark.uncollectif(lambda rate_type: rate_type == 'variable')
+# TODO: fix this parametrization, its janky and can be restructured.
+@pytest.mark.uncollectif(lambda rate_type:
+                         rate_type == 'variable',
+                         reason='Variable rate type not valid for fixed test')
 def test_chargeback_rate_fixed_1(
         rate_type, obj_type, interval, chargeback_report_data, compute_rate, soft_assert):
     """
@@ -286,7 +289,9 @@ def test_chargeback_rate_fixed_1(
         'Fixed1', obj_type, interval, chargeback_report_data, compute_rate, soft_assert)
 
 
-@pytest.mark.uncollectif(lambda rate_type: rate_type == 'variable')
+@pytest.mark.uncollectif(lambda rate_type:
+                         rate_type == 'variable',
+                         reason='Variable rate type not valid for fixed test')
 def test_chargeback_rate_fixed_2(
         rate_type, obj_type, interval, chargeback_report_data, compute_rate, soft_assert):
     """
@@ -328,7 +333,9 @@ def test_chargeback_rate_memory_used(
 
 # Network variable rate tests are skipped until this bug is solved:
 #     https://github.com/ManageIQ/integration_tests/issues/5027
-@pytest.mark.uncollectif(lambda rate_type: rate_type == 'variable')
+@pytest.mark.uncollectif(lambda rate_type:
+                         rate_type == 'variable',
+                         reason='Variable rate type not valid for network chargeback test')
 def test_chargeback_rate_network_io(
         rate_type, obj_type, interval, chargeback_report_data, compute_rate, soft_assert):
     """

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -126,7 +126,8 @@ def test_config_manager_remove(config_manager):
 @pytest.mark.tier(3)
 @test_requirements.tag
 @pytest.mark.uncollectif(lambda config_manager_obj:
-                         isinstance(config_manager_obj, AnsibleTower))
+                         isinstance(config_manager_obj, AnsibleTower),
+                         reason='Ansible tower not valid for this test')
 def test_config_system_tag(config_system, tag, appliance, config_manager, config_manager_obj):
     """
     Polarion:
@@ -141,7 +142,8 @@ def test_config_system_tag(config_system, tag, appliance, config_manager, config
 @pytest.mark.tier(3)
 @test_requirements.tag
 @pytest.mark.uncollectif(lambda config_manager_obj:
-                         not isinstance(config_manager_obj, AnsibleTower))
+                         not isinstance(config_manager_obj, AnsibleTower),
+                         reason='Only Ansible tower is valid for this test')
 def test_ansible_tower_job_templates_tag(request, config_manager, tag, config_manager_obj):
     """
     Polarion:
@@ -169,7 +171,8 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag, config_ma
 
 @pytest.mark.tier(3)
 @pytest.mark.uncollectif(lambda config_manager_obj:
-                         not isinstance(config_manager_obj, AnsibleTower))
+                         not isinstance(config_manager_obj, AnsibleTower),
+                         reason='Only Ansible tower is valid for this test')
 @pytest.mark.parametrize('template_type', TEMPLATE_TYPE.values(), ids=list(TEMPLATE_TYPE.keys()))
 def test_ansible_tower_service_dialog_creation_from_template(config_manager, appliance,
         template_type, config_manager_obj):

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -137,11 +137,9 @@ def test_discover_host(request, provider, appliance, host_ips):
 @pytest.mark.rhv2
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])
-@pytest.mark.uncollectif(
-    lambda provider, creds:
-        creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
-    reason="cred type not relevant for RHEVM Provider."
-)
+@pytest.mark.uncollectif(lambda provider, creds:
+                         creds != 'default' and provider.one_of(RHEVMProvider),
+                         reason="cred type not relevant for RHEVM Provider.")
 def test_multiple_host_good_creds(setup_provider, provider, creds):
     """
 

--- a/cfme/tests/infrastructure/test_host_analysis.py
+++ b/cfme/tests/infrastructure/test_host_analysis.py
@@ -60,9 +60,9 @@ def host_with_credentials(provider, host_name):
 
 
 @pytest.mark.rhv1
-@pytest.mark.uncollectif(
-    lambda provider, appliance: not appliance.is_downstream and provider.one_of(RHEVMProvider)
-)
+@pytest.mark.uncollectif(lambda provider, appliance:
+                         provider.one_of(RHEVMProvider) and not appliance.is_downstream,
+                         reason='RHEVM host analysis not valid on upstream')
 @pytest.mark.meta(blockers=[BZ(1650179,
                                forced_streams=['5.10'],
                                unblock=lambda provider: not provider.one_of(RHEVMProvider))])

--- a/cfme/tests/infrastructure/test_individual_host_creds.py
+++ b/cfme/tests/infrastructure/test_individual_host_creds.py
@@ -48,11 +48,9 @@ def get_host_data_by_name(provider_key, host_name):
 @pytest.mark.rhv1
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])
-@pytest.mark.uncollectif(
-    lambda provider, creds:
-    creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
-    reason="Cred type not relevant for RHEVM Provider."
-)
+@pytest.mark.uncollectif(lambda provider, creds:
+                         creds != 'default' and provider.one_of(RHEVMProvider),
+                         reason="Cred type not relevant for RHEVM Provider.")
 def test_host_good_creds(appliance, request, setup_provider, provider, creds):
     """
     Tests host credentialing  with good credentials
@@ -110,11 +108,9 @@ def test_host_good_creds(appliance, request, setup_provider, provider, creds):
 @pytest.mark.rhv3
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])
-@pytest.mark.uncollectif(
-    lambda provider, creds:
-        creds in ['remote_login', 'web_services'] and provider.one_of(RHEVMProvider),
-    reason="Cred type not relevant for RHEVM Provider."
-)
+@pytest.mark.uncollectif(lambda provider, creds:
+                         creds != 'default' and provider.one_of(RHEVMProvider),
+                         reason="Cred type not relevant for RHEVM Provider.")
 def test_host_bad_creds(appliance, request, setup_provider, provider, creds):
     """
     Tests host credentialing  with bad credentials

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -143,11 +143,10 @@ def test_vm_reconfig_add_remove_hw_cold(provider, full_vm, ensure_vm_stopped, ch
 @pytest.mark.parametrize('disk_type', ['thin', 'thick'])
 @pytest.mark.parametrize(
     'disk_mode', ['persistent', 'independent_persistent', 'independent_nonpersistent'])
-@pytest.mark.uncollectif(
-    # Disk modes cannot be specified when adding disk to VM in RHV provider
-    lambda disk_mode, provider: disk_mode != 'persistent' and provider.one_of(RHEVMProvider),
-    reason='Disk modes cannot be specified on RHEVM, only persistent included'
-)
+# Disk modes cannot be specified when adding disk to VM in RHV provider
+@pytest.mark.uncollectif(lambda disk_mode, provider:
+                         disk_mode != 'persistent' and provider.one_of(RHEVMProvider),
+                         reason='Disk modes cannot be specified on RHEVM, only persistent included')
 @pytest.mark.meta(
     blockers=[BZ(1692801, forced_streams=['5.10'],
                  unblock=lambda provider: not provider.one_of(RHEVMProvider))]

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -39,7 +39,7 @@ def pytest_generate_tests(metafunc):
 
 @pytest.mark.tier(2)
 @pytest.mark.uncollectif(lambda appliance: appliance.is_dev,
-                         reason="Is a rails server")
+                         reason="Test not valid for dev server")
 @pytest.mark.meta(automates=[BZ(1530683)])
 @test_requirements.auth
 def test_group_roles(temp_appliance_preconfig_long, setup_aws_auth_provider, group_name,

--- a/cfme/tests/integration/test_ldap_auth_and_roles.py
+++ b/cfme/tests/integration/test_ldap_auth_and_roles.py
@@ -9,7 +9,7 @@ from cfme.utils.testgen import generate
 pytest_generate_tests = generate(gen_func=auth_groups, auth_mode='ldap')
 
 
-@pytest.mark.uncollect('Needs to be fixed after menu removed')
+@pytest.mark.uncollect(reason='Needs to be fixed after menu removed')
 @test_requirements.auth
 @pytest.mark.tier(2)
 def test_group_roles(request, temp_appliance_preconfig_long, group_name, group_data):

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -496,14 +496,12 @@ def test_reports_online_vms(appliance, setup_provider, provider, request, vm):
 
 @pytest.mark.tier(1)
 @pytest.mark.ignore_stream("5.10")
-@pytest.mark.uncollectif(
-    lambda case_sensitive: not case_sensitive
-    and BZ("1741588", forced_streams=["5.11"]).blocks,
-    reason="Case Insensitive filtering is still a WIP"
-)
-@pytest.mark.parametrize(
-    "case_sensitive", [True, False], ids=["case-sensitive", "case-insensitive"]
-)
+@pytest.mark.uncollectif(lambda case_sensitive:
+                         not case_sensitive and BZ("1741588", forced_streams=["5.11"]).blocks,
+                         reason="Case Insensitive filtering is still a WIP")
+@pytest.mark.parametrize("case_sensitive",
+                         [True, False],
+                         ids=["case-sensitive", "case-insensitive"])
 @pytest.mark.meta(automates=[1678150, 1741588])
 def test_reports_filter_content(
     appliance, case_sensitive, set_and_get_tenant_quota, tenant_report

--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -56,10 +56,9 @@ def handle_extra_tabs(view):
 
 @pytest.mark.parametrize("filetype", list(extensions_mapping.keys()))
 @pytest.mark.parametrize("collection_type", OBJECTCOLLECTIONS)
-@pytest.mark.uncollectif(
-    lambda collection_type, appliance:
-    "balancers" in collection_type and appliance.version > "5.11",
-    reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
+@pytest.mark.uncollectif(lambda collection_type, appliance:
+                         "balancers" in collection_type and appliance.version >= "5.11",
+                         reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
 def test_download_lists_base(filetype, collection_type, appliance):
     """ Download the items from base lists.
 
@@ -76,10 +75,9 @@ def test_download_lists_base(filetype, collection_type, appliance):
     download(collection, filetype)
 
 
-@pytest.mark.uncollectif(
-    lambda collection_type, appliance:
-    "balancers" in collection_type and appliance.version > "5.11",
-    reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
+@pytest.mark.uncollectif(lambda collection_type, appliance:
+                         "balancers" in collection_type and appliance.version >= "5.11",
+                         reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
 @pytest.mark.parametrize("collection_type", OBJECTCOLLECTIONS)
 def test_download_pdf_summary(appliance, collection_type, provider):
     """ Download the summary details of specific object

--- a/cfme/tests/networks/test_sdn_navigation.py
+++ b/cfme/tests/networks/test_sdn_navigation.py
@@ -17,9 +17,9 @@ pytestmark = [
 
 @pytest.mark.parametrize("tested_part", ["Cloud Subnets", "Cloud Networks", "Network Routers",
                          "Security Groups", "Network Ports", "Load Balancers"])
-@pytest.mark.uncollectif(
-    lambda tested_part, appliance: "Load Balancers" in tested_part and appliance.version > "5.11",
-    reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
+@pytest.mark.uncollectif(lambda tested_part, appliance:
+                         "Load Balancers" in tested_part and appliance.version >= "5.11",
+                         reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
 def test_sdn_provider_relationships_navigation(provider, tested_part, appliance):
     """
     Metadata:

--- a/cfme/tests/networks/test_tag_tagvis.py
+++ b/cfme/tests/networks/test_tag_tagvis.py
@@ -59,9 +59,9 @@ def child_visibility(appliance, network_provider, relationship, view):
 
 @pytest.mark.parametrize("relationship,view", network_test_items,
                          ids=[rel[0] for rel in network_test_items])
-@pytest.mark.uncollectif(
-    lambda relationship, appliance: "Load Balancers" in relationship and appliance.version > "5.11",
-    reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
+@pytest.mark.uncollectif(lambda relationship, appliance:
+                         "Load Balancers" in relationship and appliance.version >= "5.11",
+                         reason="Cloud Load Balancers are removed in 5.11, see BZ 1672949")
 def test_tagvis_network_provider_children(provider, appliance, request, relationship, view,
                                           tag, user_restricted):
     """

--- a/cfme/tests/storage/test_manager.py
+++ b/cfme/tests/storage/test_manager.py
@@ -13,10 +13,9 @@ pytestmark = [
     test_requirements.storage,
     pytest.mark.usefixtures("setup_provider"),
     pytest.mark.provider([EC2Provider, OpenStackProvider], scope="module"),
-    pytest.mark.uncollectif(
-        lambda manager, provider: provider.one_of(EC2Provider) and "object_managers" in manager,
-        reason="Object Storage not supported by EC2Provider",
-    ),
+    pytest.mark.uncollectif(lambda manager, provider:
+                            provider.one_of(EC2Provider) and "object_managers" in manager,
+                            reason="Object Storage not supported by EC2Provider"),
 ]
 
 

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -10,6 +10,9 @@ from cfme.utils.blockers import BZ
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for_decorator
 
+POD_REASON = 'Test not valid for podified appliances'
+
+
 pytestmark = [pytest.mark.smoke, pytest.mark.tier(1), test_requirements.appliance]
 
 
@@ -24,7 +27,8 @@ pytestmark = [pytest.mark.smoke, pytest.mark.tier(1), test_requirements.applianc
     'rhn-check',
     'rhnlib',
 ])
-@pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
+@pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                         reason=POD_REASON)
 def test_rpms_present(appliance, package):
     """Verifies nfs-util rpms are in place needed for pxe & nfs operations
 
@@ -39,7 +43,8 @@ def test_rpms_present(appliance, package):
     assert result.success
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
+@pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                         reason=POD_REASON)
 def test_selinux_enabled(appliance):
     """Verifies selinux is enabled
 
@@ -53,7 +58,8 @@ def test_selinux_enabled(appliance):
     assert 'Enforcing' in result
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
+@pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                         reason=POD_REASON)
 def test_firewalld_running(appliance):
     """Verifies iptables service is running on the appliance
 
@@ -65,7 +71,8 @@ def test_firewalld_running(appliance):
     assert appliance.firewalld.is_active
 
 
-@pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
+@pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                         reason=POD_REASON)
 def test_evm_running(appliance):
     """Verifies overall evm service is running on the appliance
 
@@ -86,8 +93,8 @@ def test_evm_running(appliance):
     'sshd',
     'db_service',
 ])
-@pytest.mark.uncollectif(
-    lambda appliance: appliance.is_pod)
+@pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                         reason=POD_REASON)
 def test_service_enabled(appliance, service):
     """Verifies if key services are configured to start on boot up
 
@@ -102,7 +109,8 @@ def test_service_enabled(appliance, service):
 
 
 @pytest.mark.ignore_stream("upstream")
-@pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
+@pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                         reason=POD_REASON)
 def test_firewalld_services_are_active(appliance):
     """Verifies key firewalld services are in place
 
@@ -126,7 +134,8 @@ def test_firewalld_services_are_active(appliance):
 
 @pytest.mark.meta(blockers=[BZ(1712944)])
 @pytest.mark.ignore_stream("upstream")
-@pytest.mark.uncollectif(lambda appliance: appliance.is_pod)
+@pytest.mark.uncollectif(lambda appliance: appliance.is_pod,
+                         reason=POD_REASON)
 def test_firewalld_active_zone_after_restart(appliance):
     """Verifies key firewalld active zone survives firewalld restart
 

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -12,7 +12,8 @@ from cfme.utils.log import logger
 
 pytestmark = [
     test_requirements.db_migration,
-    pytest.mark.uncollectif(lambda appliance: appliance.is_dev, reason="rails server")
+    pytest.mark.uncollectif(lambda appliance: appliance.is_dev,
+                            reason="DB migrate tests not valid for dev server")
 ]
 
 

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -24,8 +24,9 @@ pytestmark = pytest.mark.usefixtures('browser')
                                              (ViaUI, '_js_auth_fn'),
                                              (ViaSSUI, 'click_on_login'),
                                              (ViaSSUI, 'press_enter_after_password')])
-@pytest.mark.uncollectif(lambda context, appliance: context == ViaSSUI and
-                         appliance.version == UPSTREAM)
+@pytest.mark.uncollectif(lambda context, appliance:
+                         context == ViaSSUI and appliance.version == UPSTREAM,
+                         reason='SSUI context not valid for upstream testing')
 def test_login(context, method, appliance):
     """ Tests that the appliance can be logged into and shows dashboard page.
 

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -170,6 +170,8 @@ COLLECTIONS_IN_UPSTREAM = COLLECTIONS_IN_510
 # non-typical collections without "id" and "resources", or additional parameters are required
 COLLECTIONS_OMITTED = {"automate_workspaces", "metric_rollups", "settings"}
 
+UNCOLLECT_REASON = 'Collection type not valid for appliance version'
+
 
 def _collection_not_in_this_version(appliance, collection_name):
     return (
@@ -183,11 +185,10 @@ def _collection_not_in_this_version(appliance, collection_name):
 @pytest.mark.rhel_testing
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("collection_name", COLLECTIONS_ALL)
-@pytest.mark.uncollectif(
-    lambda appliance, collection_name:
-        collection_name == "metric_rollups" or
-        _collection_not_in_this_version(appliance, collection_name)
-)
+@pytest.mark.uncollectif(lambda appliance, collection_name:
+                         collection_name == "metric_rollups" or
+                         _collection_not_in_this_version(appliance, collection_name),
+                         reason=UNCOLLECT_REASON)
 def test_query_simple_collections(appliance, collection_name):
     """This test tries to load each of the listed collections. 'Simple' collection means that they
     have no usable actions that we could try to run
@@ -220,11 +221,10 @@ def test_query_simple_collections(appliance, collection_name):
 @pytest.mark.meta(automates=[1392595], coverage=[1754972])
 @pytest.mark.tier(3)
 @pytest.mark.parametrize('collection_name', COLLECTIONS_ALL)
-@pytest.mark.uncollectif(
-    lambda appliance, collection_name:
-        collection_name in COLLECTIONS_OMITTED or
-        _collection_not_in_this_version(appliance, collection_name)
-)
+@pytest.mark.uncollectif(lambda appliance, collection_name:
+                         collection_name in COLLECTIONS_OMITTED or
+                         _collection_not_in_this_version(appliance, collection_name),
+                         reason=UNCOLLECT_REASON)
 def test_collections_actions(appliance, collection_name, soft_assert):
     """Tests that there are only actions with POST methods in collections.
 
@@ -259,11 +259,10 @@ def test_collections_actions(appliance, collection_name, soft_assert):
 
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("collection_name", COLLECTIONS_ALL)
-@pytest.mark.uncollectif(
-    lambda appliance, collection_name:
-        collection_name in COLLECTIONS_OMITTED or
-        _collection_not_in_this_version(appliance, collection_name)
-)
+@pytest.mark.uncollectif(lambda appliance, collection_name:
+                         collection_name in COLLECTIONS_OMITTED or
+                         _collection_not_in_this_version(appliance, collection_name),
+                         reason=UNCOLLECT_REASON)
 def test_query_with_api_version(api_version, collection_name):
     """Loads each of the listed collections using /api/<version>/<collection>.
 
@@ -286,11 +285,10 @@ def test_query_with_api_version(api_version, collection_name):
 
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("collection_name", COLLECTIONS_ALL)
-@pytest.mark.uncollectif(
-    lambda appliance, collection_name:
-        collection_name == 'metric_rollups' or  # needs additional parameters
-        _collection_not_in_this_version(appliance, collection_name)
-)
+@pytest.mark.uncollectif(lambda appliance, collection_name:
+                         collection_name == 'metric_rollups' or  # needs additional parameters
+                         _collection_not_in_this_version(appliance, collection_name),
+                         reason=UNCOLLECT_REASON)
 # testing GH#ManageIQ/manageiq:15754
 def test_select_attributes(appliance, collection_name):
     """Tests that it's possible to limit returned attributes.
@@ -616,8 +614,7 @@ PAGING_DATA = [
 ]
 
 
-@pytest.mark.parametrize(
-    'paging', PAGING_DATA, ids=['{},{}'.format(d[0], d[1]) for d in PAGING_DATA])
+@pytest.mark.parametrize('paging', PAGING_DATA, ids=[f'{d[0]},{d[1]}' for d in PAGING_DATA])
 def test_rest_paging(appliance, paging):
     """Tests paging when offset and limit are specified.
 
@@ -668,12 +665,11 @@ def test_rest_paging(appliance, paging):
 
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("collection_name", COLLECTIONS_ALL)
-@pytest.mark.uncollectif(
-    lambda appliance, collection_name:
-        collection_name == 'automate' or  # doesn't have 'href'
-        collection_name == 'metric_rollups' or  # needs additional parameters
-        _collection_not_in_this_version(appliance, collection_name)
-)
+@pytest.mark.uncollectif(lambda appliance, collection_name:
+                         collection_name == 'automate' or  # doesn't have 'href'
+                         collection_name == 'metric_rollups' or  # needs additional parameters
+                         _collection_not_in_this_version(appliance, collection_name),
+                         reason=UNCOLLECT_REASON)
 def test_attributes_present(appliance, collection_name):
     """Tests that the expected attributes are present in all collections.
 
@@ -1005,9 +1001,7 @@ class TestNotificationsRESTAPI(object):
         collection.reload()
         query_resource_attributes(collection[-1], soft_assert=soft_assert)
 
-    @pytest.mark.parametrize(
-        'from_detail', [True, False],
-        ids=['from_detail', 'from_collection'])
+    @pytest.mark.parametrize('from_detail', [True, False], ids=['from_detail', 'from_collection'])
     def test_mark_notifications(self, appliance, generate_notifications, from_detail):
         """Tests marking notifications as seen.
 
@@ -1213,9 +1207,9 @@ def image_file_path(file_name):
 
 @pytest.mark.meta(automates=[1578076])
 @pytest.mark.tier(3)
-@pytest.mark.uncollectif(
-    lambda appliance, image_type: image_type == "favicon" and appliance.version < 5.11
-)
+@pytest.mark.uncollectif(lambda appliance, image_type:
+                         image_type == "favicon" and appliance.version < 5.11,
+                         reason='Favicon image type is not valid for appliances before 5.11')
 @pytest.mark.parametrize("image_type", ["logo", "brand", "login_logo", "favicon"])
 def test_custom_logos_via_api(appliance, image_type, request):
     """

--- a/cfme/tests/webui/test_advanced_search.py
+++ b/cfme/tests/webui/test_advanced_search.py
@@ -22,14 +22,12 @@ SearchParam = namedtuple("SearchParam",
                          ["collection", "destination", "entity", "filter", "my_filters"])
 
 pytestmark = [
-    pytest.mark.uncollectif(
-        lambda param, appliance: (
-            (param.collection in (ConfigManager, 'ansible_tower_providers') or
-            param.filter == 'Job Template (Ansible Tower) : Name') or
-            (appliance.version >= '5.11' and param.entity == 'network_load_balancers')
-            # load balancers are no longer supported in 5.11 -> BZ 1672949
-        )
-    ), pytest.mark.meta(automates=[BZ(1402392)])  # should be only on test_filter_crud
+    pytest.mark.uncollectif(lambda param, appliance:
+        (param.collection in [ConfigManager, 'ansible_tower_providers'] or
+         param.filter == 'Job Template (Ansible Tower) : Name') or
+        (appliance.version >= '5.11' and param.entity == 'network_load_balancers'),
+        reason='load balancers are no longer supported in 5.11 -> BZ 1672949'),
+    pytest.mark.meta(automates=[BZ(1402392)])  # should be only on test_filter_crud
 ]
 
 


### PR DESCRIPTION
Make reason required for uncollect/uncollectif markers, raising a ValueError during collection if its not included.

Also update all of the current uses that don't have a reason.


During collection, this results in an INTERNALERROR that will look like the following at the bottom of the traceback:

```
INTERNALERROR>   File "/home/mshriver/repos/integration_tests/cfme/markers/uncollect.py", line 141, in pytest_collection_modifyitems
INTERNALERROR>     raise ValueError(REASON_REQUIRED.format(item.name))
INTERNALERROR> ValueError: A reason is required when using uncollect(if): test_upgrade_single_inplace

```