### PR TITLE
[1LP][RFR] fauxfactory args

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -506,7 +506,7 @@ def provider_app_crud(provider_class, appliance):
 
 def provision_vm(request, provider):
     """Function to provision appliance to the provider being tested"""
-    vm_name = "test_rest_db_{}".format(fauxfactory.gen_alphanumeric())
+    vm_name = fauxfactory.gen_alphanumeric(18, start="test_rest_db_")
     coll = provider.appliance.provider_based_collection(provider, coll_type="vms")
     vm = coll.instantiate(vm_name, provider)
     if not provider.mgmt.does_vm_exist(vm_name):

--- a/cfme/fixtures/depot.py
+++ b/cfme/fixtures/depot.py
@@ -23,7 +23,7 @@ def depot_machine_ip(request, appliance):
         data = cfme_data.log_db_operations
         vm = deploy_template(
             data.log_db_depot_template.provider,
-            "long-test-depot-{}".format(fauxfactory.gen_alphanumeric()),
+            fauxfactory.gen_alphanumeric(26, start="long-test-depot-"),
             template_name=data.log_db_depot_template.template_name
         )
         vm.ensure_state(VmState.RUNNING)

--- a/cfme/fixtures/soft_assert.py
+++ b/cfme/fixtures/soft_assert.py
@@ -133,7 +133,7 @@ def handle_assert_artifacts(request, fail_message=None):
         ss_error = base64_from_text(ss_error)
 
     # A simple id to match the artifacts together
-    sa_id = "softassert-{}".format(fauxfactory.gen_alpha(length=3).upper())
+    sa_id = fauxfactory.gen_alpha(length=14, start="softassert-").upper()
     from cfme.fixtures.pytest_store import store
     node = request.node
 

--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -46,7 +46,7 @@ def role(appliance):
         Returns role object used in test module
     """
     role = appliance.collections.roles.create(
-        name='role{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="role_"),
         vm_restriction='None')
     yield role
     appliance.server.login_admin()
@@ -59,7 +59,7 @@ def group_with_tag(appliance, role, tag):
         Returns group object with set up tag filter used in test module
     """
     group = appliance.collections.groups.create(
-        description='grp{}'.format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(start="group_"),
         role=role.name,
         tag=([tag.category.display_name, tag.display_name], True)
     )
@@ -75,7 +75,7 @@ def user_restricted(appliance, group_with_tag, new_credential):
         to group with tag filter used in test module
     """
     user = appliance.collections.users.create(
-        name='user{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="user_"),
         credential=new_credential,
         email='xyz@redhat.com',
         groups=[group_with_tag],
@@ -92,7 +92,7 @@ def new_credential():
         Returns credentials object used for new user in test module
     """
     return Credential(
-        principal='uid{}'.format(fauxfactory.gen_alphanumeric()), secret='redhat')
+        principal=fauxfactory.gen_alphanumeric(start="uid"), secret='redhat')
 
 
 @pytest.fixture(scope='function')

--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -466,7 +466,7 @@ def infra_mapping_default_data(source_provider, provider):
     plan_type = VersionPicker({Version.lowest(): None,
                                "5.10": "rhv" if provider.one_of(RHEVMProvider) else "osp"}).pick()
     infra_mapping_data = {
-        "name": "infra_map_{}".format(fauxfactory.gen_alphanumeric()),
+        "name": fauxfactory.gen_alphanumeric(15, start="infra_map_"),
         "description": "migration with vmware to {}".format(plan_type),
         "plan_type": plan_type,
         "clusters": [component_generator("clusters", source_provider, provider)],

--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -32,7 +32,7 @@ def service_catalogs(request, appliance, num=5):
     scls_data = []
     for _ in range(num):
         scls_data.append({
-            'name': 'cat_{}'.format(fauxfactory.gen_alphanumeric()),
+            'name': fauxfactory.gen_alphanumeric(start="cat_"),
             'description': 'my catalog',
             'service_templates': []
         })
@@ -185,7 +185,7 @@ def rates(request, appliance, num=3):
     chargeback = appliance.rest_api.collections.chargebacks.get(rate_type='Compute')
     data = []
     for _ in range(num):
-        req = {'description': 'test_rate_{}'.format(fauxfactory.gen_alphanumeric()),
+        req = {'description': fauxfactory.gen_alphanumeric(15, start="test_rate_"),
                'source': 'allocated',
                'group': 'cpu',
                'per_time': 'daily',
@@ -201,7 +201,7 @@ def vm(request, provider, appliance):
     provider_rest = appliance.rest_api.collections.providers.get(name=provider.name)
     vm = deploy_template(
         provider.key,
-        'test_rest_vm_{}'.format(fauxfactory.gen_alphanumeric(length=4))
+        fauxfactory.gen_alphanumeric(length=18, start="test_rest_vm_")
     )
     vm_name = vm.name
 
@@ -238,7 +238,7 @@ def service_templates_ui(request, appliance, service_dialog=None, service_catalo
                 provider.data.get('provisioning').get,
                 ('template', 'host', 'datastore', 'vlan')))
 
-            vm_name = 'test_rest_{}'.format(fauxfactory.gen_alphanumeric())
+            vm_name = fauxfactory.gen_alphanumeric(15, start="test_rest_")
 
             provisioning_data = {
                 'catalog': {'catalog_name': {'name': template},
@@ -256,7 +256,7 @@ def service_templates_ui(request, appliance, service_dialog=None, service_catalo
                 provisioning_data['catalog']['provision_type'] = 'VMware'
                 provisioning_data['network']['vlan'] = partial_match(vlan)
 
-        new_name = 'item_{}'.format(fauxfactory.gen_alphanumeric())
+        new_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
         new_names.append(new_name)
         cat_items_col.create(
             catalog_item_type,
@@ -379,7 +379,7 @@ def groups(request, appliance, role, num=1, **kwargs):
             {
                 "description": kwargs.get(
                     "description",
-                    "group_description_{}".format(fauxfactory.gen_alphanumeric()),
+                    fauxfactory.gen_alphanumeric(25, start="group_description_"),
                 ),
                 "role": {"href": role.href},
                 "tenant": {"href": tenant.href},
@@ -401,7 +401,7 @@ def roles(request, appliance, num=1, **kwargs):
         data.append(
             {
                 "name": kwargs.get(
-                    "name", "role_name_{}".format(fauxfactory.gen_alphanumeric())
+                    "name", fauxfactory.gen_alphanumeric(15, start="role_name_")
                 ),
                 "features": kwargs.get(
                     "features",
@@ -431,7 +431,7 @@ def copy_role(appliance, orig_name, new_name=None):
     if not orig_features:
         raise NotImplementedError('Role copy is not implemented for this version.')
     new_role = appliance.rest_api.collections.roles.action.create(
-        name=new_name or 'EvmRole-{}'.format(fauxfactory.gen_alphanumeric()),
+        name=new_name or fauxfactory.gen_alphanumeric(12, start="EvmRole-"),
         features=orig_features,
         settings=orig_settings
     )
@@ -544,7 +544,7 @@ def arbitration_profiles(request, appliance, provider, num=2):
     providers = [{'id': r_provider.id}, {'href': r_provider.href}]
     for index in range(num):
         data.append({
-            'name': 'test_settings_{}'.format(fauxfactory.gen_alphanumeric(5)),
+            'name': fauxfactory.gen_alphanumeric(20, start="test_settings_"),
             'provider': providers[index % 2]
         })
 
@@ -614,8 +614,8 @@ def custom_button_sets(request, appliance, button_type, icon="fa-user", color="#
     data = []
     for _ in range(num):
         data_dict = {
-            "name": "gp_{}".format(fauxfactory.gen_alphanumeric(3)),
-            "description": "disc_{}".format(fauxfactory.gen_alphanumeric(3)),
+            "name": fauxfactory.gen_alphanumeric(start="grp_"),
+            "description": fauxfactory.gen_alphanumeric(15, start="grp_desc_"),
             "set_data": {
                 "button_icon": "ff {}".format(icon),
                 "button_color": color,
@@ -635,8 +635,8 @@ def custom_buttons(
     for _ in range(num):
         data_dict = {
             "applies_to_class": button_type,
-            "description": "btn_{}".format(fauxfactory.gen_alphanumeric(3)),
-            "name": "disc_{}".format(fauxfactory.gen_alphanumeric(3)),
+            "description": fauxfactory.gen_alphanumeric(start="btn_"),
+            "name": fauxfactory.gen_alphanumeric(12, start="btn_desc_"),
             "options": {
                 "button_color": color,
                 "button_icon": "ff {}".format(icon),

--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -376,8 +376,8 @@ class BaseCatalogItem(BaseEntity, Updateable, Pretty, Taggable):
         return self.__class__(**item_args)
 
     def add_button_group(self, **kwargs):
-        button_name = kwargs.get("text", "gp_{}".format(fauxfactory.gen_alpha()))
-        hover_name = kwargs.get("hover", "hover_{}".format(fauxfactory.gen_alpha()))
+        button_name = kwargs.get("text", fauxfactory.gen_alpha(start="grp_"))
+        hover_name = kwargs.get("hover", fauxfactory.gen_alpha(15, start="grp_hvr_"))
 
         view = navigate_to(self, "AddButtonGroup")
         view.fill(
@@ -422,8 +422,8 @@ class BaseCatalogItem(BaseEntity, Updateable, Pretty, Taggable):
             view.browser.refresh()
 
     def add_button(self, **kwargs):
-        text = kwargs.get("text", "btn_{}".format(fauxfactory.gen_alpha()))
-        hover = kwargs.get("hover", "hover_{}".format(fauxfactory.gen_alpha()))
+        text = kwargs.get("text", fauxfactory.gen_alpha(start="btn_"))
+        hover = kwargs.get("hover", fauxfactory.gen_alpha(15, start="btn_hvr_"))
 
         view = navigate_to(self, "AddButton")
         view.fill(

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -23,7 +23,7 @@ pytestmark = [
 def ansible_action(appliance, ansible_catalog_item):
     action_collection = appliance.collections.actions
     action = action_collection.create(
-        fauxfactory.gen_alphanumeric(),
+        fauxfactory.gen_alphanumeric(15, start="action_"),
         action_type="Run Ansible Playbook",
         action_values={
             "run_ansible_playbook": {
@@ -41,12 +41,12 @@ def policy_for_testing(appliance, full_template_vm_modscope, provider, ansible_a
     vm = full_template_vm_modscope
     policy = appliance.collections.policies.create(
         VMControlPolicy,
-        fauxfactory.gen_alpha(),
+        fauxfactory.gen_alpha(15, start="policy_"),
         scope="fill_field(VM and Instance : Name, INCLUDES, {})".format(vm.name)
     )
     policy.assign_actions_to_event("Tag Complete", [ansible_action.description])
     policy_profile = appliance.collections.policy_profiles.create(
-        fauxfactory.gen_alpha(), policies=[policy])
+        fauxfactory.gen_alpha(15, start="profile_"), policies=[policy])
     provider.assign_policy_profiles(policy_profile.description)
     yield
 
@@ -60,7 +60,7 @@ def policy_for_testing(appliance, full_template_vm_modscope, provider, ansible_a
 @pytest.fixture(scope="module")
 def ansible_credential(wait_for_ansible, appliance, full_template_modscope):
     credential = appliance.collections.ansible_credentials.create(
-        fauxfactory.gen_alpha(),
+        fauxfactory.gen_alpha(start="cred_"),
         "Machine",
         username=credentials[full_template_modscope.creds]["username"],
         password=credentials[full_template_modscope.creds]["password"]

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -30,7 +30,7 @@ pytestmark = [
 @pytest.fixture(scope="module")
 def ansible_credential(appliance, ansible_repository, full_template_modscope):
     credential = appliance.collections.ansible_credentials.create(
-        fauxfactory.gen_alpha(),
+        fauxfactory.gen_alpha(start="cred_"),
         "Machine",
         username=credentials[full_template_modscope["creds"]]["username"],
         password=credentials[full_template_modscope["creds"]]["password"]
@@ -57,7 +57,7 @@ def management_event_class(appliance, namespace):
 @pytest.fixture
 def management_event_method(management_event_class, ansible_repository):
     return management_event_class.methods.create(
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="meth_"),
         location="playbook",
         repository=ansible_repository.name,
         playbook="copy_file_example.yml",
@@ -69,7 +69,7 @@ def management_event_method(management_event_class, ansible_repository):
 @pytest.fixture
 def management_event_instance(management_event_class, management_event_method):
     return management_event_class.instances.create(
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="inst_"),
         description=fauxfactory.gen_alphanumeric(),
         fields={"meth1": {"value": management_event_method.name}}
     )
@@ -78,13 +78,13 @@ def management_event_instance(management_event_class, management_event_method):
 @pytest.fixture(scope="module")
 def custom_vm_button(appliance, ansible_catalog_item):
     buttongroup = appliance.collections.button_groups.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover="btn_desc_{}".format(fauxfactory.gen_alphanumeric()),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=appliance.collections.button_groups.VM_INSTANCE)
     button = buttongroup.buttons.create(
         type="Ansible Playbook",
-        text=fauxfactory.gen_alphanumeric(),
-        hover="btn_hvr_{}".format(fauxfactory.gen_alphanumeric()),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         playbook_cat_item=ansible_catalog_item.name)
     yield button
     button.delete_if_exists()
@@ -94,7 +94,7 @@ def custom_vm_button(appliance, ansible_catalog_item):
 @pytest.fixture
 def alert(appliance, management_event_instance):
     _alert = appliance.collections.alerts.create(
-        "Trigger by Un-Tag Complete {}".format(fauxfactory.gen_alpha(length=4)),
+        fauxfactory.gen_alpha(30, start="Trigger by Un-Tag Complete "),
         active=True,
         based_on="VM and Instance",
         evaluate="Nothing",
@@ -132,7 +132,7 @@ def test_automate_ansible_playbook_method_type_crud(appliance, ansible_repositor
         initialEstimate: 1/12h
     """
     method = klass.methods.create(
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="meth_"),
         location="playbook",
         repository=ansible_repository.name,
         playbook="copy_file_example.yml",
@@ -155,7 +155,7 @@ def test_automate_ansible_playbook_method_type(request, appliance, ansible_repos
     """
     klass.schema.add_field(name="execute", type="Method", data_type="String")
     method = klass.methods.create(
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="meth_"),
         location="playbook",
         repository=ansible_repository.name,
         playbook="copy_file_example.yml",
@@ -163,7 +163,7 @@ def test_automate_ansible_playbook_method_type(request, appliance, ansible_repos
         playbook_input_parameters=[("key", "value", "string")]
     )
     instance = klass.instances.create(
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="inst_"),
         description=fauxfactory.gen_alphanumeric(),
         fields={"execute": {"value": method.name}})
 
@@ -190,21 +190,21 @@ def test_ansible_playbook_button_crud(ansible_catalog_item, appliance, request):
         initialEstimate: 1/6h
     """
     buttongroup = appliance.collections.button_groups.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=appliance.collections.button_groups.VM_INSTANCE)
     request.addfinalizer(buttongroup.delete_if_exists)
     button = buttongroup.buttons.create(
         type='Ansible Playbook',
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         playbook_cat_item=ansible_catalog_item.name)
     request.addfinalizer(button.delete_if_exists)
     assert button.exists
     view = navigate_to(button, 'Details')
     assert view.text.text == button.text
     assert view.hover.text == button.hover
-    edited_hover = "edited {}".format(fauxfactory.gen_alphanumeric())
+    edited_hover = fauxfactory.gen_alphanumeric(15, start="edited_")
     with update(button):
         button.hover = edited_hover
     assert button.exists
@@ -397,8 +397,8 @@ def test_variable_pass(request, appliance, setup_ansible_repository, import_data
     # Creating generic catalog items
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
-        name=fauxfactory.gen_alphanumeric(),
-        description=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
+        description=fauxfactory.gen_alphanumeric(15, start="item_disc_"),
         display_in=True,
         catalog=catalog,
         dialog=dialog,

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -50,72 +50,78 @@ CREDENTIALS = [
     (
         "Machine",
         {
-            "username": fauxfactory.gen_alpha(),
-            "password": fauxfactory.gen_alpha(),
+            "username": fauxfactory.gen_alpha(start="usr_"),
+            "password": fauxfactory.gen_alpha(start="pwd_"),
             "privilage_escalation": "sudo",
-            "privilage_escalation_username": fauxfactory.gen_alpha(),
-            "privilage_escalation_password": fauxfactory.gen_alpha(),
+            "privilage_escalation_username": fauxfactory.gen_alpha(start="usr_"),
+            "privilage_escalation_password": fauxfactory.gen_alpha(start="pwd_"),
         },
     ),
-    ("Scm", {"username": fauxfactory.gen_alpha(), "password": fauxfactory.gen_alpha()}),
+    (
+        "Scm",
+        {
+            "username": fauxfactory.gen_alpha(start="usr_"),
+            "password": fauxfactory.gen_alpha(start="pwd_")
+        }
+    ),
     (
         "Amazon",
         {
-            "access_key": fauxfactory.gen_alpha(),
-            "secret_key": fauxfactory.gen_alpha(),
-            "sts_token": fauxfactory.gen_alpha(),
+            "access_key": fauxfactory.gen_alpha(15, start="acc_key_"),
+            "secret_key": fauxfactory.gen_alpha(15, start="sec_key_"),
+            "sts_token": fauxfactory.gen_alpha(15, start="token_"),
         },
     ),
     (
         "VMware",
         {
-            "username": fauxfactory.gen_alpha(),
-            "password": fauxfactory.gen_alpha(),
-            "vcenter_host": fauxfactory.gen_alpha(),
+            "username": fauxfactory.gen_alpha(start="usr_"),
+            "password": fauxfactory.gen_alpha(start="pwd_"),
+            "vcenter_host": fauxfactory.gen_alpha(start="host_"),
         },
     ),
     (
         "OpenStack",
         {
-            "username": fauxfactory.gen_alpha(),
-            "password": fauxfactory.gen_alpha(),
-            "authentication_url": fauxfactory.gen_alpha(),
-            "project": fauxfactory.gen_alpha(),
-            "domain": fauxfactory.gen_alpha(),
+            "username": fauxfactory.gen_alpha(start="usr_"),
+            "password": fauxfactory.gen_alpha(start="pwd_"),
+            "authentication_url": fauxfactory.gen_alpha(start="url_"),
+            "project": fauxfactory.gen_alpha(15, start="project_"),
+            "domain": fauxfactory.gen_alpha(15, start="domain_"),
         },
     ),
     (
         "Red Hat Virtualization",
         {
-            "username": fauxfactory.gen_alpha(),
-            "password": fauxfactory.gen_alpha(),
-            "host": fauxfactory.gen_alpha(),
+            "username": fauxfactory.gen_alpha(start="usr_"),
+            "password": fauxfactory.gen_alpha(start="pwd_"),
+            "host": fauxfactory.gen_alpha(start="host_"),
         },
     ),
     (
         "Google Compute Engine",
         {
-            "service_account": fauxfactory.gen_alpha(),
+            "service_account": fauxfactory.gen_alpha(start="acc_"),
             "priv_key": private_key,
-            "project": fauxfactory.gen_alpha(),
+            "project": fauxfactory.gen_alpha(15, start="project_"),
         },
     ),
     (
         "Network",
         {
-            "username": fauxfactory.gen_alpha(),
-            "password": fauxfactory.gen_alpha(),
+            "username": fauxfactory.gen_alpha(start="usr_"),
+            "password": fauxfactory.gen_alpha(start="pwd_"),
         },
     ),
     (
         "Azure",
         {
-            "username": fauxfactory.gen_alpha(),
-            "password": fauxfactory.gen_alpha(),
-            "subscription_id": fauxfactory.gen_alpha(),
-            "tenant_id": fauxfactory.gen_alpha(),
-            "client_secret": fauxfactory.gen_alpha(),
-            "client_id": fauxfactory.gen_alpha(),
+            "username": fauxfactory.gen_alpha(start="usr_"),
+            "password": fauxfactory.gen_alpha(start="pwd_"),
+            "subscription_id": fauxfactory.gen_alpha(15, start="sub_id_"),
+            "tenant_id": fauxfactory.gen_alpha(15, start="tenant_id_"),
+            "client_secret": fauxfactory.gen_alpha(15, start="secret_"),
+            "client_id": fauxfactory.gen_alpha(15, start="client_id_"),
         },
     ),
 ]
@@ -142,7 +148,7 @@ def test_embedded_ansible_repository_crud(ansible_repository, wait_for_ansible):
         initialEstimate: 1/12h
         tags: ansible_embed
     """
-    updated_description = "edited_{}".format(fauxfactory.gen_alpha())
+    updated_description = fauxfactory.gen_alpha(15, start="edited_")
     with update(ansible_repository):
         ansible_repository.description = updated_description
     view = navigate_to(ansible_repository, "Edit")
@@ -168,9 +174,9 @@ def test_embedded_ansible_repository_branch_crud(appliance, request, wait_for_an
         playbooks_yaml = cfme_data.ansible_links.playbook_repositories
         playbook_name = getattr(request, 'param', 'embedded_ansible')
         repository = repositories.create(
-            name=fauxfactory.gen_alpha(),
+            name=fauxfactory.gen_alpha(start="repo"),
             url=getattr(playbooks_yaml, playbook_name),
-            description=fauxfactory.gen_alpha(),
+            description=fauxfactory.gen_alpha(15, start="repo_desc_"),
             scm_branch="second_playbook_branch"
         )
     except (KeyError, AttributeError):
@@ -201,9 +207,9 @@ def test_embedded_ansible_repository_invalid_url_crud(request, appliance, wait_f
     """
     repositories = appliance.collections.ansible_repositories
     repository = repositories.create(
-        name=fauxfactory.gen_alpha(),
+        name=fauxfactory.gen_alpha(start="repo_"),
         url='https://github.com/sbulage/invalid_repo_url.git',
-        description=fauxfactory.gen_alpha())
+        description=fauxfactory.gen_alpha(15, start="repo_desc_"))
     view = navigate_to(repository, "Details")
     assert (
         view.entities.summary("Properties").get_text_of("Status") == "failed"
@@ -233,7 +239,7 @@ def test_embedded_ansible_credential_crud(credentials_collection, wait_for_ansib
         credential_type,
         **credentials
     )
-    updated_value = "edited_{}".format(fauxfactory.gen_alpha())
+    updated_value = fauxfactory.gen_alpha(15, start="edited_")
     with update(credential):
         if credential.credential_type == "Google Compute Engine":
             credential.service_account = updated_value
@@ -280,9 +286,9 @@ def test_embed_tower_playbooks_list_changed(appliance, wait_for_ansible):
     repositories_collection = appliance.collections.ansible_repositories
     for repo_url in REPOSITORIES:
         repository = repositories_collection.create(
-            fauxfactory.gen_alpha(),
+            fauxfactory.gen_alpha(start="repo_"),
             repo_url,
-            description=fauxfactory.gen_alpha()
+            description=fauxfactory.gen_alpha(15, start="repo_desc_")
         )
         playbooks.append(set(playbook.name for playbook in repository.playbooks.all()))
         repository.delete()
@@ -300,7 +306,7 @@ def test_control_crud_ansible_playbook_action(
         initialEstimate: 1/12h
     """
     action = action_collection.create(
-        fauxfactory.gen_alphanumeric(),
+        fauxfactory.gen_alphanumeric(15, start="action_"),
         action_type="Run Ansible Playbook",
         action_values={
             "run_ansible_playbook": {
@@ -319,7 +325,7 @@ def test_control_crud_ansible_playbook_action(
 
     with update(action):
         ipaddr = fauxfactory.gen_ipaddr()
-        new_descr = "edited_{}".format(fauxfactory.gen_alphanumeric())
+        new_descr = fauxfactory.gen_alphanumeric(15, start="edited_")
         action.description = new_descr
         action.run_ansible_playbook = {
             "inventory": {
@@ -345,7 +351,7 @@ def test_control_add_ansible_playbook_action_invalid_address(
         initialEstimate: 1/12h
     """
     action = action_collection.create(
-        fauxfactory.gen_alphanumeric(),
+        fauxfactory.gen_alphanumeric(15, start="action_"),
         action_type="Run Ansible Playbook",
         action_values={
             "run_ansible_playbook": {
@@ -390,10 +396,10 @@ def test_embedded_ansible_credential_with_private_key(request, wait_for_ansible,
         tags: ansible_embed
     """
     credential = credentials_collection.create(
-        fauxfactory.gen_alpha(),
+        fauxfactory.gen_alpha(start="cred_"),
         "Machine",
-        username=fauxfactory.gen_alpha(),
-        password=fauxfactory.gen_alpha(),
+        username=fauxfactory.gen_alpha(start="usr_"),
+        password=fauxfactory.gen_alpha(start="pwd_"),
         private_key=private_key,
     )
     request.addfinalizer(credential.delete)

--- a/cfme/tests/ansible/test_embedded_ansible_rest.py
+++ b/cfme/tests/ansible/test_embedded_ansible_rest.py
@@ -31,7 +31,7 @@ def ansible(appliance):
 def repository(appliance, ansible):
     collection = appliance.rest_api.collections.configuration_script_sources
     uniq = fauxfactory.gen_alphanumeric(5)
-    repo_name = "test_repo_{}".format(uniq)
+    repo_name = f"test_repo_{uniq}"
     data = {
         "name": repo_name,
         "description": "Test Repo {}".format(uniq),
@@ -74,7 +74,7 @@ class TestReposRESTAPI(object):
             initialEstimate: 1/4h
             endsin: 5.10
         """
-        new_description = "Test Repository {}".format(fauxfactory.gen_alphanumeric(5))
+        new_description = fauxfactory.gen_alphanumeric(21, start="Test Repository ")
 
         if from_collection:
             repository.reload()

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -90,7 +90,7 @@ def ansible_linked_vm_action(appliance, local_ansible_catalog_item, new_vm):
     }
 
     action = appliance.collections.actions.create(
-        fauxfactory.gen_alphanumeric(),
+        fauxfactory.gen_alphanumeric(15, start="action_"),
         action_type="Run Ansible Playbook",
         action_values=action_values,
     )
@@ -117,14 +117,14 @@ def new_vm(provider, big_template):
 def ansible_policy_linked_vm(appliance, new_vm, ansible_linked_vm_action):
     policy = appliance.collections.policies.create(
         VMControlPolicy,
-        fauxfactory.gen_alpha(),
+        fauxfactory.gen_alpha(15, start="policy_"),
         scope="fill_field(VM and Instance : Name, INCLUDES, {})".format(new_vm.name),
     )
     policy.assign_actions_to_event(
         "Tag Complete", [ansible_linked_vm_action.description]
     )
     policy_profile = appliance.collections.policy_profiles.create(
-        fauxfactory.gen_alpha(), policies=[policy]
+        fauxfactory.gen_alpha(15, start="profile_"), policies=[policy]
     )
     new_vm.assign_policy_profiles(policy_profile.description)
     yield
@@ -167,10 +167,10 @@ def provider_credentials(appliance, provider, credential):
 @pytest.fixture(scope="module")
 def ansible_credential(appliance):
     credential = appliance.collections.ansible_credentials.create(
-        fauxfactory.gen_alpha(),
+        fauxfactory.gen_alpha(start="cred_"),
         "Machine",
-        username=fauxfactory.gen_alpha(),
-        password=fauxfactory.gen_alpha(),
+        username=fauxfactory.gen_alpha(start="usr_"),
+        password=fauxfactory.gen_alpha(start="pwd_"),
     )
     yield credential
 
@@ -180,12 +180,12 @@ def ansible_credential(appliance):
 @pytest.fixture
 def custom_service_button(appliance, local_ansible_catalog_item):
     buttongroup = appliance.collections.button_groups.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover="btn_desc_{}".format(fauxfactory.gen_alphanumeric()),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=appliance.collections.button_groups.SERVICE)
     button = buttongroup.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover="btn_hvr_{}".format(fauxfactory.gen_alphanumeric()),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         dialog=local_ansible_catalog_item.provisioning["provisioning_dialog_name"],
         system="Request",
         request="Order_Ansible_Playbook",
@@ -221,19 +221,19 @@ def test_service_ansible_playbook_crud(appliance, ansible_repository):
     """
     cat_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_PLAYBOOK,
-        fauxfactory.gen_alphanumeric(),
-        fauxfactory.gen_alphanumeric(),
+        fauxfactory.gen_alphanumeric(15, "cat_item"),
+        fauxfactory.gen_alphanumeric(15, "item_disc_"),
         provisioning={
             "repository": ansible_repository.name,
             "playbook": "dump_all_variables.yml",
             "machine_credential": "CFME Default Credential",
             "create_new": True,
-            "provisioning_dialog_name": fauxfactory.gen_alphanumeric(),
+            "provisioning_dialog_name": fauxfactory.gen_alphanumeric(12, start="dialog_"),
         }
     )
     assert cat_item.exists
     with update(cat_item):
-        new_name = "edited_{}".format(fauxfactory.gen_alphanumeric())
+        new_name = fauxfactory.gen_alphanumeric(15, start="edited_")
         cat_item.name = new_name
         cat_item.provisioning = {
             "playbook": "copy_file_example.yml"
@@ -402,8 +402,8 @@ def test_service_ansible_retirement_remove_resources(
     """
     cat_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ANSIBLE_PLAYBOOK,
-        fauxfactory.gen_alphanumeric(),
-        fauxfactory.gen_alphanumeric(),
+        fauxfactory.gen_alphanumeric(15, start="cat_item_"),
+        fauxfactory.gen_alphanumeric(15, start="item_desc_"),
         provisioning={
             "repository": ansible_repository.name,
             "playbook": "dump_all_variables.yml",
@@ -858,7 +858,7 @@ def test_ansible_service_order_vault_credentials(
     creds = conf.credentials['vault_creds']['password']
     creds_dict = {"vault_password": creds}
     vault_creds = appliance.collections.ansible_credentials.create(
-        "Vault_Credentials_{}".format(fauxfactory.gen_alpha()), "Vault", **creds_dict
+        fauxfactory.gen_alpha(22, start="Vault_Credentials_"), "Vault", **creds_dict
     )
 
     with update(local_ansible_catalog_item):

--- a/cfme/tests/ansible/test_embedded_ansible_tags.py
+++ b/cfme/tests/ansible/test_embedded_ansible_tags.py
@@ -17,10 +17,10 @@ pytestmark = [
 def credential(wait_for_ansible, appliance):
     credentials_collection = appliance.collections.ansible_credentials
     _credential = credentials_collection.create(
-        "{}_credential_{}".format('Machine', fauxfactory.gen_alpha()),
+        fauxfactory.gen_alpha(18, start="Machine_Cred_"),
         'Machine',
-        username=fauxfactory.gen_alpha(),
-        password=fauxfactory.gen_alpha()
+        username=fauxfactory.gen_alpha(start="usr_"),
+        password=fauxfactory.gen_alpha(start="pwd_")
     )
     wait_for(
         func=lambda: _credential.exists,

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -225,8 +225,8 @@ def test_button_avp_displayed(appliance, dialog, request):
     """
     # This is optional, our nav tree does not have unassigned button
     buttongroup = appliance.collections.button_groups.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover="btn_desc_{}".format(fauxfactory.gen_alphanumeric()),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=appliance.collections.button_groups.VM_INSTANCE,
     )
     request.addfinalizer(buttongroup.delete_if_exists)
@@ -434,8 +434,8 @@ def test_custom_button_simulation(request, appliance, provider, setup_provider, 
     )
 
     button = gp.buttons.create(
-        text="Btn_{}".format(fauxfactory.gen_alphanumeric(2)),
-        hover="Hover_{}".format(fauxfactory.gen_alphanumeric(2)),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         system="Request",
         request="InspectMe",
     )
@@ -501,8 +501,8 @@ def test_custom_button_order_sort(appliance, request, provider, setup_provider, 
     buttons = []
     for ind in range(0, 4):
         button = unassigned_gp.buttons.create(
-            text="button_{n}_{f}".format(n=str(ind), f=fauxfactory.gen_alphanumeric(2)),
-            hover="hover_{n}_{f}".format(n=str(ind), f=fauxfactory.gen_alphanumeric(2)),
+            text=fauxfactory.gen_alphanumeric(start=f"btn_{ind}_"),
+            hover=fauxfactory.gen_alphanumeric(15, start=f"btn_hvr_{ind}_"),
             system="Request",
             request="InspectMe",
         )
@@ -516,8 +516,8 @@ def test_custom_button_order_sort(appliance, request, provider, setup_provider, 
     unassigned_buttons = [btn.text for btn in buttons]
 
     group = appliance.collections.button_groups.create(
-        text="group_{}".format(fauxfactory.gen_alphanumeric(3)),
-        hover="hover_{}".format(fauxfactory.gen_alphanumeric(3)),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=btn_type,
         assign_buttons=unassigned_buttons,
     )
@@ -562,8 +562,8 @@ def test_custom_button_role_selection(appliance, request):
         text="[Unassigned Buttons]", hover="Unassigned Buttons", type="Provider"
     )
     btn = unassigned_gp.buttons.create(
-        text="group_{}".format(fauxfactory.gen_alphanumeric(3)),
-        hover="hover_{}".format(fauxfactory.gen_alphanumeric(3)),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         system="Request",
         request="InspectMe",
         roles=test_roles,
@@ -648,7 +648,7 @@ def test_attribute_override(appliance, request, provider, setup_provider, obj_ty
     ]
 
     button = button_group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(start="btn"),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
         hover=fauxfactory.gen_alphanumeric(start="hvr_"),
         system="Request",
         request=req,

--- a/cfme/tests/automate/custom_button/test_catalog_custom_button.py
+++ b/cfme/tests/automate/custom_button/test_catalog_custom_button.py
@@ -35,8 +35,8 @@ def test_custom_group_on_catalog_item_crud(generic_catalog_item):
     """
 
     btn_data = {
-        "text": "button_{}".format(gen_numeric_string(3)),
-        "hover": "hover_{}".format(gen_numeric_string(3)),
+        "text": gen_numeric_string(start="btn_"),
+        "hover": gen_numeric_string(15, start="btn_hvr_"),
         "image": "fa-user",
     }
 
@@ -70,8 +70,8 @@ def test_custom_button_on_catalog_item_crud(generic_catalog_item):
         1687289
     """
     btn_data = {
-        "text": "button_{}".format(gen_numeric_string(3)),
-        "hover": "hover_{}".format(gen_numeric_string(3)),
+        "text": gen_numeric_string(start="btn_"),
+        "hover": gen_numeric_string(15, start="btn_hvr_"),
         "image": "fa-user",
     }
 
@@ -108,8 +108,8 @@ def test_custom_button_unassigned_behavior_catalog_level(appliance, generic_serv
     service, catalog_item = generic_service
 
     btn_data = {
-        "text": "button_{}".format(gen_numeric_string(3)),
-        "hover": "hover_{}".format(gen_numeric_string(3)),
+        "text": gen_numeric_string(start="btn_"),
+        "hover": gen_numeric_string(15, start="btn_hvr_"),
         "image": "fa-user",
     }
 

--- a/cfme/tests/automate/custom_button/test_cloud_objects.py
+++ b/cfme/tests/automate/custom_button/test_cloud_objects.py
@@ -50,8 +50,8 @@ SUBMIT = ["Submit all", "One by one"]
 def button_group(appliance, request):
     collection = appliance.collections.button_groups
     button_gp = collection.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=getattr(collection, request.param),
     )
     yield button_gp, request.param
@@ -128,8 +128,8 @@ def test_custom_button_display_cloud_obj(appliance, request, display, setup_objs
 
     group, obj_type = button_group
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for=display,
         system="Request",
         request="InspectMe",
@@ -181,8 +181,8 @@ def test_custom_button_dialog_cloud_obj(appliance, dialog, request, setup_objs, 
 
     # Note: No need to set display_for dialog only work with Single entity
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         dialog=dialog,
         system="Request",
         request="InspectMe",
@@ -254,8 +254,8 @@ def test_custom_button_automate_cloud_obj(appliance, request, submit, setup_objs
 
     group, obj_type = button_group
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for="Single and list",
         submit=submit,
         system="Request",
@@ -346,8 +346,8 @@ def test_custom_button_expression_cloud_obj(
     exp = {expression: {"tag": "My Company Tags : Department", "value": "Engineering"}}
     disabled_txt = "Tag - My Company Tags : Department : Engineering"
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for="Single entity",
         system="Request",
         request="InspectMe",
@@ -418,8 +418,8 @@ def test_custom_button_events_cloud_obj(request, dialog, setup_objs, button_grou
     dialog_ = dialog if btn_dialog else None
 
     button = group.buttons.create(
-        text="btn_{}".format(fauxfactory.gen_alphanumeric(3)),
-        hover="btn_hover{}".format(fauxfactory.gen_alphanumeric(3)),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         dialog=dialog_,
         system="Request",
         request="InspectMe",

--- a/cfme/tests/automate/custom_button/test_container_objects.py
+++ b/cfme/tests/automate/custom_button/test_container_objects.py
@@ -45,8 +45,8 @@ DISPLAY_NAV = {
 def button_group(appliance, request):
     collection = appliance.collections.button_groups
     button_gp = collection.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=getattr(collection, request.param),
     )
     yield button_gp, request.param
@@ -101,8 +101,8 @@ def test_custom_button_display_container_obj(request, display, setup_obj, button
 
     group, obj_type = button_group
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_grp_"),
         display_for=display,
         system="Request",
         request="InspectMe",
@@ -150,8 +150,8 @@ def test_custom_button_dialog_container_obj(appliance, dialog, request, setup_ob
 
     # Note: No need to set display_for dialog only work with Single entity
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         dialog=dialog,
         system="Request",
         request="InspectMe",
@@ -217,8 +217,8 @@ def test_custom_button_expression_container_obj(
     exp = {expression: {"tag": "My Company Tags : Department", "value": "Engineering"}}
     disabled_txt = "Tag - My Company Tags : Department : Engineering"
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for="Single entity",
         system="Request",
         request="InspectMe",

--- a/cfme/tests/automate/custom_button/test_generic_objects.py
+++ b/cfme/tests/automate/custom_button/test_generic_objects.py
@@ -32,8 +32,8 @@ SUBMIT = ["Submit all", "One by one"]
 def button_group(appliance, request):
     collection = appliance.collections.button_groups
     button_gp = collection.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=getattr(collection, request.param),
     )
     yield button_gp, request.param
@@ -109,8 +109,8 @@ def test_custom_button_display_evm_obj(request, display, setup_obj, button_group
 
     group, obj_type = button_group
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for=display,
         system="Request",
         request="InspectMe",
@@ -156,8 +156,8 @@ def test_custom_button_automate_evm_obj(appliance, request, submit, setup_obj, b
 
     group, obj_type = button_group
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for="Single and list",
         submit=submit,
         system="Request",
@@ -233,8 +233,8 @@ def test_custom_button_dialog_evm_obj(appliance, dialog, request, setup_obj, but
 
     # Note: No need to set display_for dialog only work with Single entity
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         dialog=dialog,
         system="Request",
         request="InspectMe",
@@ -299,8 +299,8 @@ def test_custom_button_expression_evm_obj(appliance, request, setup_obj, button_
     disabled_txt = "Tag - My Company Tags : Department : Engineering"
 
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for="Single entity",
         system="Request",
         request="InspectMe",

--- a/cfme/tests/automate/custom_button/test_import_export.py
+++ b/cfme/tests/automate/custom_button/test_import_export.py
@@ -23,14 +23,14 @@ def setup_groups_buttons(appliance, provider):
 
     for obj_type in ["PROVIDER", "VM_INSTANCE"]:
         gp = collection.create(
-            text=fauxfactory.gen_alphanumeric(),
-            hover=fauxfactory.gen_alphanumeric(),
+            text=fauxfactory.gen_alphanumeric(start="grp_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
             type=getattr(collection, obj_type, None),
         )
 
         button = gp.buttons.create(
-            text=fauxfactory.gen_alphanumeric(),
-            hover=fauxfactory.gen_alphanumeric(),
+            text=fauxfactory.gen_alphanumeric(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
             display_for="Single and list",
             system="Request",
             request="InspectMe",

--- a/cfme/tests/automate/custom_button/test_infra_objects.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects.py
@@ -45,7 +45,7 @@ SUBMIT = ["Submit all", "One by one"]
 @pytest.fixture(scope="module")
 def cls(appliance):
     domain = appliance.collections.domains.create(
-        name="domain_{}".format(fauxfactory.gen_alphanumeric(4)), enabled=True
+        name=fauxfactory.gen_alphanumeric(12, start="domain_"), enabled=True
     )
     original_class = (
         domain.parent.instantiate(name="ManageIQ")
@@ -61,7 +61,7 @@ def cls(appliance):
 @pytest.fixture(scope="module")
 def method(cls):
     meth = cls.methods.create(
-        name="meth_{}".format(fauxfactory.gen_alphanumeric(4)),
+        name=fauxfactory.gen_alphanumeric(start="meth_"),
         script=dedent(
             """
             # add google url to open
@@ -73,7 +73,7 @@ def method(cls):
     )
 
     instance = cls.instances.create(
-        name="inst_{}".format(fauxfactory.gen_alphanumeric(4)),
+        name=fauxfactory.gen_alphanumeric(start="inst_"),
         fields={"meth1": {"value": meth.name}},
     )
     yield instance
@@ -87,8 +87,8 @@ def method(cls):
 def button_group(appliance, request):
     collection = appliance.collections.button_groups
     button_gp = collection.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=getattr(collection, request.param),
     )
     yield button_gp, request.param
@@ -145,8 +145,8 @@ def test_custom_button_display_infra_obj(request, display, setup_obj, button_gro
 
     group, obj_type = button_group
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for=display,
         system="Request",
         request="InspectMe",
@@ -200,8 +200,8 @@ def test_custom_button_automate_infra_obj(appliance, request, submit, setup_obj,
 
     group, obj_type = button_group
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for="Single and list",
         submit=submit,
         system="Request",
@@ -305,8 +305,8 @@ def test_custom_button_dialog_infra_obj(appliance, dialog, request, setup_obj, b
 
     # Note: No need to set display_for dialog only work with Single entity
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         dialog=dialog,
         system="Request",
         request="InspectMe",
@@ -378,8 +378,8 @@ def test_custom_button_expression_infra_obj(
     exp = {expression: {"tag": "My Company Tags : Department", "value": "Engineering"}}
     disabled_txt = "Tag - My Company Tags : Department : Engineering"
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         display_for="Single entity",
         system="Request",
         request="InspectMe",
@@ -449,8 +449,8 @@ def test_custom_button_open_url_infra_obj(request, setup_obj, button_group, meth
 
     group, obj_type = button_group
     button = group.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         open_url=True,
         display_for="Single entity",
         system="Request",
@@ -521,8 +521,8 @@ def test_custom_button_events_infra_obj(request, dialog, setup_obj, button_group
     dialog_ = dialog if btn_dialog else None
 
     button = group.buttons.create(
-        text="btn_{}".format(fauxfactory.gen_alphanumeric(3)),
-        hover="btn_hover{}".format(fauxfactory.gen_alphanumeric(3)),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         dialog=dialog_,
         system="Request",
         request="InspectMe",

--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -63,8 +63,8 @@ def button_group(appliance, request):
     with appliance.context.use(ViaUI):
         collection = appliance.collections.button_groups
         button_gp = collection.create(
-            text=fauxfactory.gen_alphanumeric(),
-            hover=fauxfactory.gen_alphanumeric(),
+            text=fauxfactory.gen_alphanumeric(start="grp_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
             type=getattr(collection, request.param),
         )
         yield button_gp, request.param
@@ -77,15 +77,15 @@ def serv_button_group(appliance, request):
     with appliance.context.use(ViaUI):
         collection = appliance.collections.button_groups
         button_gp = collection.create(
-            text="group_{}".format(fauxfactory.gen_numeric_string(3)),
-            hover="hover_{}".format(fauxfactory.gen_alphanumeric(3)),
+            text=fauxfactory.gen_numeric_string(start="grp_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
             display=TEXT_DISPLAY[request.param]["group_display"],
             type=getattr(collection, "SERVICE"),
         )
 
         button = button_gp.buttons.create(
-            text="btn_{}".format(fauxfactory.gen_numeric_string(3)),
-            hover="hover_{}".format(fauxfactory.gen_alphanumeric(3)),
+            text=fauxfactory.gen_numeric_string(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
             display=TEXT_DISPLAY[request.param]["btn_display"],
             display_for="Single and list",
             system="Request",
@@ -142,7 +142,7 @@ def user_self_service_role(appliance):
 
         # credentials for user
         creds = Credential(
-            principal=format(fauxfactory.gen_alphanumeric(start="usr_")),
+            principal=fauxfactory.gen_alphanumeric(start="usr_"),
             secret=fauxfactory.gen_alphanumeric(),
         )
 
@@ -213,8 +213,8 @@ def test_custom_button_display_service_obj(
 
     with appliance.context.use(ViaUI):
         button = group.buttons.create(
-            text=fauxfactory.gen_alphanumeric(),
-            hover=fauxfactory.gen_alphanumeric(),
+            text=fauxfactory.gen_alphanumeric(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(start="btn_hvr_"),
             display_for=display,
             system="Request",
             request="InspectMe",
@@ -269,8 +269,8 @@ def test_custom_button_automate_service_obj(
     group, obj_type = button_group
     with appliance.context.use(ViaUI):
         button = group.buttons.create(
-            text=fauxfactory.gen_alphanumeric(),
-            hover=fauxfactory.gen_alphanumeric(),
+            text=fauxfactory.gen_alphanumeric(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
             display_for="Single and list",
             submit=submit,
             system="Request",
@@ -408,8 +408,8 @@ def vis_enb_button(request, appliance, button_group):
 
     with appliance.context.use(ViaUI):
         button = group.buttons.create(
-            text=fauxfactory.gen_alphanumeric(),
-            hover=fauxfactory.gen_alphanumeric(),
+            text=fauxfactory.gen_alphanumeric(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
             display_for="Single entity",
             system="Request",
             request="InspectMe",
@@ -689,8 +689,8 @@ def test_custom_button_dialog_service_obj(
     group, obj_type = button_group
     with appliance.context.use(ViaUI):
         button = group.buttons.create(
-            text="btn_{}".format(fauxfactory.gen_alphanumeric(3)),
-            hover="btn_hover_{}".format(fauxfactory.gen_alphanumeric(3)),
+            text=fauxfactory.gen_alphanumeric(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
             dialog=dialog,
             system="Request",
             request="InspectMe",
@@ -815,8 +815,8 @@ def test_custom_button_unassigned_behavior_objs(
 
     with appliance.context.use(ViaUI):
         button = gp.buttons.create(
-            text="btn_{}".format(fauxfactory.gen_alphanumeric(3)),
-            hover="btn_hover_{}".format(fauxfactory.gen_alphanumeric(3)),
+            text=fauxfactory.gen_alphanumeric(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
             system="Request",
             request="InspectMe",
         )

--- a/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
+++ b/cfme/tests/automate/custom_button/test_service_vm_custom_button.py
@@ -32,8 +32,8 @@ pytestmark = [
 def button_group(appliance):
     collection = appliance.collections.button_groups
     button_gp = collection.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=getattr(collection, "VM_INSTANCE"),
     )
     yield button_gp
@@ -56,14 +56,14 @@ def setup_dynamic_dialog(appliance, custom_instance):
 
     # Create dynamic dialog
     service_dialog = appliance.collections.service_dialogs
-    dialog = "dialog_{}".format(fauxfactory.gen_alphanumeric())
-    ele_name = "ele_{}".format(fauxfactory.gen_alphanumeric())
+    dialog = fauxfactory.gen_alphanumeric(12, start="dialog_")
+    ele_name = fauxfactory.gen_alphanumeric(start="ele_")
 
     element_data = {
         "element_information": {
-            "ele_label": "ele_{}".format(fauxfactory.gen_alphanumeric()),
+            "ele_label": fauxfactory.gen_alphanumeric(15, start="ele_label_"),
             "ele_name": ele_name,
-            "ele_desc": fauxfactory.gen_alphanumeric(),
+            "ele_desc": fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             "dynamic_chkbox": True,
             "choose_type": "Dropdown",
         },
@@ -71,10 +71,10 @@ def setup_dynamic_dialog(appliance, custom_instance):
     }
     sd = service_dialog.create(label=dialog, description="my dialog")
     tab = sd.tabs.create(
-        tab_label="tab_{}".format(fauxfactory.gen_alphanumeric()), tab_desc="my tab desc"
+        tab_label=fauxfactory.gen_alphanumeric(start="tab_"), tab_desc="my tab desc"
     )
     box = tab.boxes.create(
-        box_label="box_{}".format(fauxfactory.gen_alphanumeric()), box_desc="my box desc"
+        box_label=fauxfactory.gen_alphanumeric(start="box_"), box_desc="my box desc"
     )
     box.elements.create(element_data=[element_data])
 
@@ -113,8 +113,8 @@ def test_custom_button_display_service_vm(request, appliance, service_vm, button
     service, _ = service_vm
     with appliance.context.use(ViaUI):
         button = button_group.buttons.create(
-            text=fauxfactory.gen_alphanumeric(),
-            hover=fauxfactory.gen_alphanumeric(),
+            text=fauxfactory.gen_alphanumeric(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
             system="Request",
             request="InspectMe",
         )
@@ -183,16 +183,16 @@ def test_custom_button_with_dynamic_dialog_vm(
     # Create button group
     collection = appliance.collections.button_groups
     button_gp = collection.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="grp_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
         type=getattr(collection, "VM_INSTANCE"),
     )
     request.addfinalizer(button_gp.delete_if_exists)
 
     # Create custom button under group
     button = button_gp.buttons.create(
-        text=fauxfactory.gen_alphanumeric(),
-        hover=fauxfactory.gen_alphanumeric(),
+        text=fauxfactory.gen_alphanumeric(start="btn_"),
+        hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
         dialog=dialog.label,
         system="Request",
         request="InspectMe",
@@ -254,8 +254,8 @@ def test_custom_button_automate_service_vm(request, appliance, service_vm, butto
     service, _ = service_vm
     with appliance.context.use(ViaUI):
         button = button_group.buttons.create(
-            text=fauxfactory.gen_alphanumeric(),
-            hover=fauxfactory.gen_alphanumeric(),
+            text=fauxfactory.gen_alphanumeric(start="btn_"),
+            hover=fauxfactory.gen_alphanumeric(15, start="btn_hvr_"),
             system="Request",
             request="InspectMe",
         )

--- a/cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py
+++ b/cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py
@@ -26,8 +26,8 @@ def generic_object_button(appliance, generic_object_button_group, generic_defini
             button_parent = (
                 generic_object_button_group(button_group) if button_group else generic_definition
             )
-            button_name = 'button_{}'.format(fauxfactory.gen_alphanumeric())
-            button_desc = 'Button_description_{}'.format(fauxfactory.gen_alphanumeric())
+            button_name = fauxfactory.gen_alphanumeric(12, start="button_")
+            button_desc = fauxfactory.gen_alphanumeric(23, start="Button_description_")
             generic_object_button = button_parent.collections.generic_object_buttons.create(
                 name=button_name,
                 description=button_desc,
@@ -45,8 +45,8 @@ def generic_object_button_group(appliance, generic_definition):
     def _generic_object_button_group(create_action=True):
         if create_action:
             with appliance.context.use(ViaUI):
-                group_name = "button_group_{}".format(fauxfactory.gen_alphanumeric())
-                group_desc = "Group_button_description_{}".format(fauxfactory.gen_alphanumeric())
+                group_name = fauxfactory.gen_alphanumeric(15, start="button_group_")
+                group_desc = fauxfactory.gen_alphanumeric(28, start="Group_button_description_")
                 groups_buttons = generic_definition.collections.generic_object_groups_buttons
                 generic_object_button_group = groups_buttons.create(
                     name=group_name, description=group_desc, image="fa-user"

--- a/cfme/tests/automate/generic_objects/test_definitions.py
+++ b/cfme/tests/automate/generic_objects/test_definitions.py
@@ -20,7 +20,7 @@ GEN_OBJ_DIRECTORY = "/var/www/miq/vmdb/tmp/generic_object_definitions"
 def gen_obj_def_import_export(appliance):
     with appliance.context.use(ViaREST):
         definition = appliance.collections.generic_object_definitions.create(
-            name="rest_gen_class_imp_exp{}".format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(28, start="rest_gen_class_imp_exp_"),
             description="Generic Object Definition",
             attributes={'addr01': 'string'},
             methods=['add_vm', 'remove_vm']

--- a/cfme/tests/automate/generic_objects/test_instances.py
+++ b/cfme/tests/automate/generic_objects/test_instances.py
@@ -35,8 +35,8 @@ def button_with_dialog(appliance, generic_object, dialog):
     generic_definition = generic_object.definition
     with appliance.context.use(ViaUI):
         button = generic_definition.collections.generic_object_buttons.create(
-            name=fauxfactory.gen_alpha(),
-            description=fauxfactory.gen_alpha(),
+            name=fauxfactory.gen_alpha(start="btn_"),
+            description=fauxfactory.gen_alpha(15, start="btn_desc_"),
             request="call_instance",
             image="ff ff-network-interface",
             dialog=dialog.label
@@ -59,7 +59,7 @@ def test_generic_objects_crud(appliance, context, request):
     """
     with appliance.context.use(context):
         definition = appliance.collections.generic_object_definitions.create(
-            name='rest_generic_class{}'.format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(25, start="rest_generic_class_"),
             description='Generic Object Definition',
             attributes={'addr01': 'string'},
             associations={'services': 'Service'}
@@ -70,7 +70,7 @@ def test_generic_objects_crud(appliance, context, request):
     with appliance.context.use(ViaREST):
         myservices = []
         for _ in range(2):
-            service_name = 'rest_service_{}'.format(fauxfactory.gen_alphanumeric())
+            service_name = fauxfactory.gen_alphanumeric(15, start="rest_serv_")
             rest_service = appliance.rest_api.collections.services.action.create(
                 name=service_name,
                 display=True
@@ -79,7 +79,7 @@ def test_generic_objects_crud(appliance, context, request):
             request.addfinalizer(rest_service.action.delete)
             myservices.append(MyService(appliance, name=service_name))
         instance = appliance.collections.generic_objects.create(
-            name='rest_generic_instance{}'.format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(26, start="rest_generic_instance_"),
             definition=definition,
             attributes={'addr01': 'Test Address'},
             associations={'services': [myservices[0]]}

--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -91,14 +91,14 @@ def test_vm_retire_extend(appliance, request, testing_vm, soft_assert):
                 .format(set_date, retirement_date.strftime(vm_retire_date_fmt)))
 
     # Create the vm_retire_extend button and click on it
-    grp_name = "grp_{}".format(fauxfactory.gen_alphanumeric())
+    grp_name = fauxfactory.gen_alphanumeric(start="grp_")
     grp = appliance.collections.button_groups.create(
         text=grp_name,
         hover=grp_name,
         type=appliance.collections.button_groups.VM_INSTANCE
     )
     request.addfinalizer(lambda: grp.delete_if_exists())
-    btn_name = "btn_{}".format(fauxfactory.gen_alphanumeric())
+    btn_name = fauxfactory.gen_alphanumeric(start="btn_")
     button = grp.buttons.create(
         text=btn_name,
         hover=btn_name,

--- a/cfme/tests/automate/test_domain.py
+++ b/cfme/tests/automate/test_domain.py
@@ -44,7 +44,7 @@ def test_domain_crud(request, enabled, appliance):
         assert 'Disabled' not in view.title.text
     else:
         assert 'Disabled' in view.title.text
-    updated_description = "editdescription{}".format(fauxfactory.gen_alpha())
+    updated_description = fauxfactory.gen_alpha(20, start="editdescription_")
     with update(domain):
         domain.description = updated_description
     view = navigate_to(domain, 'Edit')

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -35,9 +35,9 @@ def new_user(appliance):
     """This fixture creates new user which assigned with non-super group"""
     group = appliance.collections.groups.instantiate(description='EvmGroup-administrator')
     user = appliance.collections.users.create(
-        name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
-        credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
-                              secret='{password}'.format(password=fauxfactory.gen_alphanumeric(4))),
+        name=fauxfactory.gen_alphanumeric(start="user_").lower(),
+        credential=Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
+                              secret=fauxfactory.gen_alphanumeric(start="pwd")),
         email=fauxfactory.gen_email(),
         groups=[group],
         cost_center="Workload",

--- a/cfme/tests/automate/test_method.py
+++ b/cfme/tests/automate/test_method.py
@@ -360,7 +360,7 @@ def generic_object_definition(appliance):
     # Creating generic object using REST
     with appliance.context.use(ViaREST):
         definition = appliance.collections.generic_object_definitions.create(
-            name="LoadBalancer_{}".format(fauxfactory.gen_numeric_string(3)),
+            name=fauxfactory.gen_numeric_string(18, start="LoadBalancer_"),
             description="LoadBalancer",
             attributes={"location": "string"},
             associations={"vms": "Vm", "services": "Service"}

--- a/cfme/tests/automate/test_namespace.py
+++ b/cfme/tests/automate/test_namespace.py
@@ -38,7 +38,7 @@ def test_namespace_crud(parent_namespace):
         name=fauxfactory.gen_alpha(),
         description=fauxfactory.gen_alpha())
     assert ns.exists
-    updated_description = "editdescription{}".format(fauxfactory.gen_alpha())
+    updated_description = fauxfactory.gen_alpha(20, start="editdescription_")
     with update(ns):
         ns.description = updated_description
     assert ns.exists

--- a/cfme/tests/automate/test_provisioning_dialogs.py
+++ b/cfme/tests/automate/test_provisioning_dialogs.py
@@ -23,8 +23,8 @@ def test_provisioning_dialog_crud(appliance):
     # CREATE
     collection = appliance.collections.provisioning_dialogs
     dialog = collection.create(
-        name='test-{}'.format(fauxfactory.gen_alphanumeric(length=5)),
-        description='test-{}'.format(fauxfactory.gen_alphanumeric(length=5)),
+        name=fauxfactory.gen_alphanumeric(start="dialog_"),
+        description=fauxfactory.gen_alphanumeric(15, start="dialog_desc_"),
         diag_type=collection.VM_PROVISION)
     assert dialog.exists
 

--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -24,14 +24,14 @@ pytestmark = [test_requirements.automate]
 def new_users(appliance):
     """This fixture creates new users"""
     users = [appliance.collections.users.create(
-        name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
-        credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
+        name=fauxfactory.gen_alphanumeric(start="user_").lower(),
+        credential=Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
                               secret=fauxfactory.gen_alphanumeric(4)),
         email=fauxfactory.gen_email(),
         groups=appliance.collections.groups.instantiate(description="EvmGroup-super_administrator"),
         cost_center="Workload",
         value_assign="Database",
-    ) for i in range(2)]
+    ) for _ in range(2)]
 
     yield users
     for user in users:
@@ -160,9 +160,9 @@ def setup_dynamic_dialog(appliance, custom_instance):
     # Create dynamic dialog
     element_data = {
         "element_information": {
-            "ele_label": fauxfactory.gen_alphanumeric(start="ele_"),
-            "ele_name": fauxfactory.gen_alphanumeric(start="ele_"),
-            "ele_desc": fauxfactory.gen_alphanumeric(),
+            "ele_label": fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            "ele_name": fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            "ele_desc": fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             "dynamic_chkbox": True,
             "choose_type": "Text Box",
         },

--- a/cfme/tests/automate/test_service_dialog.py
+++ b/cfme/tests/automate/test_service_dialog.py
@@ -21,11 +21,11 @@ pytestmark = [
 def create_dialog(appliance, element_data, label=None):
     service_dialog = appliance.collections.service_dialogs
     if not label:
-        label = "label_{}".format(fauxfactory.gen_alphanumeric())
+        label = fauxfactory.gen_alphanumeric(15, start="label_")
     sd = service_dialog.create(label=label, description="my dialog")
-    tab = sd.tabs.create(tab_label="tab_{}".format(fauxfactory.gen_alphanumeric()),
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
                          tab_desc="my tab desc")
-    box = tab.boxes.create(box_label="box_{}".format(fauxfactory.gen_alphanumeric()),
+    box = tab.boxes.create(box_label=fauxfactory.gen_alphanumeric(start="box_"),
                            box_desc="my box desc")
     element = box.elements.create(element_data=[element_data])
     return sd, element
@@ -42,9 +42,9 @@ def test_crud_service_dialog(appliance):
     """
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Text Box"
         },
         'options': {
@@ -73,16 +73,16 @@ def test_service_dialog_duplicate_name(appliance, request):
     """
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Text Box"
         },
         'options': {
             'default_text_box': "Default text"
         }
     }
-    label = "duplicate_{}".format(fauxfactory.gen_alphanumeric())
+    label = fauxfactory.gen_alphanumeric(15, start="duplicate_")
     dialog, element = create_dialog(appliance, element_data, label=label)
     request.addfinalizer(dialog.delete_if_exists)
     region_number = appliance.server.zone.region.number
@@ -109,9 +109,9 @@ def test_checkbox_dialog_element(appliance, request):
     """
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Check Box"
         },
         'options': {
@@ -135,9 +135,9 @@ def test_datecontrol_dialog_element(appliance, request):
 
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Datepicker"
         },
         'options': {
@@ -159,9 +159,9 @@ def test_tagcontrol_dialog_element(appliance, request):
     """
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Tag Control"
         },
         'options': {
@@ -185,9 +185,9 @@ def test_textareabox_dialog_element(appliance, request):
 
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Text Area",
         },
         'options': {
@@ -208,27 +208,27 @@ def test_reorder_elements(appliance, request):
     """
     element_1_data = {
         'element_information': {
-            'ele_label': "ele_label_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Text Box",
         }
     }
     element_2_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Check Box",
 
         }
     }
     service_dialog = appliance.collections.service_dialogs
-    sd = service_dialog.create(label="label_{}".format(fauxfactory.gen_alphanumeric()),
+    sd = service_dialog.create(label=fauxfactory.gen_alphanumeric(start="label_"),
                                description="my dialog")
-    tab = sd.tabs.create(tab_label="tab_{}".format(fauxfactory.gen_alphanumeric()),
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
         tab_desc="my tab desc")
-    box = tab.boxes.create(box_label="box_{}".format(fauxfactory.gen_alphanumeric()),
+    box = tab.boxes.create(box_label=fauxfactory.gen_alphanumeric(start="box_"),
         box_desc="my box desc")
     element = box.elements.create(element_data=[element_1_data, element_2_data])
     request.addfinalizer(sd.delete_if_exists)
@@ -247,27 +247,27 @@ def test_reorder_unsaved_elements(appliance, request):
         initialEstimate: 1/16h
         tags: service
     """
-    box_label = "box_{}".format(fauxfactory.gen_alphanumeric())
+    box_label = fauxfactory.gen_alphanumeric(start="box_")
     element_1_data = {
         'element_information': {
-            'ele_label': "ele_label_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele1_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele1_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele1_desc_"),
             'choose_type': "Text Box",
         }
     }
     element_2_data = {
         'element_information': {
             'ele_label': box_label,
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele2_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele2_desc_"),
             'choose_type': "Check Box"
         }
     }
     service_dialog = appliance.collections.service_dialogs
-    sd = service_dialog.create(label="label_{}".format(fauxfactory.gen_alphanumeric()),
+    sd = service_dialog.create(label=fauxfactory.gen_alphanumeric(start="label_"),
                                description="my dialog")
-    tab = sd.tabs.create(tab_label="tab_{}".format(fauxfactory.gen_alphanumeric()),
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
         tab_desc="my tab desc")
     box = tab.boxes.create(box_label=box_label,
         box_desc="my box desc")
@@ -288,9 +288,9 @@ def test_dropdownlist_dialog_element(appliance, request):
 
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Dropdown"
         }
     }
@@ -309,9 +309,9 @@ def test_radiobutton_dialog_element(appliance, request):
     """
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Radio Button"
         }
     }
@@ -334,20 +334,20 @@ def test_mandatory_entry_point_with_dynamic_element(appliance):
     """
     element_1_data = {
         'element_information': {
-            'ele_label': "ele_label_{}".format(fauxfactory.gen_alphanumeric()),
-            'ele_name': fauxfactory.gen_alphanumeric(),
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            'ele_name': fauxfactory.gen_alphanumeric(15, start="ele_name_"),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'dynamic_chkbox': True,
             'choose_type': "Text Box",
         }
     }
     service_dialog = appliance.collections.service_dialogs
-    sd = service_dialog.create(label='label_{}'.format(fauxfactory.gen_alphanumeric(),
-                               description="my dialog"))
-    tab = sd.tabs.create(tab_label='tab_{}'.format(fauxfactory.gen_alphanumeric(),
-                         tab_desc="my tab desc"))
-    box = tab.boxes.create(box_label='box_{}'.format(fauxfactory.gen_alphanumeric(),
-                           box_desc="my box desc"))
+    sd = service_dialog.create(label=fauxfactory.gen_alphanumeric(start="label_"),
+                               description="my dialog")
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
+                         tab_desc="my tab desc")
+    box = tab.boxes.create(box_label=fauxfactory.gen_alphanumeric(start="box_"),
+                           box_desc="my box desc")
     assert box.elements.create(element_data=[element_1_data]) is False
     view_cls = navigator.get_class(sd.parent, 'Add').VIEW
     view = appliance.browser.create_view(view_cls)

--- a/cfme/tests/automate/test_vmware_methods.py
+++ b/cfme/tests/automate/test_vmware_methods.py
@@ -91,7 +91,7 @@ def test_vmware_vimapi_hotadd_disk(
         1311221
     """
     meth = cls.methods.create(
-        name='load_value_{}'.format(fauxfactory.gen_alpha()),
+        name=fauxfactory.gen_alpha(15, start="load_value_"),
         script=dedent('''\
             # Sets the capacity of the new disk.
 
@@ -103,7 +103,7 @@ def test_vmware_vimapi_hotadd_disk(
 
     # Instance that calls the method and is accessible from the button
     instance = cls.instances.create(
-        name="VMware_HotAdd_Disk_{}".format(fauxfactory.gen_alpha()),
+        name=fauxfactory.gen_alpha(23, start="VMware_HotAdd_Disk_"),
         fields={
             "meth4": {'value': meth.name},  # To get the value
             "rel5": {'value': "/Integration/VMware/VimApi/VMware_HotAdd_Disk"},

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -38,7 +38,7 @@ def provider_app_crud(provider_class, appliance):
 
 def provision_vm(request, provider):
     """Function to provision appliance to the provider being tested"""
-    vm_name = "test_rest_db_{}".format(fauxfactory.gen_alphanumeric())
+    vm_name = fauxfactory.gen_alphanumeric(16, start="test_rest_db_")
     coll = provider.appliance.provider_based_collection(provider, coll_type='vms')
     vm = coll.instantiate(vm_name, provider)
     request.addfinalizer(vm.cleanup_on_provider)

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -211,8 +211,8 @@ def test_update_embedded_ansible_webui(enabled_embedded_appliance, appliance, ol
 
     with enabled_embedded_appliance:
         repositories = enabled_embedded_appliance.collections.ansible_repositories
-        name = "example_{}".format(fauxfactory.gen_alpha())
-        description = "edited_{}".format(fauxfactory.gen_alpha())
+        name = fauxfactory.gen_alpha(15, start="example_")
+        description = fauxfactory.gen_alpha(15, start="edited_")
         try:
             repository = repositories.create(
                 name=name,

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -38,7 +38,7 @@ def create_instance(appliance, provider, template_name):
     if not instance.exists_on_provider:
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
     elif instance.provider.one_of(EC2Provider) and instance.mgmt.state == VmState.DELETED:
-        instance.mgmt.rename('test_terminated_{}'.format(fauxfactory.gen_alphanumeric(8)))
+        instance.mgmt.rename(fauxfactory.gen_alphanumeric(20, "test_terminated_"))
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
     return instance
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -590,7 +590,7 @@ def test_refresh_with_empty_iot_hub_azure(request, provider, setup_provider):
     result.start_monitoring()
     azure = provider.mgmt
     if not azure.has_iothub():
-        iothub_name = f"potatoiothub_{fauxfactory.gen_alpha()}"
+        iothub_name = fauxfactory.gen_alpha(18, start="potatoiothub_")
         azure.create_iothub(iothub_name)
         request.addfinalizer(lambda: azure.delete_iothub(iothub_name))
         assert azure.has_iothub()

--- a/cfme/tests/cloud/test_quota.py
+++ b/cfme/tests/cloud/test_quota.py
@@ -67,8 +67,8 @@ def new_tenant(appliance):
     """This fixture creates new tenant under root tenant(My Company)"""
     collection = appliance.collections.tenants
     tenant = collection.create(
-        name="tenant_{}".format(fauxfactory.gen_alphanumeric()),
-        description="tenant_des{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(12, start="tenant_"),
+        description=fauxfactory.gen_alphanumeric(15, start="tenant_des_"),
         parent=collection.get_root_tenant(),
     )
     yield tenant
@@ -80,8 +80,8 @@ def new_tenant(appliance):
 def new_child(appliance, new_tenant):
     """The fixture creates new child tenant"""
     child_tenant = appliance.collections.tenants.create(
-        name="tenant_{}".format(fauxfactory.gen_alphanumeric()),
-        description="tenant_des{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(12, start="tenant_"),
+        description=fauxfactory.gen_alphanumeric(15, start="tenant_des_"),
         parent=new_tenant,
     )
     yield child_tenant
@@ -93,7 +93,7 @@ def new_child(appliance, new_tenant):
 def new_group_child(appliance, new_child, new_tenant):
     """This fixture creates new group assigned by new child tenant"""
     group = appliance.collections.groups.create(
-        description="group_{}".format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(start="group_"),
         role="EvmRole-super_administrator",
         tenant="My Company/{parent}/{child}".format(parent=new_tenant.name, child=new_child.name),
     )
@@ -106,9 +106,9 @@ def new_group_child(appliance, new_child, new_tenant):
 def new_user_child(appliance, new_group_child):
     """This fixture creates new user which assigned to new child tenant"""
     user = appliance.collections.users.create(
-        name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
-        credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
-                              secret='{password}'.format(password=fauxfactory.gen_alphanumeric(4))),
+        name=fauxfactory.gen_alphanumeric(start="user_").lower(),
+        credential=Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
+                              secret=fauxfactory.gen_alphanumeric(start="pwd_")),
         email=fauxfactory.gen_email(),
         groups=new_group_child,
         cost_center="Workload",
@@ -124,8 +124,8 @@ def new_project(appliance):
     """This fixture creates new project"""
     collection = appliance.collections.projects
     project = collection.create(
-        name="project_{}".format(fauxfactory.gen_alphanumeric()),
-        description="project_des{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(12, start="project_"),
+        description=fauxfactory.gen_alphanumeric(15, start="project_desc"),
         parent=collection.get_root_tenant(),
     )
     yield project
@@ -137,7 +137,7 @@ def new_project(appliance):
 def new_group_project(appliance, new_project):
     """This fixture creates new group and assigned by new project"""
     group = appliance.collections.groups.create(
-        description="group_{}".format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(start="group_"),
         role="EvmRole-super_administrator",
         tenant="My Company/{project}".format(project=new_project.name),
     )
@@ -150,9 +150,9 @@ def new_group_project(appliance, new_project):
 def new_user_project(appliance, new_group_project):
     """This fixture creates new user which is assigned to new group and project"""
     user = appliance.collections.users.create(
-        name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
-        credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
-                              secret='{password}'.format(password=fauxfactory.gen_alphanumeric(4))),
+        name=fauxfactory.gen_alphanumeric(start="user_").lower(),
+        credential=Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
+                              secret=fauxfactory.gen_alphanumeric(start="pwd")),
         email=fauxfactory.gen_email(),
         groups=new_group_project,
         cost_center="Workload",
@@ -211,9 +211,9 @@ def test_child_tenant_quota_enforce_via_lifecycle_cloud(
             {
                 "request": {
                     "email": fauxfactory.gen_email(),
-                    "first_name": fauxfactory.gen_alphanumeric(),
-                    "last_name": fauxfactory.gen_alphanumeric(),
-                    "manager_name": "{name}".format(name=fauxfactory.gen_alphanumeric()),
+                    "first_name": fauxfactory.gen_alphanumeric(start="first_"),
+                    "last_name": fauxfactory.gen_alphanumeric(start="last_"),
+                    "manager_name": fauxfactory.gen_alphanumeric(start="manager_"),
                 }
             },
         )
@@ -283,9 +283,9 @@ def test_project_quota_enforce_via_lifecycle_cloud(
             {
                 "request": {
                     "email": fauxfactory.gen_email(),
-                    "first_name": fauxfactory.gen_alphanumeric(),
-                    "last_name": fauxfactory.gen_alphanumeric(),
-                    "manager_name": "{name}".format(name=fauxfactory.gen_alphanumeric()),
+                    "first_name": fauxfactory.gen_alphanumeric(start="first_"),
+                    "last_name": fauxfactory.gen_alphanumeric(start="last_"),
+                    "manager_name": fauxfactory.gen_alphanumeric(start="manager_"),
                 }
             },
         )
@@ -380,7 +380,7 @@ def dialog(appliance, automate_flavor_method):
     """This fixture is used to create dynamic service dialog"""
     data = {
         "buttons": "submit,cancel",
-        "label": "flavour_dialog_{}".format(fauxfactory.gen_alphanumeric()),
+        "label": fauxfactory.gen_alphanumeric(20, start="flavour_dialog_"),
         "dialog_tabs": [
             {
                 "display": 'edit',

--- a/cfme/tests/cloud/test_quota_tagging.py
+++ b/cfme/tests/cloud/test_quota_tagging.py
@@ -58,10 +58,11 @@ def prov_data(provider, vm_name, template_name, provisioning):
 
 @pytest.fixture(scope='module')
 def domain(appliance):
-    domain = appliance.collections.domains.create('test_{}'.format(fauxfactory.gen_alphanumeric()),
-                                                  'description_{}'.format(
-                                                      fauxfactory.gen_alphanumeric()),
-                                                  enabled=True)
+    domain = appliance.collections.domains.create(
+        fauxfactory.gen_alphanumeric(start="domain_"),
+        fauxfactory.gen_alphanumeric(15, start="domain_desc_"),
+        enabled=True
+    )
     yield domain
     if domain.exists:
         domain.delete()
@@ -72,7 +73,7 @@ def catalog_item(appliance, provider, dialog, catalog, prov_data):
     collection = appliance.collections.catalog_items
     catalog_item = collection.create(
         provider.catalog_item_type,
-        name='test_{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
         description='test catalog',
         display_in=True,
         catalog=catalog,

--- a/cfme/tests/cloud/test_tag_mapping.py
+++ b/cfme/tests/cloud/test_tag_mapping.py
@@ -67,8 +67,10 @@ def tag_mapping_items(request, appliance, provider):
 
 def tag_components():
     # Return tuple with random tag_label and tag_value
-    return ('tag_label_{}'.format(fauxfactory.gen_alphanumeric()),
-            'tag_value_{}'.format(fauxfactory.gen_alphanumeric()))
+    return (
+        fauxfactory.gen_alphanumeric(15, start="tag_label_"),
+        fauxfactory.gen_alphanumeric(15, start="tag_value_")
+    )
 
 
 @pytest.mark.provider([AzureProvider], selector=ONE_PER_TYPE, scope='function')

--- a/cfme/tests/cloud/test_tenant.py
+++ b/cfme/tests/cloud/test_tenant.py
@@ -11,14 +11,18 @@ from cfme.utils.update import update
 pytestmark = [pytest.mark.provider([OpenStackProvider], scope='module')]
 
 # List of tenant's names
-TENANTS = ["parent_{}".format(fauxfactory.gen_alphanumeric()),
-           "child_{}".format(fauxfactory.gen_alphanumeric())]
+TENANTS = [
+    fauxfactory.gen_alphanumeric(start="parent_"),
+    fauxfactory.gen_alphanumeric(start="child_")
+]
 
 
 @pytest.fixture(scope='function')
 def tenant(provider, setup_provider, appliance):
-    tenant = appliance.collections.cloud_tenants.create(name=fauxfactory.gen_alphanumeric(8),
-                                                        provider=provider)
+    tenant = appliance.collections.cloud_tenants.create(
+        name=fauxfactory.gen_alphanumeric(start="tenant_"),
+        provider=provider
+    )
     yield tenant
 
     try:
@@ -46,7 +50,7 @@ def test_tenant_crud(tenant):
     """
 
     with update(tenant):
-        tenant.name = fauxfactory.gen_alphanumeric(8)
+        tenant.name = fauxfactory.gen_alphanumeric(15, start="edited_")
     tenant.wait_for_appear()
     assert tenant.exists
 
@@ -59,7 +63,7 @@ def new_tenant(appliance):
     # Here TENANT[0] is the first tenant(parent tenant) from the tenant's list
     tenant = collection.create(
         name=TENANTS[0],
-        description="tenant_des{}".format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(15, start="tenant_desc_"),
         parent=collection.get_root_tenant(),
     )
     yield tenant
@@ -72,7 +76,7 @@ def child_tenant(new_tenant):
     # Here TENANT[1] is the second tenant(child tenant) from the tenant's list
     child_tenant = new_tenant.appliance.collections.tenants.create(
         name=TENANTS[1],
-        description="tenant_des{}".format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(15, start="tenant_desc_"),
         parent=new_tenant,
     )
     yield child_tenant
@@ -164,7 +168,7 @@ def test_dynamic_product_feature_for_tenant_quota(request, appliance, new_tenant
 
         # Creating two different groups with assigned custom roles and tenants
         group = appliance.collections.groups.create(
-            description="group_{}".format(fauxfactory.gen_alphanumeric()),
+            description=fauxfactory.gen_alphanumeric(start="group_"),
             role=new_role.name,
             tenant=tenant_[i]
         )
@@ -172,10 +176,10 @@ def test_dynamic_product_feature_for_tenant_quota(request, appliance, new_tenant
 
         # Creating two different users which are assigned with different groups
         user = appliance.collections.users.create(
-            name="user_{}".format(fauxfactory.gen_alphanumeric().lower()),
+            name=fauxfactory.gen_alphanumeric(start="user_").lower(),
             credential=Credential(
-                principal="uid{}".format(fauxfactory.gen_alphanumeric(4)),
-                secret="{password}".format(password=fauxfactory.gen_alphanumeric(4)),
+                principal=fauxfactory.gen_alphanumeric(start="uid"),
+                secret=fauxfactory.gen_alphanumeric(start="pwd_"),
             ),
             email=fauxfactory.gen_email(),
             groups=group,

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -29,7 +29,7 @@ pytestmark = [
 def vm_crud(provider, setup_provider_modscope, small_template_modscope):
     template = small_template_modscope
     base_name = 'test-events-' if provider.one_of(GCEProvider) else 'test_events_'
-    vm_name = base_name + fauxfactory.gen_alpha(length=8).lower()
+    vm_name = fauxfactory.gen_alpha(20, start=base_name).lower()
 
     collection = provider.appliance.provider_based_collection(provider)
     vm = collection.instantiate(vm_name, provider, template_name=template.name)

--- a/cfme/tests/cloud_infra_common/test_tag_visibility.py
+++ b/cfme/tests/cloud_infra_common/test_tag_visibility.py
@@ -99,7 +99,7 @@ def group_with_tag_expression(appliance, user_restricted, request):
     def _group_with_tag_expression(expression):
         """Updates group with provided expression, also assign user to group"""
         group = appliance.collections.groups.create(
-            description='grp{}'.format(fauxfactory.gen_alphanumeric()),
+            description=fauxfactory.gen_alphanumeric(start="grp_"),
             role='EvmRole-approver',
             tag=expression
         )

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -190,7 +190,7 @@ def set_hosts_credentials(appliance, request, provider):
 def set_agent_creds(appliance, request, provider):
     version = appliance.version.vstring
     docker_image_name = "simaishi/amazon-ssa:{}".format(version)
-    unique_agent = 'test_ssa_agent-{}'.format(fauxfactory.gen_alpha(length=5))
+    unique_agent = fauxfactory.gen_alpha(length=20, start="test_ssa_agent-")
     agent_data = {
         "ems": {
             "ems_amazon": {
@@ -250,7 +250,7 @@ def enable_smartproxy_affinity(request, appliance, provider):
 def ssa_compliance_policy(appliance):
     policy = appliance.collections.policies.create(
         VMControlPolicy,
-        'ssa_policy_{}'.format(fauxfactory.gen_alpha())
+        fauxfactory.gen_alpha(15, start="ssa_policy_")
     )
     policy.assign_events("VM Provision Complete")
     policy.assign_actions_to_event("VM Provision Complete", ["Initiate SmartState Analysis for VM"])
@@ -262,7 +262,9 @@ def ssa_compliance_policy(appliance):
 @pytest.fixture(scope="module")
 def ssa_compliance_profile(appliance, provider, ssa_compliance_policy):
     profile = appliance.collections.policy_profiles.create(
-        'ssa_policy_profile_{}'.format(fauxfactory.gen_alpha()), policies=[ssa_compliance_policy])
+        fauxfactory.gen_alpha(25, start="ssa_policy_profile_"),
+        policies=[ssa_compliance_policy]
+    )
 
     provider.assign_policy_profiles(profile.description)
     yield
@@ -377,7 +379,9 @@ def assign_profile_to_vm(appliance, ssa_policy, request):
     """ Assign policy profile to vm"""
     def _assign_profile_to_vm(vm):
         profile = appliance.collections.policy_profiles.create(
-            'ssa_policy_profile_{}'.format(fauxfactory.gen_alpha()), policies=[ssa_policy])
+            fauxfactory.gen_alpha(25, start="ssa_policy_profile_"),
+            policies=[ssa_policy]
+        )
         vm.assign_policy_profiles(profile.description)
         request.addfinalizer(profile.delete)
     return _assign_profile_to_vm
@@ -410,7 +414,7 @@ def ssa_analysis_profile(appliance):
 @pytest.fixture(scope="module")
 def ssa_action(appliance, ssa_analysis_profile):
     action = appliance.collections.actions.create(
-        'ssa_action_{}'.format(fauxfactory.gen_alpha()),
+        fauxfactory.gen_alpha(15, start="ssa_action_"),
         "Assign Profile to Analysis Task",
         dict(analysis_profile=ssa_analysis_profile.name))
     yield action
@@ -421,7 +425,7 @@ def ssa_action(appliance, ssa_analysis_profile):
 def ssa_policy(appliance, ssa_action):
     policy = appliance.collections.policies.create(
         VMControlPolicy,
-        'ssa_policy_{}'.format(fauxfactory.gen_alpha())
+        fauxfactory.gen_alpha(15, start="ssa_policy_")
     )
     policy.assign_events("VM Analysis Start")
     policy.assign_actions_to_event("VM Analysis Start", ssa_action)
@@ -457,7 +461,7 @@ def schedule_ssa(appliance, ssa_vm, wait_for_task_result=True):
     hour = dt.strftime('%-H')
     minute = dt.strftime('%-M')
     schedule_args = {
-        'name': 'test_ssa_schedule{}'.format(fauxfactory.gen_alpha()),
+        'name': fauxfactory.gen_alpha(25, start="test_ssa_schedule_"),
         'description': 'Testing SSA via Schedule',
         'active': True,
         'filter_level1': 'A single VM',

--- a/cfme/tests/cloud_infra_common/test_vm_ownership.py
+++ b/cfme/tests/cloud_infra_common/test_vm_ownership.py
@@ -44,7 +44,7 @@ def vm_crud(provider):
 def role_only_user_owned(appliance):
     appliance.server.login_admin()
     role = appliance.collections.roles.create(
-        name='role_only_user_owned_' + fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(25, start="role_only_user_owned_"),
         vm_restriction='Only User Owned'
     )
     yield role
@@ -56,7 +56,7 @@ def role_only_user_owned(appliance):
 def group_only_user_owned(appliance, role_only_user_owned):
     group_collection = appliance.collections.groups
     group = group_collection.create(
-        description='group_only_user_owned_{}'.format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(25, start="group_only_user_owned_"),
         role=role_only_user_owned.name)
     yield group
     appliance.server.login_admin()
@@ -67,7 +67,7 @@ def group_only_user_owned(appliance, role_only_user_owned):
 def role_user_or_group_owned(appliance):
     appliance.server.login_admin()
     role = appliance.collections.roles.create(
-        name='role_user_or_group_owned_' + fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(30, start="role_user_or_group_owned_"),
         vm_restriction='Only User or Group Owned'
     )
     yield role
@@ -79,7 +79,7 @@ def role_user_or_group_owned(appliance):
 def group_user_or_group_owned(appliance, role_user_or_group_owned):
     group_collection = appliance.collections.groups
     group = group_collection.create(
-        description='group_user_or_group_owned_{}'.format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(30, start="group_user_or_group_owned_"),
         role=role_user_or_group_owned.name)
     yield group
     appliance.server.login_admin()
@@ -89,9 +89,12 @@ def group_user_or_group_owned(appliance, role_user_or_group_owned):
 def new_credential():
     # BZ1487199 - CFME allows usernames with uppercase chars which blocks logins
     if BZ.bugzilla.get_bug(1487199).is_opened:
-        return Credential(principal='uid' + fauxfactory.gen_alphanumeric().lower(), secret='redhat')
+        return Credential(
+            principal=fauxfactory.gen_alphanumeric(start="uid").lower(),
+            secret='redhat'
+        )
     else:
-        return Credential(principal='uid' + fauxfactory.gen_alphanumeric(), secret='redhat')
+        return Credential(principal=fauxfactory.gen_alphanumeric(start="uid"), secret='redhat')
 
 
 @pytest.fixture(scope="module")
@@ -120,9 +123,9 @@ def user3(appliance, group_user_or_group_owned):
 
 def new_user(appliance, group_only_user_owned):
     user = appliance.collections.users.create(
-        name='user_' + fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="user_"),
         credential=new_credential(),
-        email='abc@redhat.com',
+        email=fauxfactory.gen_email(),
         groups=[group_only_user_owned],
         cost_center='Workload',
         value_assign='Database'

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -28,12 +28,12 @@ pytestmark = [
 
 
 def new_credential():
-    return Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric(4)),
+    return Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
                       secret='redhat')
 
 
 def new_user(appliance, groups, name=None, credential=None):
-    name = name or 'user{}'.format(fauxfactory.gen_alphanumeric())
+    name = name or fauxfactory.gen_alphanumeric(start="user_")
     credential = credential or new_credential()
 
     user = appliance.collections.users.create(
@@ -47,7 +47,7 @@ def new_user(appliance, groups, name=None, credential=None):
 
 
 def new_role(appliance, name=None):
-    name = name or 'rol{}'.format(fauxfactory.gen_alphanumeric())
+    name = name or fauxfactory.gen_alphanumeric(start="role_")
     return appliance.collections.roles.create(
         name=name,
         vm_restriction='None')
@@ -108,7 +108,7 @@ def setup_openldap_user_group(appliance, two_child_tenants, openldap_auth_provid
 @pytest.fixture(scope='module')
 def child_tenant(appliance):
     child_tenant = appliance.collections.tenants.create(
-        name='child_tenant{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(15, start="child_tenant_"),
         description='tenant description',
         parent=appliance.collections.tenants.get_root_tenant()
     )
@@ -138,7 +138,7 @@ def tenant_role(appliance, request):
 @pytest.fixture(scope='module')
 def new_tenant_admin(appliance, request, child_tenant, tenant_role):
     group = appliance.collections.groups.create(
-        description=f'tenant_grp_{fauxfactory.gen_alphanumeric()}', role=tenant_role.name,
+        description=fauxfactory.gen_alphanumeric(15, start="tenant_grp_"), role=tenant_role.name,
         tenant=f'My Company/{child_tenant.name}')
 
     tenant_admin = new_user(appliance, group, name='tenant_admin_user')
@@ -175,7 +175,7 @@ def tag_value(appliance, category, tag, request):
 
 @pytest.fixture(scope='module')
 def catalog_obj(appliance):
-    catalog_name = fauxfactory.gen_alphanumeric()
+    catalog_name = fauxfactory.gen_alphanumeric(start="cat_")
     catalog_desc = "My Catalog"
 
     cat = appliance.collections.catalogs.create(name=catalog_name, description=catalog_desc)
@@ -349,7 +349,7 @@ def test_user_allow_duplicate_name(appliance):
     group_collection = appliance.collections.groups
     group = group_collection.instantiate(description=group_name)
 
-    name = 'user{}'.format(fauxfactory.gen_alphanumeric())
+    name = fauxfactory.gen_alphanumeric(start="user_")
 
     # Create first user
     new_user(appliance, [group], name=name)
@@ -396,7 +396,7 @@ def test_userid_required_error_validation(appliance):
 
     with pytest.raises(Exception, match="Userid can't be blank"):
         appliance.collections.users.create(
-            name='user{}'.format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(start="user_"),
             credential=Credential(principal='', secret='redhat'),
             email='xyz@redhat.com',
             groups=[group]
@@ -423,9 +423,9 @@ def test_user_password_required_error_validation(appliance):
 
     with pytest.raises(Exception, match=check):
         appliance.collections.users.create(
-            name='user{}'.format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(start="user_"),
             credential=Credential(
-                principal='uid{}'.format(fauxfactory.gen_alphanumeric()), secret=None),
+                principal=fauxfactory.gen_alphanumeric(start="uid"), secret=None),
             email='xyz@redhat.com',
             groups=[group])
     # Navigating away from this page will create an "Abandon Changes" alert
@@ -444,7 +444,7 @@ def test_user_group_error_validation(appliance):
     """
     with pytest.raises(Exception, match="A User must be assigned to a Group"):
         appliance.collections.users.create(
-            name='user{}'.format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(start="user_"),
             credential=new_credential(),
             email='xyz@redhat.com',
             groups=[''])
@@ -464,7 +464,7 @@ def test_user_email_error_validation(appliance):
 
     with pytest.raises(Exception, match="Email must be a valid email address"):
         appliance.collections.users.create(
-            name='user{}'.format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(start="user_"),
             credential=new_credential(),
             email='xyzdhat.com',
             groups=group)
@@ -601,7 +601,7 @@ def test_group_crud(appliance):
     role = 'EvmRole-administrator'
     group_collection = appliance.collections.groups
     group = group_collection.create(
-        description='grp{}'.format(fauxfactory.gen_alphanumeric()), role=role)
+        description=fauxfactory.gen_alphanumeric(start="grp_"), role=role)
     with update(group):
         group.description = "{}edited".format(group.description)
     group.delete()
@@ -632,7 +632,7 @@ def test_group_crud_with_tag(appliance, provider, setup_provider, tag_value):
 
     group_collection = appliance.collections.groups
     group = group_collection.create(
-        description='grp{}'.format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(start="grp_"),
         role='EvmRole-approver',
         tag=tag_for_create,
         host_cluster=([provider.data['name']], True),
@@ -658,7 +658,7 @@ def test_group_duplicate_name(appliance):
         casecomponent: Configuration
     """
     role = 'EvmRole-approver'
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
@@ -681,7 +681,7 @@ def test_group_edit_tag(appliance):
         casecomponent: Tagging
     """
     role = 'EvmRole-approver'
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
@@ -704,7 +704,7 @@ def test_group_remove_tag(appliance):
         casecomponent: Tagging
     """
     role = 'EvmRole-approver'
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
 
@@ -771,7 +771,7 @@ def test_delete_group_with_assigned_user(appliance):
         tags: rbac
     """
     role = 'EvmRole-approver'
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role)
     new_user(appliance, [group])
@@ -818,7 +818,7 @@ def test_edit_sequence_usergroups(appliance, request):
         tags: rbac
     """
     role_name = 'EvmRole-approver'
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role_name)
     request.addfinalizer(group.delete)
@@ -899,7 +899,7 @@ def test_rolename_duplicate_validation(appliance):
         initialEstimate: 1/8h
         tags: rbac
     """
-    name = 'rol{}'.format(fauxfactory.gen_alphanumeric())
+    name = fauxfactory.gen_alphanumeric(start="role_")
     role = appliance.collections.roles.create(name=name)
     assert role.exists
     view = navigate_to(appliance.collections.roles, 'Add')
@@ -947,7 +947,7 @@ def test_edit_default_roles(appliance):
         tags: rbac
     """
     role = appliance.collections.roles.instantiate(name='EvmRole-auditor')
-    newrole_name = "{}-{}".format(role.name, fauxfactory.gen_alphanumeric())
+    newrole_name = fauxfactory.gen_alphanumeric(20, start=role.name)
     role_updates = {'name': newrole_name}
 
     with pytest.raises(RBACOperationBlocked):
@@ -964,7 +964,7 @@ def test_delete_roles_with_assigned_group(appliance):
         tags: rbac
     """
     role = new_role(appliance)
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group_collection.create(description=group_description, role=role.name)
 
@@ -983,7 +983,7 @@ def test_assign_user_to_new_group(appliance):
     """
     role = new_role(appliance)  # call function to get role
 
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role.name)
 
@@ -1036,12 +1036,12 @@ def test_permission_edit(appliance, request, product_features):
         initialEstimate: 1h
         tags: rbac
     """
-    role_name = fauxfactory.gen_alphanumeric()
+    role_name = fauxfactory.gen_alphanumeric(start="role_")
     role = appliance.collections.roles.create(name=role_name,
                 vm_restriction=None,
                 product_features=[(['Everything'], False)] +  # role_features
                                  [(k, True) for k in product_features])
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role.name)
     user = new_user(appliance, [group])
@@ -1068,7 +1068,7 @@ def _mk_role(appliance, name=None, vm_restriction=None, product_features=None):
        testing.  name=None will generate a random name
 
     """
-    name = name or fauxfactory.gen_alphanumeric()
+    name = name or fauxfactory.gen_alphanumeric(start="role_")
     return appliance.collections.roles.create(
         name=name,
         vm_restriction=vm_restriction,
@@ -1148,7 +1148,7 @@ def test_permissions(appliance, product_features, allowed_actions, disallowed_ac
     """
     # create a user and role
     role = _mk_role(appliance, product_features=product_features)
-    group_description = 'grp{}'.format(fauxfactory.gen_alphanumeric())
+    group_description = fauxfactory.gen_alphanumeric(start="grp_")
     group_collection = appliance.collections.groups
     group = group_collection.create(description=group_description, role=role.name)
     user = new_user(appliance, [group])
@@ -1374,7 +1374,7 @@ def test_superadmin_tenant_crud(request, appliance):
     """
     tenant_collection = appliance.collections.tenants
     tenant = tenant_collection.create(
-        name='tenant1{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="tenant1"),
         description='tenant1 description',
         parent=tenant_collection.get_root_tenant()
     )
@@ -1416,12 +1416,12 @@ def test_superadmin_tenant_project_crud(request, appliance):
     tenant_collection = appliance.collections.tenants
     project_collection = appliance.collections.projects
     tenant = tenant_collection.create(
-        name='tenant1{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="tenant1"),
         description='tenant1 description',
         parent=tenant_collection.get_root_tenant())
 
     project = project_collection.create(
-        name='project1{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(12, start="project1"),
         description='project1 description',
         parent=project_collection.get_root_tenant())
 
@@ -1473,7 +1473,7 @@ def test_superadmin_child_tenant_crud(request, appliance, number_of_childrens):
     tenant = tenant_collection.get_root_tenant()
     for i in range(1, number_of_childrens + 1):
         new_tenant = tenant_collection.create(
-            name="tenant{}_{}".format(i, fauxfactory.gen_alpha(4)),
+            name=fauxfactory.gen_alpha(15, start=f"tenant_{i}_"),
             description=fauxfactory.gen_alphanumeric(16),
             parent=tenant)
         tenant_list.append(new_tenant)
@@ -1508,7 +1508,7 @@ def test_unique_name_on_parent_level(request, appliance, collection_name):
             4. Delete created objects
     """
     object_collection = getattr(appliance.collections, collection_name)
-    name_of_tenant = fauxfactory.gen_alphanumeric()
+    name_of_tenant = fauxfactory.gen_alphanumeric(15, start="tenant_")
     tenant_description = 'description'
 
     tenant = object_collection.create(
@@ -1584,7 +1584,7 @@ def test_tenantadmin_group_crud(new_tenant_admin, tenant_role, child_tenant, req
 
         group_collection = appliance.collections.groups
         group = group_collection.create(
-            description=f'tenantgrp_{fauxfactory.gen_alphanumeric()}',
+            description=fauxfactory.gen_alphanumeric(15, "tenantgrp_"),
             role=tenant_role.name, tenant=f'My Company/{child_tenant.name}')
         request.addfinalizer(group.delete_if_exists)
         assert group.exists
@@ -1844,7 +1844,7 @@ def test_tenant_unique_automation_domain_name_on_parent_level(appliance, request
         initialEstimate: 1/2h
         startsin: 5.5
     """
-    domain_name = fauxfactory.gen_alphanumeric()
+    domain_name = fauxfactory.gen_alphanumeric(15, start="domain_")
     domain1 = appliance.collections.domains.create(name=domain_name, enabled=True)
     msg = "Name has already been taken"
 
@@ -1929,15 +1929,15 @@ def test_superadmin_child_tenant_delete_parent_catalog(appliance, request):
     """
     tenant_collection = appliance.collections.tenants
     root_tenant = tenant_collection.get_root_tenant()
-    catalog_name = fauxfactory.gen_alphanumeric()
+    catalog_name = fauxfactory.gen_alphanumeric(start="cat_")
     cat = appliance.collections.catalogs.create(name=catalog_name, description='my catalog')
     new_tenant = tenant_collection.create(
-        name="tenant{}".format(fauxfactory.gen_alpha(4)),
+        name=fauxfactory.gen_alpha(15, start="tenant_"),
         description=fauxfactory.gen_alphanumeric(16),
         parent=root_tenant)
 
     group_collection = appliance.collections.groups
-    group = group_collection.create(description='grp{}'.format(fauxfactory.gen_alphanumeric()),
+    group = group_collection.create(description=fauxfactory.gen_alphanumeric(start="grp_"),
                                     role="EvmRole-super_administrator",
                                     tenant="{}/{}".format(root_tenant.name, new_tenant.name))
     user = new_user(appliance, [group])

--- a/cfme/tests/configure/test_analysis_profiles.py
+++ b/cfme/tests/configure/test_analysis_profiles.py
@@ -25,7 +25,7 @@ updated_files = [
     {'Name': files_list[0]['Name'],
      'Collect Contents?': not files_list[0]['Collect Contents?']}]
 
-TENANT_NAME = "tenant_{}".format(fauxfactory.gen_alphanumeric())
+TENANT_NAME = fauxfactory.gen_alphanumeric(15, start="tenant_")
 
 # Operations performed on service dialogs with respect to RBAC permissions
 OPERATIONS = ["Add", "Edit", "Delete", "Copy"]
@@ -404,13 +404,12 @@ def test_custom_role_modify_for_dynamic_product_feature(request, appliance, prod
     """
     tenant = appliance.collections.tenants.create(
         name=TENANT_NAME,
-        description="tenant_des{}".format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(15, start="tenant_desc_"),
         parent=appliance.collections.tenants.get_root_tenant(),
     )
     request.addfinalizer(tenant.delete)
     role = appliance.collections.roles.instantiate(name='EvmRole-tenant_quota_administrator')
-    copied_role = role.copy(name="{role}_{name}".format(
-        role=role.name, name=fauxfactory.gen_alpha()))
+    copied_role = role.copy(name=fauxfactory.gen_alpha(start=role.name))
     request.addfinalizer(copied_role.delete)
     view = navigate_to(copied_role, 'Details')
     # node_checked: Checks whether feature tree path is checked for given node

--- a/cfme/tests/configure/test_db_backup_schedule.py
+++ b/cfme/tests/configure/test_db_backup_schedule.py
@@ -46,10 +46,10 @@ class DbBackupData(Pretty):
         self.__dict__.update(self._get_data(protocol_data, protocol_type))
 
     def _get_random_schedule_name(self):
-        return '{}_name'.format(fauxfactory.gen_alphanumeric())
+        return fauxfactory.gen_alphanumeric(15, start="schedule_")
 
     def _get_random_schedule_description(self):
-        return '{}_desc'.format(fauxfactory.gen_alphanumeric())
+        return fauxfactory.gen_alphanumeric(20, start="schedule_desc_")
 
     def _get_credentials(self):
         """ Loads credentials that correspond to 'credentials' key from machine_data dict

--- a/cfme/tests/configure/test_ntp_server.py
+++ b/cfme/tests/configure/test_ntp_server.py
@@ -61,7 +61,7 @@ def test_ntp_crud(request, appliance, empty_ntp_dict, ntp_servers_keys):
         ntp_servers_keys, [ntp_server for ntp_server in cfme_data['clock_servers']]))))
     # Set from random values
     appliance.server.settings.update_ntp_servers(dict(list(zip(
-        ntp_servers_keys, [fauxfactory.gen_alphanumeric() for _ in range(3)]))))
+        ntp_servers_keys, [fauxfactory.gen_alphanumeric(start="key_") for _ in range(3)]))))
     # Deleting the ntp values
     appliance.server.settings.update_ntp_servers(empty_ntp_dict)
 
@@ -79,7 +79,7 @@ def test_ntp_server_max_character(request, appliance, ntp_servers_keys, empty_nt
     ntp_file_date_stamp = appliance.ssh_client.run_command(
         "stat --format '%y' /etc/chrony.conf").output
     appliance.server.settings.update_ntp_servers(dict(list(zip(
-        ntp_servers_keys, [fauxfactory.gen_alphanumeric() for _ in range(3)]))))
+        ntp_servers_keys, [fauxfactory.gen_alphanumeric(start="key_") for _ in range(3)]))))
     wait_for(lambda: ntp_file_date_stamp != appliance.ssh_client.run_command(
         "stat --format '%y' /etc/chrony.conf").output, num_sec=60, delay=10)
 

--- a/cfme/tests/configure/test_paginator.py
+++ b/cfme/tests/configure/test_paginator.py
@@ -86,8 +86,8 @@ def check_paginator_for_page(view):
 @pytest.fixture(scope='module')
 def schedule(appliance):
     schedule = appliance.collections.system_schedules.create(
-        name=fauxfactory.gen_alphanumeric(),
-        description=fauxfactory.gen_alphanumeric()
+        name=fauxfactory.gen_alphanumeric(15, start="schedule_"),
+        description=fauxfactory.gen_alphanumeric(20, start="schedule_desc_")
     )
     yield schedule
     schedule.delete()

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -200,7 +200,7 @@ class TestRolesViaREST(object):
         roles_len = len(roles)
         new = []
         for _ in range(roles_len):
-            new.append({"name": "test_role_{}".format(fauxfactory.gen_alphanumeric())})
+            new.append({"name": fauxfactory.gen_alphanumeric(15, start="test_role_")})
         if multiple:
             for index in range(roles_len):
                 new[index].update(roles[index]._ref_repr())
@@ -266,7 +266,7 @@ class TestRolesViaREST(object):
             caseimportance: low
             initialEstimate: 1/3h
         """
-        role_data = {"name": "role_name_{}".format(fauxfactory.gen_alphanumeric())}
+        role_data = {"name": fauxfactory.gen_alphanumeric(15, start="role_name_")}
         role = appliance.rest_api.collections.roles.action.add(role_data)[0]
         assert_response(appliance)
         assert role.name == role_data["name"]
@@ -568,7 +568,7 @@ class TestUsersViaREST(object):
         users_len = len(users)
         new = []
         for _ in range(users_len):
-            new.append({"name": "user_name_{}".format(fauxfactory.gen_alphanumeric())})
+            new.append({"name": fauxfactory.gen_alphanumeric(15, "user_name_")})
         if multiple:
             for index in range(users_len):
                 new[index].update(users[index]._ref_repr())

--- a/cfme/tests/configure/test_tag.py
+++ b/cfme/tests/configure/test_tag.py
@@ -264,7 +264,7 @@ class TestTagsViaREST(object):
         for tag in tags:
             tags_data_edited.append({
                 "href": tag.href,
-                "name": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower()),
+                "name": fauxfactory.gen_alphanumeric(15, start="test_tag_").lower(),
             })
         edited = collection.action.edit(*tags_data_edited)
         assert_response(appliance, results_num=tags_len)
@@ -292,7 +292,7 @@ class TestTagsViaREST(object):
         edited = []
         new_names = []
         for tag in tags:
-            new_name = 'test_tag_{}'.format(fauxfactory.gen_alphanumeric())
+            new_name = fauxfactory.gen_alphanumeric(15, start="test_tag_")
             new_names.append(new_name)
             edited.append(tag.action.edit(name=new_name))
             assert_response(appliance)
@@ -349,8 +349,8 @@ class TestTagsViaREST(object):
             initialEstimate: 1/30h
         """
         data = {
-            "name": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower()),
-            "description": "test_tag_{}".format(fauxfactory.gen_alphanumeric().lower())
+            "name": fauxfactory.gen_alphanumeric(15, start="test_tag_").lower(),
+            "description": fauxfactory.gen_alphanumeric(20, start="test_tag_desc_").lower()
         }
         msg = "BadRequestError: Category id, href or name needs to be specified"
         with pytest.raises(Exception, match=msg):

--- a/cfme/tests/configure/test_tag_category.py
+++ b/cfme/tests/configure/test_tag_category.py
@@ -124,7 +124,7 @@ class TestCategoriesViaREST(object):
         new = []
         for _ in range(categories_len):
             new.append(
-                {'description': 'test_category_{}'.format(fauxfactory.gen_alphanumeric().lower())})
+                {'description': fauxfactory.gen_alphanumeric(20, start="test_category_").lower()})
         if multiple:
             for index in range(categories_len):
                 new[index].update(categories[index]._ref_repr())

--- a/cfme/tests/configure/test_timeprofile.py
+++ b/cfme/tests/configure/test_timeprofile.py
@@ -25,7 +25,7 @@ def test_time_profile_crud(appliance):
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.create(
-        description='time_profile {}'.format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(15, start="time_profile"),
         scope='Current User',
         days=True, hours=True,
         timezone='(GMT-10:00) Hawaii')
@@ -136,7 +136,7 @@ def test_time_profile_copy(appliance):
     """
     collection = appliance.collections.time_profiles
     time_profile = collection.create(
-        description='time_profile {}'.format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(20, start="time_profile_"),
         scope='Current User',
         days=True,
         hours=True,

--- a/cfme/tests/containers/test_chargeback.py
+++ b/cfme/tests/containers/test_chargeback.py
@@ -163,7 +163,7 @@ def assign_custom_compute_rate(obj_type, chargeback_rate, provider):
 @pytest.fixture(scope='module')
 def compute_rate(appliance, rate_type, interval):
     variable_rate = 1 if rate_type == 'variable' else 0
-    description = 'custom_rate_' + fauxfactory.gen_alphanumeric()
+    description = fauxfactory.gen_alphanumeric(20, start="custom_rate_")
     data = {
         'Used CPU Cores': {'per_time': interval,
                            'fixed_rate': 1,

--- a/cfme/tests/control/test_actions.py
+++ b/cfme/tests/control/test_actions.py
@@ -77,12 +77,12 @@ def vm_big(request, provider, setup_provider_modscope, big_template_modscope):
 
 @pytest.fixture(scope="module")
 def policy_name():
-    return "action_testing: policy {}".format(fauxfactory.gen_alphanumeric())
+    return fauxfactory.gen_alphanumeric(28, start="action_testing: policy ")
 
 
 @pytest.fixture(scope="module")
 def policy_profile_name():
-    return "action_testing: policy profile {}".format(fauxfactory.gen_alphanumeric())
+    return fauxfactory.gen_alphanumeric(35, start="action_testing: policy profile ")
 
 
 @pytest.fixture(scope="module")
@@ -150,11 +150,11 @@ def host(provider, setup_provider_modscope):
 def host_policy(appliance, host):
     control_policy = appliance.collections.policies.create(
         policies.HostControlPolicy,
-        "action_testing: host policy {}".format(fauxfactory.gen_alphanumeric()),
+        fauxfactory.gen_alphanumeric(35, start="action_testing: host policy "),
     )
     policy_profile_collection = appliance.collections.policy_profiles
     policy_profile = policy_profile_collection.create(
-        "action_testing: host policy profile {}".format(fauxfactory.gen_alphanumeric()),
+        fauxfactory.gen_alphanumeric(40, start="action_testing: host policy profile "),
         policies=[control_policy],
     )
     host.assign_policy_profiles(policy_profile.description)
@@ -559,7 +559,7 @@ def test_action_create_snapshot_and_delete_last(appliance, request, vm, vm_on, p
         casecomponent: Control
     """
     # Set up the policy and prepare finalizer
-    snapshot_name = fauxfactory.gen_alphanumeric()
+    snapshot_name = fauxfactory.gen_alphanumeric(start="snap_")
     snapshot_create_action = appliance.collections.actions.create(
         fauxfactory.gen_alphanumeric(),
         action_type="Create a Snapshot",
@@ -619,7 +619,7 @@ def test_action_create_snapshots_and_delete_them(request, appliance, vm, vm_on, 
         casecomponent: Control
     """
     # Set up the policy and prepare finalizer
-    snapshot_name = fauxfactory.gen_alphanumeric()
+    snapshot_name = fauxfactory.gen_alphanumeric(start="snap_")
     snapshot_create_action = appliance.collections.actions.create(
         fauxfactory.gen_alphanumeric(),
         action_type="Create a Snapshot",

--- a/cfme/tests/control/test_alerts.py
+++ b/cfme/tests/control/test_alerts.py
@@ -228,7 +228,7 @@ def test_alert_rtp(request, appliance, full_template_vm, smtp_test, provider,
     """
     email = fauxfactory.gen_email()
     alert = appliance.collections.alerts.create(
-        "Trigger by CPU {}".format(fauxfactory.gen_alpha(length=4)),
+        fauxfactory.gen_alpha(length=20, start="Trigger by CPU "),
         active=True,
         based_on="VM and Instance",
         evaluate=(
@@ -265,7 +265,7 @@ def test_alert_timeline_cpu(request, appliance, full_template_vm,
         initialEstimate: 1/6h
     """
     alert = appliance.collections.alerts.create(
-        "TL event by CPU {}".format(fauxfactory.gen_alpha(length=4)),
+        fauxfactory.gen_alpha(length=20, start="TL event by CPU "),
         active=True,
         based_on="VM and Instance",
         evaluate=(
@@ -316,7 +316,7 @@ def test_alert_snmp(request, appliance, provider, setup_snmp, setup_candu, full_
     """
     match_string = fauxfactory.gen_alpha(length=8)
     alert = appliance.collections.alerts.create(
-        "Trigger by CPU {}".format(fauxfactory.gen_alpha(length=4)),
+        fauxfactory.gen_alpha(length=20, start="Trigger by CPU "),
         active=True,
         based_on="VM and Instance",
         evaluate=(
@@ -385,7 +385,7 @@ def test_alert_hardware_reconfigured(request, appliance, configure_fleecing, smt
     service_request_desc = ("VM Reconfigure for: {0} - Processor Sockets: {1}, "
         "Processor Cores Per Socket: 1, Total Processors: {1}")
     alert = appliance.collections.alerts.create(
-        "Trigger by hardware reconfigured {}".format(fauxfactory.gen_alpha(length=4)),
+        fauxfactory.gen_alpha(length=36, start="Trigger by hardware reconfigured "),
         active=True,
         based_on="VM and Instance",
         evaluate=(

--- a/cfme/tests/control/test_bugs.py
+++ b/cfme/tests/control/test_bugs.py
@@ -220,7 +220,7 @@ def compliance_condition(appliance, virtualcenter_provider):
     ).format(vm_name, fauxfactory.gen_alphanumeric(), fauxfactory.gen_alphanumeric())
     condition = appliance.collections.conditions.create(
         conditions.VMCondition,
-        "vm-name-{}".format(fauxfactory.gen_alphanumeric()),
+        fauxfactory.gen_alphanumeric(12, start="vm-name-"),
         expression=expression
     )
     yield condition
@@ -230,11 +230,11 @@ def compliance_condition(appliance, virtualcenter_provider):
 @pytest.fixture
 def vm_compliance_policy_profile(appliance, compliance_condition):
     policy = appliance.collections.policies.create(
-        VMCompliancePolicy, "vm-compliance-{}".format(fauxfactory.gen_alphanumeric())
+        VMCompliancePolicy, fauxfactory.gen_alphanumeric(20, start="vm-compliance-")
     )
     policy.assign_conditions(compliance_condition)
     profile = appliance.collections.policy_profiles.create(
-        "VM Compliance Profile {}".format(fauxfactory.gen_alphanumeric()),
+        fauxfactory.gen_alphanumeric(26, start="VM Compliance Profile "),
         [policy],
     )
     yield profile
@@ -343,7 +343,7 @@ def test_check_compliance_history(request, virtualcenter_provider, vmware_vm, ap
     """
     policy = appliance.collections.policies.create(
         VMCompliancePolicy,
-        "Check compliance history policy {}".format(fauxfactory.gen_alpha()),
+        fauxfactory.gen_alpha(36, start="Check compliance history policy "),
         active=True,
         scope="fill_field(VM and Instance : Name, INCLUDES, {})".format(vmware_vm.name)
     )
@@ -439,7 +439,7 @@ def test_vmware_alarm_selection_does_not_fail(request, appliance):
     """
     try:
         alert = appliance.collections.alerts.create(
-            "Trigger by CPU {}".format(fauxfactory.gen_alpha(length=4)),
+            fauxfactory.gen_alpha(length=20, start="Trigger by CPU "),
             active=True,
             based_on="VM and Instance",
             evaluate=("VMware Alarm", {}),

--- a/cfme/tests/control/test_compliance.py
+++ b/cfme/tests/control/test_compliance.py
@@ -25,12 +25,12 @@ pytestmark = [
 
 @pytest.fixture
 def policy_name():
-    return "compliance_testing: policy {}".format(fauxfactory.gen_alphanumeric(8))
+    return fauxfactory.gen_alphanumeric(35, start="compliance_testing: policy ")
 
 
 @pytest.fixture
 def policy_profile_name():
-    return "compliance_testing: policy profile {}".format(fauxfactory.gen_alphanumeric(8))
+    return fauxfactory.gen_alphanumeric(43, start="compliance_testing: policy profile ")
 
 
 @pytest.fixture
@@ -58,7 +58,7 @@ def assign_policy_for_testing(policy_for_testing, host, policy_profile_name):
 
 @pytest.fixture(scope="module")
 def compliance_vm(configure_fleecing_modscope, provider, full_template_modscope):
-    name = "{}-{}".format("test-compliance", fauxfactory.gen_alpha(4))
+    name = fauxfactory.gen_alpha(20, start="test-compliance-")
     collection = provider.appliance.provider_based_collection(provider)
     vm = collection.instantiate(name, provider, full_template_modscope.name)
     # TODO: remove this check once issue with SSA on other hosts in vSphere 6.5 is figured out
@@ -116,19 +116,19 @@ def test_check_package_presence(request, appliance, compliance_vm, analysis_prof
     """
     condition = appliance.collections.conditions.create(
         VMCondition,
-        "Compliance testing condition {}".format(fauxfactory.gen_alphanumeric(8)),
+        fauxfactory.gen_alphanumeric(40, start="Compliance testing condition "),
         expression=("fill_find(field=VM and Instance.Guest Applications : Name, "
             "skey=STARTS WITH, value=kernel, check=Check Count, ckey= = , cvalue=1)")
     )
     request.addfinalizer(lambda: diaper(condition.delete))
     policy = appliance.collections.policies.create(
         VMCompliancePolicy,
-        "Compliance {}".format(fauxfactory.gen_alphanumeric(8))
+        fauxfactory.gen_alphanumeric(15, start="Compliance ")
     )
     request.addfinalizer(lambda: diaper(policy.delete))
     policy.assign_conditions(condition)
     profile = appliance.collections.policy_profiles.create(
-        "Compliance PP {}".format(fauxfactory.gen_alphanumeric(8)),
+        fauxfactory.gen_alphanumeric(20, start="Compliance PP "),
         policies=[policy]
     )
     request.addfinalizer(lambda: diaper(profile.delete))
@@ -159,7 +159,7 @@ def test_check_files(request, appliance, compliance_vm, analysis_profile):
     check_file_contents = "127.0.0.1"
     condition = appliance.collections.conditions.create(
         VMCondition,
-        "Compliance testing condition {}".format(fauxfactory.gen_alphanumeric(8)),
+        fauxfactory.gen_alphanumeric(40, start="Compliance testing condition "),
         expression=("fill_find(VM and Instance.Files : Name, "
             "=, {}, Check Any, Contents, INCLUDES, {})".format(
                 check_file_name, check_file_contents))
@@ -167,12 +167,12 @@ def test_check_files(request, appliance, compliance_vm, analysis_profile):
     request.addfinalizer(lambda: diaper(condition.delete))
     policy = appliance.collections.policies.create(
         VMCompliancePolicy,
-        "Compliance {}".format(fauxfactory.gen_alphanumeric(8))
+        fauxfactory.gen_alphanumeric(15, start="Compliance ")
     )
     request.addfinalizer(lambda: diaper(policy.delete))
     policy.assign_conditions(condition)
     profile = appliance.collections.policy_profiles.create(
-        "Compliance PP {}".format(fauxfactory.gen_alphanumeric(8)),
+        fauxfactory.gen_alphanumeric(20, start="Compliance PP "),
         policies=[policy]
     )
     request.addfinalizer(lambda: diaper(profile.delete))

--- a/cfme/tests/infrastructure/test_child_tenant.py
+++ b/cfme/tests/infrastructure/test_child_tenant.py
@@ -54,8 +54,8 @@ def set_child_tenant_quota(request, appliance, new_child):
 @pytest.fixture(scope='module')
 def new_tenant(appliance):
     collection = appliance.collections.tenants
-    tenant = collection.create(name='tenant{}'.format(fauxfactory.gen_alphanumeric()),
-                               description='tenant_des{}'.format(fauxfactory.gen_alphanumeric()),
+    tenant = collection.create(name=fauxfactory.gen_alphanumeric(15, start="tenant_"),
+                               description=fauxfactory.gen_alphanumeric(15, start="tenant_desc_"),
                                parent=collection.get_root_tenant())
     yield tenant
     if tenant.exists:
@@ -65,10 +65,11 @@ def new_tenant(appliance):
 @pytest.fixture(scope='module')
 def new_child(appliance, new_tenant):
     collection = appliance.collections.tenants
-    child_tenant = collection.create(name='tenant{}'.format(fauxfactory.gen_alphanumeric()),
-                                     description='tenant_des{}'.format(
-                                         fauxfactory.gen_alphanumeric()),
-                                     parent=new_tenant)
+    child_tenant = collection.create(
+        name=fauxfactory.gen_alphanumeric(15, start="tenant_"),
+        description=fauxfactory.gen_alphanumeric(15, start="tenant_desc_"),
+        parent=new_tenant
+    )
     yield child_tenant
     if child_tenant.exists:
         child_tenant.delete()
@@ -77,7 +78,7 @@ def new_child(appliance, new_tenant):
 @pytest.fixture(scope='module')
 def new_group(appliance, new_child, new_tenant):
     collection = appliance.collections.groups
-    group = collection.create(description='group_{}'.format(fauxfactory.gen_alphanumeric()),
+    group = collection.create(description=fauxfactory.gen_alphanumeric(start="group_"),
                               role='EvmRole-super_administrator',
                               tenant='My Company/{}/{}'.format(new_tenant.name, new_child.name))
     yield group
@@ -89,7 +90,7 @@ def new_group(appliance, new_child, new_tenant):
 def new_user(appliance, new_group, new_credential):
     collection = appliance.collections.users
     user = collection.create(
-        name='user_{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="user_"),
         credential=new_credential,
         email=fauxfactory.gen_email(),
         groups=new_group,

--- a/cfme/tests/infrastructure/test_config_management_rest.py
+++ b/cfme/tests/infrastructure/test_config_management_rest.py
@@ -118,7 +118,7 @@ class TestAuthenticationsRESTAPI(object):
         new_names = []
         responses = []
         for auth in authentications:
-            new_name = 'test_edited_{}'.format(fauxfactory.gen_alphanumeric().lower())
+            new_name = fauxfactory.gen_alphanumeric(20, start="test_edited_").lower()
             new_names.append(new_name)
             responses.append(auth.action.edit(name=new_name))
             assert_response(appliance)
@@ -140,7 +140,7 @@ class TestAuthenticationsRESTAPI(object):
         new_names = []
         auths_data_edited = []
         for auth in authentications:
-            new_name = 'test_edited_{}'.format(fauxfactory.gen_alphanumeric().lower())
+            new_name = fauxfactory.gen_alphanumeric(20, start="test_edited_").lower()
             new_names.append(new_name)
             auth.reload()
             auths_data_edited.append({

--- a/cfme/tests/infrastructure/test_customization_template.py
+++ b/cfme/tests/infrastructure/test_customization_template.py
@@ -38,14 +38,13 @@ def test_customization_template_crud(collection, script_type, image_type):
         initialEstimate: 1/15h
     """
 
-    template_crud = collection.create(name="{}_{}".format(script_type,
-                                                          fauxfactory.gen_alphanumeric(4)),
+    template_crud = collection.create(name=fauxfactory.gen_alphanumeric(15, script_type),
                                       description=fauxfactory.gen_alphanumeric(16),
                                       image_type=image_type.name,
                                       script_type=script_type,
                                       script_data='Testing the script')
     with update(template_crud):
-        template_crud.name = template_crud.name + "_update"
+        template_crud.name = f"{template_crud.name}_update"
     collection.delete(False, template_crud)
 
 

--- a/cfme/tests/infrastructure/test_iso_provisioning.py
+++ b/cfme/tests/infrastructure/test_iso_provisioning.py
@@ -74,7 +74,7 @@ def datastore_init(iso_cust_template, iso_datastore, provisioning, setup_provide
 
 @pytest.fixture(scope="function")
 def vm_name():
-    vm_name = 'test_iso_prov_{}'.format(fauxfactory.gen_alphanumeric(8))
+    vm_name = fauxfactory.gen_alphanumeric(20, start="test_iso_prov_")
     return vm_name
 
 

--- a/cfme/tests/infrastructure/test_kubevirt.py
+++ b/cfme/tests/infrastructure/test_kubevirt.py
@@ -48,7 +48,7 @@ def test_k6t_provider_crud(provider):
         casecomponent: Infra
     """
     with update(provider):
-        provider.name = fauxfactory.gen_alphanumeric() + '_updated'
+        provider.name = fauxfactory.gen_alphanumeric(start="edited_")
 
     provider.delete()
     provider.wait_for_delete()

--- a/cfme/tests/infrastructure/test_project_quota.py
+++ b/cfme/tests/infrastructure/test_project_quota.py
@@ -53,8 +53,8 @@ def set_project_quota(request, appliance, new_project):
 @pytest.fixture(scope='module')
 def new_project(appliance):
     collection = appliance.collections.projects
-    project = collection.create(name='project{}'.format(fauxfactory.gen_alphanumeric()),
-                                description='project_des{}'.format(fauxfactory.gen_alphanumeric()),
+    project = collection.create(name=fauxfactory.gen_alphanumeric(15, start="project_"),
+                                description=fauxfactory.gen_alphanumeric(15, start="project_desc_"),
                                 parent=collection.get_root_tenant())
     yield project
     project.delete()
@@ -63,7 +63,7 @@ def new_project(appliance):
 @pytest.fixture(scope='module')
 def new_role(appliance):
     collection = appliance.collections.roles
-    role = collection.create(name='role_{}'.format(fauxfactory.gen_alphanumeric()),
+    role = collection.create(name=fauxfactory.gen_alphanumeric(start="role_"),
                              vm_restriction=None,
                              product_features=[(['Everything'], True)])
     yield role
@@ -73,7 +73,7 @@ def new_role(appliance):
 @pytest.fixture(scope='module')
 def new_group(appliance, new_project, new_role):
     collection = appliance.collections.groups
-    group = collection.create(description='group_{}'.format(fauxfactory.gen_alphanumeric()),
+    group = collection.create(description=fauxfactory.gen_alphanumeric(start="group_"),
                               role=new_role.name,
                               tenant='My Company/{}'.format(new_project.name))
     yield group
@@ -84,7 +84,7 @@ def new_group(appliance, new_project, new_role):
 def new_user(appliance, new_group, new_credential):
     collection = appliance.collections.users
     user = collection.create(
-        name='user_{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="user_"),
         credential=new_credential,
         email=fauxfactory.gen_email(),
         groups=new_group,

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -50,12 +50,10 @@ def vm_name():
 def prov_data(provisioning, provider):
     data = {
         'request': {
-            'email': "{}@{}.test".format(fauxfactory.gen_alphanumeric(),
-                                         fauxfactory.gen_alphanumeric()),
+            'email': fauxfactory.gen_email(),
             'first_name': fauxfactory.gen_alphanumeric(),
             'last_name': fauxfactory.gen_alphanumeric(),
-            'manager_name': '{} {}'.format(fauxfactory.gen_alphanumeric(),
-                                           fauxfactory.gen_alphanumeric())},
+            'manager_name': fauxfactory.gen_alphanumeric(20, start="manager ")},
         'network': {'vlan': partial_match(provisioning.get('vlan'))},
         'environment': {'datastore_name': {'name': provisioning['datastore']},
                         'host_name': {'name': provisioning['host']}},

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -41,7 +41,7 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
         },
         "vm_fields": {
             "number_of_cpus": 1,
-            "vm_name": "test_rest_prov_{}".format(fauxfactory.gen_alphanumeric()),
+            "vm_name": fauxfactory.gen_alphanumeric(20, start="test_rest_prov_"),
             "vm_memory": "2048",
             "vlan": provider.data["provisioning"]["vlan"],
         },

--- a/cfme/tests/infrastructure/test_pxe_provisioning.py
+++ b/cfme/tests/infrastructure/test_pxe_provisioning.py
@@ -89,7 +89,7 @@ def setup_pxe_servers_vm_prov(pxe_server, pxe_cust_template, provisioning):
 
 @pytest.fixture(scope="function")
 def vm_name():
-    vm_name = 'test_pxe_prov_{}'.format(fauxfactory.gen_alphanumeric())
+    vm_name = fauxfactory.gen_alphanumeric(20, start="test_pxe_prov_")
     return vm_name
 
 

--- a/cfme/tests/infrastructure/test_quota.py
+++ b/cfme/tests/infrastructure/test_quota.py
@@ -56,10 +56,11 @@ def prov_data(vm_name):
 
 @pytest.fixture(scope='module')
 def domain(appliance):
-    domain = appliance.collections.domains.create('test_{}'.format(fauxfactory.gen_alphanumeric()),
-                                                  'description_{}'.format(
-                                                      fauxfactory.gen_alphanumeric()),
-                                                  enabled=True)
+    domain = appliance.collections.domains.create(
+        fauxfactory.gen_alphanumeric(15, start="domain_"),
+        fauxfactory.gen_alphanumeric(15, start="domain_desc_"),
+        enabled=True
+    )
     yield domain
     if domain.exists:
         domain.delete()
@@ -111,10 +112,11 @@ def new_tenant(appliance):
     tenant_list = []
     for i in range(0, NUM_TENANTS):
         collection = appliance.collections.tenants
-        tenant = collection.create(name='tenant{}'.format(fauxfactory.gen_alphanumeric()),
-                                   description='tenant_des{}'.
-                                   format(fauxfactory.gen_alphanumeric()),
-                                   parent=collection.get_root_tenant())
+        tenant = collection.create(
+            name=fauxfactory.gen_alphanumeric(15, start="tenant_"),
+            description=fauxfactory.gen_alphanumeric(15, start="tenant_desc_"),
+            parent=collection.get_root_tenant()
+        )
         tenant_list.append(tenant)
     yield tenant_list
     for tnt in tenant_list:
@@ -147,7 +149,7 @@ def new_group_list(appliance, new_tenant):
     group_list = []
     collection = appliance.collections.groups
     for i in range(0, NUM_GROUPS):
-        group = collection.create(description='group_{}'.format(fauxfactory.gen_alphanumeric()),
+        group = collection.create(description=fauxfactory.gen_alphanumeric(start="group_"),
                                   role='EvmRole-super_administrator',
                                   tenant='My Company/{}'.format(new_tenant[i].name))
         group_list.append(group)
@@ -163,7 +165,7 @@ def new_user(appliance, new_group_list, new_credential):
     """
     collection = appliance.collections.users
     user = collection.create(
-        name='user_{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="user_"),
         credential=new_credential,
         email=fauxfactory.gen_email(),
         groups=new_group_list,

--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -65,10 +65,11 @@ def prov_data(provider, vm_name, template_name):
 
 @pytest.fixture(scope='module')
 def domain(appliance):
-    domain = appliance.collections.domains.create('test_{}'.format(fauxfactory.gen_alphanumeric()),
-                                                  'description_{}'.format(
-                                                      fauxfactory.gen_alphanumeric()),
-                                                  enabled=True)
+    domain = appliance.collections.domains.create(
+        fauxfactory.gen_alphanumeric(15, start="domain_"),
+        fauxfactory.gen_alphanumeric(15, start="domain_desc_"),
+        enabled=True
+    )
     yield domain
     if domain.exists:
         domain.delete()
@@ -79,7 +80,7 @@ def catalog_item(appliance, provider, dialog, catalog, prov_data):
 
     collection = appliance.collections.catalog_items
     catalog_item = collection.create(provider.catalog_item_type,
-                                     name='test_{}'.format(fauxfactory.gen_alphanumeric()),
+                                     name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
                                      description='test catalog',
                                      display_in=True,
                                      catalog=catalog,
@@ -93,7 +94,7 @@ def catalog_item(appliance, provider, dialog, catalog, prov_data):
 @pytest.fixture
 def catalog_bundle(appliance, dialog, catalog, catalog_item):
     collection = appliance.collections.catalog_bundles
-    catalog_bundle = collection.create(name='test_{}'.format(fauxfactory.gen_alphanumeric()),
+    catalog_bundle = collection.create(name=fauxfactory.gen_alphanumeric(15, start="cat_bundle_"),
                                        catalog_items=[catalog_item.name],
                                        description='test catalog bundle',
                                        display_in=True,

--- a/cfme/tests/infrastructure/test_scvmm_specific.py
+++ b/cfme/tests/infrastructure/test_scvmm_specific.py
@@ -38,7 +38,7 @@ def get_vhd_name(url, pattern="hyperv"):
 
 @pytest.fixture
 def vm(provider, small_template):
-    vm_name = "test-scvmm-{}".format(fauxfactory.gen_alpha())
+    vm_name = fauxfactory.gen_alpha(18, start="test-scvmm-")
     vm = provider.appliance.collections.infra_vms.instantiate(
         vm_name, provider, small_template.name
     )

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -538,7 +538,7 @@ def test_create_snapshot_via_ae(appliance, request, domain, small_test_vm):
     request.addfinalizer(instance.delete)
 
     # SIMULATE
-    snap_name = fauxfactory.gen_alpha()
+    snap_name = fauxfactory.gen_alpha(start="snap_")
     snapshot = InfraVm.Snapshot(name=snap_name, parent_vm=small_test_vm)
     simulate(
         appliance=appliance,

--- a/cfme/tests/infrastructure/test_ssa_vddk.py
+++ b/cfme/tests/infrastructure/test_ssa_vddk.py
@@ -33,7 +33,7 @@ def ssa_analysis_profile(appliance):
     for file in ["/etc/hosts", "/etc/passwd"]:
         collected_files.append({"Name": file, "Collect Contents?": True})
 
-    analysis_profile_name = 'ssa_analysis_{}'.format(fauxfactory.gen_alphanumeric())
+    analysis_profile_name = fauxfactory.gen_alphanumeric(18, start="ssa_analysis_")
     analysis_profile_collection = appliance.collections.analysis_profiles
     analysis_profile = analysis_profile_collection.create(
         name=analysis_profile_name,

--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -67,11 +67,11 @@ def roottenant(appliance):
 def tenants_setup(appliance):
     tenants = appliance.collections.tenants
     my_company = tenants.get_root_tenant()
-    test_parent = tenants.create(name='test_parent{}'.format(fauxfactory.gen_alphanumeric()),
-                                 description='test_parent{}'.format(fauxfactory.gen_alphanumeric()),
+    test_parent = tenants.create(name=fauxfactory.gen_alphanumeric(18, start="test_parent_"),
+                                 description=fauxfactory.gen_alphanumeric(18, start="parent_desc_"),
                                  parent=my_company)
-    test_child = tenants.create(name='test_child{}'.format(fauxfactory.gen_alphanumeric()),
-                                description='test_child{}'.format(fauxfactory.gen_alphanumeric()),
+    test_child = tenants.create(name=fauxfactory.gen_alphanumeric(18, start="test_child_"),
+                                description=fauxfactory.gen_alphanumeric(18, start="child_desc_"),
                                 parent=test_parent)
     yield test_parent, test_child
     test_child.delete()
@@ -110,7 +110,7 @@ def catalog_item(appliance, provider, dialog, catalog, prov_data, set_default):
     collection = appliance.collections.catalog_items
     catalog_item = collection.create(
         provider.catalog_item_type,
-        name='test_{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
         description='test catalog',
         display_in=True,
         catalog=catalog,

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -30,14 +30,14 @@ pytestmark = [
 
 @pytest.fixture(scope="function")
 def clone_vm_name():
-    clone_vm_name = 'test_cloning_{}'.format(fauxfactory.gen_alphanumeric())
+    clone_vm_name = fauxfactory.gen_alphanumeric(18, start="test_cloning_")
     return clone_vm_name
 
 
 @pytest.fixture
 def create_vm(appliance, provider, request):
     """Fixture to provision vm to the provider being tested"""
-    vm_name = 'test_clone_{}'.format(fauxfactory.gen_alphanumeric())
+    vm_name = fauxfactory.gen_alphanumeric(15, start="test_clone_")
     vm = appliance.collections.infra_vms.instantiate(vm_name, provider)
     logger.info("provider_key: %s", provider.key)
 

--- a/cfme/tests/infrastructure/test_vm_ownership.py
+++ b/cfme/tests/infrastructure/test_vm_ownership.py
@@ -146,7 +146,7 @@ def test_rename_vm(small_vm):
     """
     view = navigate_to(small_vm, 'Details')
     vm_name = small_vm.name
-    changed_vm = small_vm.rename(new_vm_name="test-{}".format(fauxfactory.gen_alphanumeric()))
+    changed_vm = small_vm.rename(new_vm_name=fauxfactory.gen_alphanumeric(15, start="renamed_"))
     view.flash.wait_displayed(timeout=20)
     view.flash.assert_success_message('Rename of Virtual Machine "{vm_name}" has been initiated'
                                       .format(vm_name=vm_name))

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -96,7 +96,7 @@ def test_edit_vm(request, vm, appliance, from_detail):
         initialEstimate: 1/4h
     """
     request.addfinalizer(vm.action.delete)
-    new_description = 'Test REST VM {}'.format(fauxfactory.gen_alphanumeric(5))
+    new_description = fauxfactory.gen_alphanumeric(18, start="Test REST VM ")
     payload = {'description': new_description}
     if from_detail:
         edited = vm.action.edit(**payload)

--- a/cfme/tests/infrastructure/test_vmware_provider.py
+++ b/cfme/tests/infrastructure/test_vmware_provider.py
@@ -340,9 +340,11 @@ def test_vmware_inaccessible_datastore_vm_provisioning(request, appliance, provi
         logger.info("Found {} inaccessible_datastores".format(inaccessible_datastores))
     else:
         pytest.skip("This provider {} has no inaccessible_datastores.".format(provider.name))
-    vm = appliance.collections.infra_vms.create('test-vmware-{}'.format(
-        fauxfactory.gen_alphanumeric()), provider, find_in_cfme=True, wait=True,
-        form_values={'environment': {'automatic_placement': True}})
+    vm = appliance.collections.infra_vms.create(
+        fauxfactory.gen_alphanumeric(18, start="test-vmware-"),
+        provider, find_in_cfme=True, wait=True,
+        form_values={'environment': {'automatic_placement': True}}
+    )
     request.addfinalizer(vm.delete)
     assert vm.datastore.name not in inaccessible_datastores
 
@@ -370,10 +372,11 @@ def test_vmware_provisioned_vm_host_relationship(request, appliance, provider):
             2.See all available templates
             3.CFME Provisioned VM should have host relationship.
     """
-    vm = appliance.collections.infra_vms.create('test-vmware-{}'
-        .format(fauxfactory.gen_alphanumeric()),
+    vm = appliance.collections.infra_vms.create(
+        fauxfactory.gen_alphanumeric(18, start="test-vmware-"),
         provider, find_in_cfme=True, wait=True,
-        form_values={'environment': {'automatic_placement': True}})
+        form_values={'environment': {'automatic_placement': True}}
+    )
     request.addfinalizer(vm.delete)
     # assert if Host property is set for VM.
     assert isinstance(vm.host, Host)

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -274,7 +274,7 @@ def format_user_principal(username, user_type, auth_provider):
 @pytest.fixture(scope='function')
 def local_group(temp_appliance_preconfig_long):
     """Helper method to check for existance of a group and delete if need be"""
-    group_name = 'test-group-{}'.format(gen_alphanumeric(length=5))
+    group_name = gen_alphanumeric(length=15, start="test-group-")
     group = temp_appliance_preconfig_long.collections.groups.create(
         description=group_name, role='EvmRole-desktop'
     )

--- a/cfme/tests/integration/test_db_auth.py
+++ b/cfme/tests/integration/test_db_auth.py
@@ -22,7 +22,7 @@ TEST_PASSWORDS = [
 
 @pytest.fixture
 def user(appliance):
-    name = f"test-user-{fauxfactory.gen_alpha()}"
+    name = fauxfactory.gen_alpha(15, start="test-user-")
     creds = Credential(principal=name, secret=fauxfactory.gen_alpha())
     user_group = appliance.collections.groups.instantiate(description="EvmGroup-vm_user")
     user = appliance.collections.users.create(
@@ -36,7 +36,7 @@ def user(appliance):
 
 @pytest.fixture
 def nonexistent_user(appliance):
-    name = f"test-user-{fauxfactory.gen_alpha()}"
+    name = fauxfactory.gen_alpha(15, start="test-user-")
     creds = Credential(principal=name, secret=fauxfactory.gen_alpha())
     user_group = appliance.collections.groups.instantiate(description="EvmGroup-vm_user")
     user = appliance.collections.users.instantiate(

--- a/cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py
+++ b/cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py
@@ -61,7 +61,7 @@ def vm_ownership(enable_candu, provider, appliance):
     # No vm creation or cleanup
     user = appliance.collections.users.create(
         name='{}_{}'.format(provider.name, fauxfactory.gen_alphanumeric()),
-        credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric()),
+        credential=Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
             secret='secret'),
         email='abc@example.com',
         groups=cb_group,
@@ -359,7 +359,7 @@ def chargeback_report_custom(appliance, vm_ownership, assign_custom_rate, interv
 @pytest.fixture(scope="module")
 def new_compute_rate(appliance, interval):
     """Create a new Compute Chargeback rate"""
-    desc = 'custom_{}_{}'.format(interval, fauxfactory.gen_alphanumeric())
+    desc = fauxfactory.gen_alphanumeric(20, start=f"custom_{interval}")
     try:
         compute = appliance.collections.compute_rates.create(
             description=desc,

--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -74,8 +74,8 @@ def vm_ownership(enable_candu, provider, appliance):
     group_collection = appliance.collections.groups
     cb_group = group_collection.instantiate(description='EvmGroup-user')
     user = appliance.collections.users.create(
-        name="{}_{}".format(provider.name, fauxfactory.gen_alphanumeric()),
-        credential=Credential(principal='uid{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(25, start=provider.name),
+        credential=Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
                               secret='secret'),
         email='abc@example.com',
         groups=cb_group,
@@ -362,7 +362,7 @@ def chargeback_report_custom(appliance, vm_ownership, assign_custom_rate, provid
 @pytest.yield_fixture(scope="module")
 def new_chargeback_rate(appliance):
     """Create a new chargeback rate"""
-    desc = 'custom_{}'.format(fauxfactory.gen_alphanumeric())
+    desc = fauxfactory.gen_alphanumeric(15, start="custom_")
     try:
         compute = appliance.collections.compute_rates.create(
             description=desc,

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -325,7 +325,7 @@ def test_import_report_rest(appliance, request):
         caseimportance: medium
         initialEstimate: 1/16h
     """
-    menu_name = 'test_report_{}'.format(fauxfactory.gen_alphanumeric())
+    menu_name = fauxfactory.gen_alphanumeric(18, start="test_report_")
     data = {
         'report': {
             'menu_name': menu_name,

--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -66,7 +66,7 @@ def vm_ownership(enable_candu, clean_setup_provider, provider, appliance):
     cb_group = group_collection.instantiate(description='EvmGroup-user')
     user = appliance.collections.users.create(
         name=fauxfactory.gen_alphanumeric(),
-        credential=Credential(principal='uid' + '{}'.format(fauxfactory.gen_alphanumeric()),
+        credential=Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
             secret='secret'),
         email='abc@example.com',
         groups=cb_group,

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -54,7 +54,7 @@ TIMER = {
 }
 
 INVALID_EMAILS = {
-    "string": "{name}".format(name=fauxfactory.gen_alpha()),
+    "string": fauxfactory.gen_alpha(),
     "multiple-dots": "{name}..{name}@example..com".format(
         name=fauxfactory.gen_alpha(5)
     ),

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -84,8 +84,8 @@ def vm_ownership(enable_candu, provider, appliance):
     user = None
     try:
         user = appliance.collections.users.create(
-            name=provider.name + fauxfactory.gen_alphanumeric(),
-            credential=Credential(principal='uid' + '{}'.format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(25, start=provider.name),
+            credential=Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
                 secret='secret'),
             email='abc@example.com',
             groups=cb_group,

--- a/cfme/tests/intelligence/test_chargeback.py
+++ b/cfme/tests/intelligence/test_chargeback.py
@@ -193,7 +193,7 @@ class TestRatesViaREST(object):
         if multiple:
             rates_data_edited = []
             for rate in rates:
-                new_description = "test_rate_{}".format(fauxfactory.gen_alphanumeric().lower())
+                new_description = fauxfactory.gen_alphanumeric(15, start="test_rate_").lower()
                 new_descriptions.append(new_description)
                 rate.reload()
                 rates_data_edited.append({
@@ -205,7 +205,7 @@ class TestRatesViaREST(object):
         else:
             edited = []
             for rate in rates:
-                new_description = "test_rate_{}".format(fauxfactory.gen_alphanumeric().lower())
+                new_description = fauxfactory.gen_alphanumeric(15, start="test_rate_").lower()
                 new_descriptions.append(new_description)
                 edited.append(rate.action.edit(description=new_description))
                 assert_response(appliance)

--- a/cfme/tests/intelligence/test_reports_with_timelines.py
+++ b/cfme/tests/intelligence/test_reports_with_timelines.py
@@ -102,8 +102,7 @@ def setup_for_reports(request, appliance, provider, path, updates, vm_crud, regi
 @pytest.fixture
 def vm_crud(provider, small_template):
     template = small_template
-    base_name = "test_events_{}"
-    vm_name = base_name.format(fauxfactory.gen_alpha(length=8).lower())
+    vm_name = fauxfactory.gen_alpha(length=18, start="test_events_").lower()
 
     collection = provider.appliance.provider_based_collection(provider)
     vm = collection.instantiate(vm_name, provider, template_name=template.name)

--- a/cfme/tests/networks/test_provision_to_virtual_network.py
+++ b/cfme/tests/networks/test_provision_to_virtual_network.py
@@ -24,7 +24,7 @@ pytestmark = [
 @pytest.fixture(scope='function')
 def network(provider, appliance):
     """Adding cloud network in ui."""
-    test_name = 'test_network_{}'.format(fauxfactory.gen_alphanumeric(6))
+    test_name = fauxfactory.gen_alphanumeric(18, start="test_network_")
     net_manager = '{} Network Manager'.format(provider.name)
 
     collection = appliance.collections.network_providers

--- a/cfme/tests/networks/test_sdn_inventory_collection.py
+++ b/cfme/tests/networks/test_sdn_inventory_collection.py
@@ -133,7 +133,7 @@ def test_sdn_api_inventory_loadbalancers(provider, appliance):
 @pytest.fixture
 def secgroup_with_rule(provider):
     res_group = provider.data['provisioning']['resource_group']
-    secgroup_name = 'secgroup_with_rule_{}'.format(fauxfactory.gen_alpha(8).lower())
+    secgroup_name = fauxfactory.gen_alpha(25, start="secgroup_with_rule_").lower()
     provider.mgmt.create_netsec_group(secgroup_name, res_group)
     provider.mgmt.create_netsec_group_port_allow(secgroup_name,
         'Tcp', '*', '*', 'Allow', 'Inbound', description='Allow port 22',

--- a/cfme/tests/networks/test_sdn_security_groups.py
+++ b/cfme/tests/networks/test_sdn_security_groups.py
@@ -17,10 +17,12 @@ pytestmark = [
 def sec_group(appliance, provider):
     collection = appliance.collections.security_groups
     try:
-        sec_group = collection.create(name=fauxfactory.gen_alphanumeric(),
-                                      description=fauxfactory.gen_alphanumeric(),
-                                      provider=provider,
-                                      wait=True)
+        sec_group = collection.create(
+            name=fauxfactory.gen_alphanumeric(15, start="sec_grp_"),
+            description=fauxfactory.gen_alphanumeric(18, start="sec_grp_desc_"),
+            provider=provider,
+            wait=True
+        )
     except TimedOutError:
         pytest.fail('Timed out creating Security Groups')
     yield sec_group
@@ -66,10 +68,12 @@ def test_security_group_create_cancel(appliance, provider):
         casecomponent: Cloud
     """
     security_group = appliance.collections.security_groups
-    sec_group = security_group.create(name=fauxfactory.gen_alphanumeric(),
-                                      description=fauxfactory.gen_alphanumeric(),
-                                      provider=provider,
-                                      cancel=True)
+    sec_group = security_group.create(
+        name=fauxfactory.gen_alphanumeric(15, start="sec_grp_"),
+        description=fauxfactory.gen_alphanumeric(18, start="sec_grp_desc_"),
+        provider=provider,
+        cancel=True
+    )
     assert not sec_group.exists
 
 

--- a/cfme/tests/openstack/cloud/test_flavors.py
+++ b/cfme/tests/openstack/cloud/test_flavors.py
@@ -47,7 +47,7 @@ def zero_disk_flavor(provider):
 def private_flavor(appliance, provider):
     prov_data = provider.data['provisioning']
     collection = appliance.collections.cloud_flavors
-    private_flavor = collection.create(name=fauxfactory.gen_alpha(),
+    private_flavor = collection.create(name=fauxfactory.gen_alpha(12, start="flavor_"),
                                provider=provider,
                                ram=RAM,
                                vcpus=VCPUS,
@@ -177,7 +177,7 @@ def test_flavor_crud(appliance, provider, request):
         initialEstimate: 1/4h
     """
     collection = appliance.collections.cloud_flavors
-    flavor = collection.create(name=fauxfactory.gen_alpha(),
+    flavor = collection.create(name=fauxfactory.gen_alpha(12, start="flavor_"),
                                provider=provider,
                                ram=RAM,
                                vcpus=VCPUS,

--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -68,7 +68,7 @@ def new_instance(provider):
 def volume(appliance, provider):
     collection = appliance.collections.volumes
     storage_manager = '{} Cinder Manager'.format(provider.name)
-    volume = collection.create(name=fauxfactory.gen_alpha(),
+    volume = collection.create(name=fauxfactory.gen_alpha(start="vol_"),
                                storage_manager=storage_manager,
                                tenant=provider.data['provisioning']['cloud_tenant'],
                                size=VOLUME_SIZE,
@@ -81,7 +81,7 @@ def volume(appliance, provider):
 
 @pytest.fixture(scope='function')
 def volume_with_type(appliance, provider):
-    vol_type = provider.mgmt.capi.volume_types.create(name=fauxfactory.gen_alpha())
+    vol_type = provider.mgmt.capi.volume_types.create(name=fauxfactory.gen_alpha(start="type_"))
     volume_type = appliance.collections.volume_types.instantiate(vol_type.name, provider)
 
     @wait_for_decorator(delay=10, timeout=300,
@@ -92,7 +92,7 @@ def volume_with_type(appliance, provider):
 
     collection = appliance.collections.volumes
     storage_manager = '{} Cinder Manager'.format(provider.name)
-    volume = collection.create(name=fauxfactory.gen_alpha(),
+    volume = collection.create(name=fauxfactory.gen_alpha(start="vol_"),
                                storage_manager=storage_manager,
                                tenant=provider.data['provisioning']['cloud_tenant'],
                                volume_type=volume_type.name,

--- a/cfme/tests/openstack/cloud/test_networks.py
+++ b/cfme/tests/openstack/cloud/test_networks.py
@@ -29,7 +29,7 @@ def delete_entity(entity):
 
 def create_network(appliance, provider, is_external):
     collection = appliance.collections.cloud_networks
-    network = collection.create(name=fauxfactory.gen_alpha(),
+    network = collection.create(name=fauxfactory.gen_alpha(start="nwk_"),
                                 tenant=provider.data.get('provisioning').get('cloud_tenant'),
                                 provider=provider,
                                 network_type='VXLAN',
@@ -40,7 +40,7 @@ def create_network(appliance, provider, is_external):
 
 def create_subnet(appliance, provider, network):
     collection = appliance.collections.network_subnets
-    subnet = collection.create(name=fauxfactory.gen_alpha(),
+    subnet = collection.create(name=fauxfactory.gen_alpha(12, start="subnet_"),
                                tenant=provider.data.get('provisioning').get('cloud_tenant'),
                                provider=provider,
                                network_manager='{} Network Manager'.format(provider.name),
@@ -51,7 +51,7 @@ def create_subnet(appliance, provider, network):
 
 def create_router(appliance, provider, ext_gw, ext_network=None, ext_subnet=None):
     collection = appliance.collections.network_routers
-    router = collection.create(name=fauxfactory.gen_alpha(),
+    router = collection.create(name=fauxfactory.gen_alpha(12, start="router_"),
                                tenant=provider.data.get('provisioning').get('cloud_tenant'),
                                provider=provider,
                                network_manager='{} Network Manager'.format(provider.name),
@@ -133,7 +133,7 @@ def test_edit_network(network):
         casecomponent: Cloud
         initialEstimate: 1/4h
     """
-    network.edit(name=fauxfactory.gen_alpha())
+    network.edit(name=fauxfactory.gen_alpha(12, start="edited_"))
     wait_for(network.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
     wait_for(lambda: network.exists,
@@ -184,7 +184,7 @@ def test_edit_subnet(subnet):
         casecomponent: Cloud
         initialEstimate: 1/4h
     """
-    subnet.edit(new_name=fauxfactory.gen_alpha())
+    subnet.edit(new_name=fauxfactory.gen_alpha(12, start="edited_"))
     wait_for(subnet.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
     wait_for(lambda: subnet.exists, delay=15, timeout=600, fail_func=subnet.browser.refresh)
@@ -244,7 +244,7 @@ def test_edit_router(router):
         casecomponent: Cloud
         initialEstimate: 1/4h
     """
-    router.edit(name=fauxfactory.gen_alpha())
+    router.edit(name=fauxfactory.gen_alpha(12, start="edited_"))
     wait_for(router.provider_obj.is_refreshed, func_kwargs=dict(refresh_delta=10), timeout=600,
              delay=10)
     wait_for(lambda: router.exists,

--- a/cfme/tests/openstack/cloud/test_volume_backup.py
+++ b/cfme/tests/openstack/cloud/test_volume_backup.py
@@ -24,7 +24,7 @@ def volume_backup(appliance, provider):
     backup_collection = appliance.collections.volume_backups.filter({'provider': provider})
 
     # create new volume
-    volume = volume_collection.create(name=fauxfactory.gen_alpha(),
+    volume = volume_collection.create(name=fauxfactory.gen_alpha(start="vol_"),
                                       storage_manager=storage_manager,
                                       tenant=provider.data['provisioning']['cloud_tenant'],
                                       size=VOLUME_SIZE,
@@ -32,7 +32,7 @@ def volume_backup(appliance, provider):
 
     # create new backup for crated volume
     if volume.status == 'available':
-        backup_name = fauxfactory.gen_alpha()
+        backup_name = fauxfactory.gen_alpha(start="bkup_")
         volume.create_backup(backup_name)
         volume_backup = backup_collection.instantiate(backup_name, provider)
         yield volume_backup
@@ -50,7 +50,7 @@ def volume_backup(appliance, provider):
 
 @pytest.fixture(scope='function')
 def volume_backup_with_type(appliance, provider):
-    vol_type = provider.mgmt.capi.volume_types.create(name=fauxfactory.gen_alpha())
+    vol_type = provider.mgmt.capi.volume_types.create(name=fauxfactory.gen_alpha(start="type_"))
     volume_type = appliance.collections.volume_types.instantiate(vol_type.name, provider)
 
     @wait_for_decorator(delay=10, timeout=300,
@@ -64,7 +64,7 @@ def volume_backup_with_type(appliance, provider):
     backup_collection = appliance.collections.volume_backups.filter({'provider': provider})
 
     # create new volume
-    volume = volume_collection.create(name=fauxfactory.gen_alpha(),
+    volume = volume_collection.create(name=fauxfactory.gen_alpha(start="vol_"),
                                       storage_manager=storage_manager,
                                       tenant=provider.data['provisioning']['cloud_tenant'],
                                       volume_type=volume_type.name,
@@ -73,7 +73,7 @@ def volume_backup_with_type(appliance, provider):
 
     # create new backup for crated volume
     if volume.status == 'available':
-        backup_name = fauxfactory.gen_alpha()
+        backup_name = fauxfactory.gen_alpha(start="bkup_")
         volume.create_backup(backup_name)
         volume_backup = backup_collection.instantiate(backup_name, provider)
         yield volume_backup
@@ -97,7 +97,7 @@ def incremental_backup(volume_backup, provider):
 
     # create incremental backup for a volume with existing backup
     if volume.status == 'available':
-        backup_name = fauxfactory.gen_alpha()
+        backup_name = fauxfactory.gen_alpha(start="bkup_")
         volume.create_backup(backup_name, incremental=True)
         incremental_backup = backup_collection.instantiate(backup_name, provider)
         yield incremental_backup
@@ -113,7 +113,7 @@ def incremental_backup(volume_backup, provider):
 
 @pytest.fixture(scope='function')
 def new_instance(provider):
-    instance_name = fauxfactory.gen_alpha()
+    instance_name = fauxfactory.gen_alpha(15, start="test_vol_")
     collection = provider.appliance.provider_based_collection(provider)
     instance = collection.create_rest(instance_name, provider)
     yield instance
@@ -176,7 +176,7 @@ def test_incr_backup_of_attached_volume_crud(appliance, provider, request, attac
         casecomponent: Cloud
         initialEstimate: 1/4h
     """
-    backup_name = fauxfactory.gen_alpha()
+    backup_name = fauxfactory.gen_alpha(start="bkup_")
     collection = appliance.collections.volume_backups.filter({'provider': provider})
     attached_volume.create_backup(backup_name, incremental=True, force=True)
     incr_backup_of_attached_volume = collection.instantiate(backup_name, provider)

--- a/cfme/tests/openstack/cloud/test_volumes.py
+++ b/cfme/tests/openstack/cloud/test_volumes.py
@@ -22,7 +22,7 @@ VOLUME_SIZE = 1
 def volume(appliance, provider):
     collection = appliance.collections.volumes
     storage_manager = '{} Cinder Manager'.format(provider.name)
-    volume = collection.create(name=fauxfactory.gen_alpha(),
+    volume = collection.create(name=fauxfactory.gen_alpha(start="vol_"),
                                storage_manager=storage_manager,
                                tenant=provider.data['provisioning']['cloud_tenant'],
                                size=VOLUME_SIZE,
@@ -39,7 +39,7 @@ def volume(appliance, provider):
 @pytest.mark.regression
 @pytest.fixture(scope='function')
 def volume_with_type(appliance, provider):
-    vol_type = provider.mgmt.capi.volume_types.create(name=fauxfactory.gen_alpha())
+    vol_type = provider.mgmt.capi.volume_types.create(name=fauxfactory.gen_alpha(start="type_"))
     volume_type = appliance.collections.volume_types.instantiate(vol_type.name, provider)
 
     @wait_for_decorator(delay=10, timeout=300,
@@ -50,7 +50,7 @@ def volume_with_type(appliance, provider):
 
     collection = appliance.collections.volumes
     storage_manager = '{} Cinder Manager'.format(provider.name)
-    volume = collection.create(name=fauxfactory.gen_alpha(),
+    volume = collection.create(name=fauxfactory.gen_alpha(start="vol_"),
                                storage_manager=storage_manager,
                                tenant=provider.data['provisioning']['cloud_tenant'],
                                volume_type=volume_type.name,
@@ -67,7 +67,7 @@ def volume_with_type(appliance, provider):
 
 @pytest.fixture(scope='function')
 def new_instance(provider):
-    instance_name = fauxfactory.gen_alpha()
+    instance_name = fauxfactory.gen_alpha(15, start="test_vol_")
     collection = provider.appliance.provider_based_collection(provider)
     instance = collection.create_rest(instance_name, provider)
     yield instance
@@ -96,7 +96,7 @@ def test_edit_volume(volume, appliance):
         casecomponent: Cloud
         initialEstimate: 1/4h
     """
-    new_name = fauxfactory.gen_alpha()
+    new_name = fauxfactory.gen_alpha(15, start="edited_")
     with update(volume):
         volume.name = new_name
     view = navigate_to(appliance.collections.volumes, 'All')
@@ -136,7 +136,7 @@ def test_edit_volume_with_type(volume_with_type, appliance):
         casecomponent: Cloud
         initialEstimate: 1/4h
     """
-    new_name = fauxfactory.gen_alpha()
+    new_name = fauxfactory.gen_alpha(15, start="edited_")
     with update(volume_with_type):
         volume_with_type.name = new_name
     view = navigate_to(appliance.collections.volumes, 'All')

--- a/cfme/tests/perf/workloads/test_provisioning.py
+++ b/cfme/tests/perf/workloads/test_provisioning.py
@@ -45,7 +45,7 @@ def get_provision_data(rest_api, provider, template_name, auto_approve=True):
         },
         "vm_fields": {
             "number_of_cpus": 1,
-            "vm_name": "test_rest_prov_{}".format(fauxfactory.gen_alphanumeric()),
+            "vm_name": fauxfactory.gen_alphanumeric(20, start="test_rest_prov_"),
             "vm_memory": "2048",
             "vlan": provider.data["provisioning"]["vlan"],
         },

--- a/cfme/tests/pod/test_appliance_crud.py
+++ b/cfme/tests/pod/test_appliance_crud.py
@@ -209,7 +209,7 @@ def temp_pod_appliance(appliance, provider, appliance_data, pytestconfig):
 def temp_extdb_pod_appliance(appliance, provider, extdb_template, template_tags,
                              create_external_database, appliance_data):
     db_host, db_name = create_external_database
-    project = 'test-pod-extdb-{t}'.format(t=fauxfactory.gen_alphanumeric().lower())
+    project = fauxfactory.gen_alphanumeric(20, start="test-pod-extdb-").lower()
     provision_data = {
         'template': extdb_template['name'],
         'tags': template_tags,
@@ -250,7 +250,7 @@ def temp_extdb_pod_appliance(appliance, provider, extdb_template, template_tags,
 def temp_pod_ansible_appliance(provider, appliance_data, template_tags):
     tags = template_tags
     params = appliance_data.copy()
-    project = 'test-pod-ansible-{t}'.format(t=fauxfactory.gen_alphanumeric().lower())
+    project = fauxfactory.gen_alphanumeric(22, start="test-pod-ansible-").lower()
     try:
         with ssh.SSHClient(hostname=params['openshift_creds']['hostname'],
                            username=params['openshift_creds']['ssh']['username'],

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -22,7 +22,7 @@ pytestmark = [
 @pytest.fixture(scope='function')
 def new_vm(appliance, provider, setup_provider, small_template_modscope):
     """Fixture to provision and delete vm on the provider"""
-    vm_name = 'test_service_{}'.format(fauxfactory.gen_alphanumeric())
+    vm_name = fauxfactory.gen_alphanumeric(18, start="test_service_")
     collection = appliance.provider_based_collection(provider)
 
     vm = collection.instantiate(vm_name, provider, small_template_modscope.name)
@@ -35,7 +35,7 @@ def new_vm(appliance, provider, setup_provider, small_template_modscope):
 @pytest.fixture(scope="function")
 def copy_domain(request, appliance):
     dc = DomainCollection(appliance)
-    domain = dc.create(name=fauxfactory.gen_alphanumeric(), enabled=True)
+    domain = dc.create(name=fauxfactory.gen_alphanumeric(12, start="domain_"), enabled=True)
     request.addfinalizer(domain.delete_if_exists)
     dc.instantiate(name='ManageIQ')\
         .namespaces.instantiate(name='System')\

--- a/cfme/tests/services/test_catalog.py
+++ b/cfme/tests/services/test_catalog.py
@@ -25,7 +25,7 @@ def test_catalog_crud(request, appliance):
         tags: service
     """
     # Create Catalog
-    catalog_name = fauxfactory.gen_alphanumeric()
+    catalog_name = fauxfactory.gen_alphanumeric(start="cat_")
     cat = appliance.collections.catalogs.create(name=catalog_name, description='my catalog')
     request.addfinalizer(cat.delete_if_exists)
 
@@ -79,8 +79,10 @@ def test_permissions_catalog_add(appliance, request):
     """
 
     def _create_catalog(appliance):
-        cat = appliance.collections.catalogs.create(name=fauxfactory.gen_alphanumeric(),
-                                                    description="my catalog")
+        cat = appliance.collections.catalogs.create(
+            name=fauxfactory.gen_alphanumeric(start="cat_"),
+            description="my catalog"
+        )
         request.addfinalizer(lambda: cat.delete())
 
     test_product_features = [['Everything', 'Services', 'Catalogs Explorer', 'Catalogs']]

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -24,7 +24,7 @@ pytestmark = [test_requirements.service, pytest.mark.tier(3), pytest.mark.ignore
 def catalog_item(appliance, dialog, catalog):
     cat_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
-        name='test_item_{}'.format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
         description="my catalog item", display_in=True,
         catalog=catalog, dialog=dialog
     )
@@ -48,7 +48,7 @@ def catalog_bundle(appliance, catalog_item):
         Args:
             catalog_item: as resource for bundle creation
     """
-    bundle_name = "bundle" + fauxfactory.gen_alphanumeric()
+    bundle_name = fauxfactory.gen_alphanumeric(15, start="cat_bundle_")
     catalog_bundle = appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",
         display_in=True, catalog=catalog_item.catalog,
@@ -91,7 +91,7 @@ def test_catalog_item_crud(appliance, dialog, catalog):
     """
     cat_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
-        name="test_item_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
         description="my catalog item",
         display_in=True,
         catalog=catalog,
@@ -165,7 +165,7 @@ def test_catalog_item_duplicate_name(appliance, dialog, catalog):
         initialEstimate: 1/8h
         tags: service
     """
-    cat_item_name = fauxfactory.gen_alphanumeric()
+    cat_item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     cat_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
         name=cat_item_name,
@@ -203,7 +203,7 @@ def test_permissions_catalog_item_add(appliance, catalog, dialog, request):
     def _create_catalog(appliance):
         cat_item = appliance.collections.catalog_items.create(
             appliance.collections.catalog_items.GENERIC,
-            name='test_item_{}'.format(fauxfactory.gen_alphanumeric()),
+            name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
             description="my catalog item",
             display_in=True,
             catalog=catalog,

--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -58,7 +58,7 @@ def service_dialog(appliance, widget_name):
 @pytest.fixture(scope="function")
 def catalog_item(appliance, service_dialog, catalog):
     sd, element_data = service_dialog
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
         name=item_name,
@@ -261,8 +261,8 @@ def test_dynamic_field_on_refresh_button(request, appliance, import_datastore, i
                          'merged': 'var_2_var_3'}
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
-        name=fauxfactory.gen_alpha(),
-        description=fauxfactory.gen_alpha(),
+        name=fauxfactory.gen_alpha(15, start="cat_item_"),
+        description=fauxfactory.gen_alpha(18, start="cat_item_desc_"),
         display_in=True,
         catalog=catalog,
         dialog=sd)

--- a/cfme/tests/services/test_dialog_regex_validation_in_catalog.py
+++ b/cfme/tests/services/test_dialog_regex_validation_in_catalog.py
@@ -16,13 +16,13 @@ pytestmark = [
 @pytest.fixture(scope="function")
 def dialog_cat_item(appliance, catalog):
     service_dialog = appliance.collections.service_dialogs
-    dialog = "dialog_{}".format(fauxfactory.gen_alphanumeric())
-    ele_name = fauxfactory.gen_alphanumeric()
+    dialog = fauxfactory.gen_alphanumeric(12, start="dialog_")
+    ele_name = fauxfactory.gen_alphanumeric(start="ele_")
     element_data = {
         'element_information': {
-            'ele_label': "ele_{}".format(fauxfactory.gen_alphanumeric()),
+            'ele_label': fauxfactory.gen_alphanumeric(15, start="ele_label_"),
             'ele_name': ele_name,
-            'ele_desc': fauxfactory.gen_alphanumeric(),
+            'ele_desc': fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
             'choose_type': "Text Box"
         },
         'options': {
@@ -33,15 +33,15 @@ def dialog_cat_item(appliance, catalog):
     if appliance.version < '5.10':
         element_data["options"].pop("validation_switch", None)
     sd = service_dialog.create(label=dialog, description="my dialog")
-    tab = sd.tabs.create(tab_label="tab_{}".format(fauxfactory.gen_alphanumeric()),
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
                          tab_desc="my tab desc")
-    box = tab.boxes.create(box_label="box_{}".format(fauxfactory.gen_alphanumeric()),
+    box = tab.boxes.create(box_label=fauxfactory.gen_alphanumeric(start="box_"),
                            box_desc="my box desc")
     box.elements.create(element_data=[element_data])
 
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
         description="my catalog",
         display_in=True,
         catalog=catalog,

--- a/cfme/tests/services/test_different_dialogs_in_catalogs.py
+++ b/cfme/tests/services/test_different_dialogs_in_catalogs.py
@@ -82,7 +82,7 @@ def catalog_item(appliance, provider, provisioning, service_dialog, catalog):
 
     catalog_item = appliance.collections.catalog_items.create(
         provider.catalog_item_type,
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
         description="my catalog",
         display_in=True,
         catalog=catalog,
@@ -95,7 +95,7 @@ def catalog_item(appliance, provider, provisioning, service_dialog, catalog):
 @pytest.fixture(scope="function")
 def generic_catalog_item(appliance, service_dialog, catalog):
     sd, element_data = service_dialog
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
         name=item_name,
@@ -443,22 +443,25 @@ def new_user(appliance, permission):
     # Tenant created
     collection = appliance.collections.tenants
     tenant = collection.create(
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="tenant_"),
         description=fauxfactory.gen_alphanumeric(),
         parent=collection.get_root_tenant(),
     )
 
     # Role created
-    role = appliance.collections.roles.create(name=f'role_{fauxfactory.gen_alphanumeric()}',
+    role = appliance.collections.roles.create(name=fauxfactory.gen_alphanumeric(start="role_"),
                                               vm_restriction="Only User or Group Owned",
                                               product_features=permission)
     # Group creates
-    group = appliance.collections.groups.create(description=fauxfactory.gen_alphanumeric(),
-                                                role=role.name, tenant=f"My Company/{tenant.name}")
+    group = appliance.collections.groups.create(
+        description=fauxfactory.gen_alphanumeric(start="grp_"),
+        role=role.name,
+        tenant=f"My Company/{tenant.name}"
+    )
     creds = Credential(principal=fauxfactory.gen_alphanumeric(4),
                        secret=fauxfactory.gen_alphanumeric(4))
     # User created
-    user = appliance.collections.users.create(name=fauxfactory.gen_alphanumeric(),
+    user = appliance.collections.users.create(name=fauxfactory.gen_alphanumeric(start="user_"),
                                               credential=creds, email=fauxfactory.gen_email(),
                                               groups=group, cost_center='Workload',
                                               value_assign='Database')

--- a/cfme/tests/services/test_dynamicdd_dialogelement.py
+++ b/cfme/tests/services/test_dynamicdd_dialogelement.py
@@ -13,7 +13,7 @@ pytestmark = [
     pytest.mark.meta(server_roles="+automate")
 ]
 
-item_name = fauxfactory.gen_alphanumeric()
+item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
 
 METHOD_TORSO = """
 # Method for logging
@@ -38,15 +38,15 @@ log(:info, "===========================================") if @debug
 @pytest.fixture(scope="function")
 def dialog(appliance, copy_instance, create_method):
     service_dialogs = appliance.collections.service_dialogs
-    dialog = "dialog_" + fauxfactory.gen_alphanumeric()
+    dialog = fauxfactory.gen_alphanumeric(12, start="dialog_")
     sd = service_dialogs.create(label=dialog, description="my dialog")
-    tab = sd.tabs.create(tab_label='tab_' + fauxfactory.gen_alphanumeric(),
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
         tab_desc="my tab desc")
-    box = tab.boxes.create(box_label='box_' + fauxfactory.gen_alphanumeric(),
+    box = tab.boxes.create(box_label=fauxfactory.gen_alphanumeric(start="box_"),
         box_desc="my box desc")
     element_data = {
         'element_information': {
-            'ele_label': "ele_" + fauxfactory.gen_alphanumeric(),
+            'ele_label': fauxfactory.gen_alphanumeric(start="ele_"),
             'ele_name': fauxfactory.gen_alphanumeric(),
             'ele_desc': fauxfactory.gen_alphanumeric(),
             'choose_type': "Dropdown"
@@ -61,7 +61,7 @@ def dialog(appliance, copy_instance, create_method):
 
 @pytest.fixture(scope="function")
 def catalog(appliance):
-    cat_name = "cat_" + fauxfactory.gen_alphanumeric()
+    cat_name = fauxfactory.gen_alphanumeric(start="cat_")
     catalog = appliance.collections.catalogs.create(name=cat_name, description="my catalog")
     yield catalog
 
@@ -107,7 +107,7 @@ def test_dynamicdropdown_dialog(appliance, dialog, catalog):
         initialEstimate: 1/8h
         tags: service
     """
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC, name=item_name,
         description="my catalog", display_in=True, catalog=catalog,

--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -22,7 +22,7 @@ pytestmark = [
 
 @pytest.fixture(scope="function")
 def catalog_item(appliance, dialog, catalog):
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
         name=item_name,
@@ -40,7 +40,7 @@ def test_delete_catalog_deletes_service(appliance, dialog, catalog):
         initialEstimate: 1/8h
         tags: service
     """
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
         name=item_name,
@@ -77,12 +77,12 @@ def test_service_circular_reference(appliance, catalog_item):
         initialEstimate: 1/8h
         tags: service
     """
-    bundle_name = "first_" + fauxfactory.gen_alphanumeric()
+    bundle_name = fauxfactory.gen_alphanumeric(start="first_")
     catalog_bundle = appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",
         display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
         catalog_items=[catalog_item.name])
-    sec_bundle_name = "sec_" + fauxfactory.gen_alphanumeric()
+    sec_bundle_name = fauxfactory.gen_alphanumeric(start="sec_")
     sec_catalog_bundle = appliance.collections.catalog_bundles.create(
         sec_bundle_name, description="catalog_bundle",
         display_in=True, catalog=catalog_item.catalog,
@@ -102,7 +102,7 @@ def test_service_generic_catalog_bundle(appliance, catalog_item):
         initialEstimate: 1/8h
         tags: service
     """
-    bundle_name = "generic_" + fauxfactory.gen_alphanumeric()
+    bundle_name = fauxfactory.gen_alphanumeric(12, start="generic_")
     appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",
         display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
@@ -128,17 +128,17 @@ def test_bundles_in_bundle(appliance, catalog_item):
         initialEstimate: 1/8h
         tags: service
     """
-    bundle_name = "first_" + fauxfactory.gen_alphanumeric()
+    bundle_name = fauxfactory.gen_alphanumeric(start="first_")
     appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",
         display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
         catalog_items=[catalog_item.name])
-    sec_bundle_name = "sec_" + fauxfactory.gen_alphanumeric()
+    sec_bundle_name = fauxfactory.gen_alphanumeric(start="sec_")
     appliance.collections.catalog_bundles.create(
         sec_bundle_name, description="catalog_bundle",
         display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
         catalog_items=[bundle_name])
-    third_bundle_name = "third_" + fauxfactory.gen_alphanumeric()
+    third_bundle_name = fauxfactory.gen_alphanumeric(start="third_")
     third_catalog_bundle = appliance.collections.catalog_bundles.create(
         third_bundle_name, description="catalog_bundle",
         display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -84,7 +84,7 @@ def catalog_item(appliance, provider, dialog, catalog, provisioning):
         'network': {'vlan': partial_match(vlan)},
     }
 
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     return appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.RHV,
         name=item_name,

--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -92,14 +92,14 @@ def stack_data(appliance, provider, provisioning, request):
 
 @pytest.fixture
 def dialog_name():
-    return 'dialog_{}'.format(fauxfactory.gen_alphanumeric())
+    return fauxfactory.gen_alphanumeric(12, start="dialog_")
 
 
 @pytest.fixture
 def template(appliance, provider, provisioning, dialog_name):
     template_group = provisioning['stack_provisioning']['template_type']
     template_type = provisioning['stack_provisioning']['template_type_dd']
-    template_name = fauxfactory.gen_alphanumeric()
+    template_name = fauxfactory.gen_alphanumeric(start="temp_")
     file = provisioning['stack_provisioning']['data_file']
     data_file = load_data_file(str(orchestration_path.join(file)))
     content = data_file.read().replace('CFMETemplateName', template_name)
@@ -115,7 +115,7 @@ def template(appliance, provider, provisioning, dialog_name):
 
 @pytest.fixture
 def catalog(appliance):
-    cat_name = "cat_{}".format(fauxfactory.gen_alphanumeric())
+    cat_name = fauxfactory.gen_alphanumeric(start="cat_")
     catalog = appliance.collections.catalogs.create(name=cat_name, description="my catalog")
     yield catalog
     if catalog.exists:
@@ -124,7 +124,7 @@ def catalog(appliance):
 
 @pytest.fixture
 def catalog_item(appliance, dialog, catalog, template, provider, dialog_name):
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.ORCHESTRATION,
         name=item_name,

--- a/cfme/tests/services/test_pxe_service_catalogs.py
+++ b/cfme/tests/services/test_pxe_service_catalogs.py
@@ -110,7 +110,7 @@ def catalog_item(appliance, provider, dialog, catalog, provisioning,
         'network': {'vlan': partial_match(pxe_vlan)},
     }
 
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     return appliance.collections.catalog_items.create(
         provider.catalog_item_type,
         name=item_name,

--- a/cfme/tests/services/test_rest_services.py
+++ b/cfme/tests/services/test_rest_services.py
@@ -870,7 +870,7 @@ class TestServiceDialogsRESTAPI(object):
         if from_detail:
             edited = []
             for dialog in service_dialogs:
-                new_description = 'Test Dialog {}'.format(fauxfactory.gen_alphanumeric().lower())
+                new_description = fauxfactory.gen_alphanumeric(18, start="Test Dialog ").lower()
                 new_descriptions.append(new_description)
                 edited.append(dialog.action.edit(description=new_description))
                 assert_response(appliance)
@@ -878,7 +878,7 @@ class TestServiceDialogsRESTAPI(object):
         else:
             catalog_edited = []
             for dialog in service_dialogs:
-                new_description = 'Test Dialog {}'.format(fauxfactory.gen_alphanumeric().lower())
+                new_description = fauxfactory.gen_alphanumeric(18, start="Test Dialog ").lower()
                 new_descriptions.append(new_description)
                 dialog.reload()
                 catalog_edited.append({
@@ -1146,14 +1146,14 @@ class TestServiceCatalogsRESTAPI(object):
         if from_detail:
             edited = []
             for catalog in service_catalogs:
-                new_description = 'Test Catalog {}'.format(fauxfactory.gen_alphanumeric().lower())
+                new_description = fauxfactory.gen_alphanumeric(18, start="Test Catalog ").lower()
                 new_descriptions.append(new_description)
                 edited.append(catalog.action.edit(description=new_description))
                 assert_response(appliance)
         else:
             catalog_edited = []
             for catalog in service_catalogs:
-                new_description = 'Test Catalog {}'.format(fauxfactory.gen_alphanumeric().lower())
+                new_description = fauxfactory.gen_alphanumeric(18, start="Test Catalog ").lower()
                 new_descriptions.append(new_description)
                 catalog.reload()
                 catalog_edited.append({
@@ -1374,7 +1374,7 @@ class TestPendingRequestsRESTAPI(object):
     def new_domain(self, request, appliance):
         """Creates new domain and copy instance from ManageIQ to this domain."""
         dc = appliance.collections.domains
-        domain = dc.create(name=fauxfactory.gen_alphanumeric(), enabled=True)
+        domain = dc.create(name=fauxfactory.gen_alphanumeric(12, start="domain_"), enabled=True)
         request.addfinalizer(domain.delete_if_exists)
         miq_domain = dc.instantiate(name='ManageIQ')
         instance = self._get_instance(miq_domain)
@@ -1563,8 +1563,8 @@ class TestServiceRequests(object):
     def user_auth(self, request, appliance, new_group):
         password = fauxfactory.gen_alphanumeric()
         data = [{
-            "userid": "rest_{}".format(fauxfactory.gen_alphanumeric(3).lower()),
-            "name": "REST User {}".format(fauxfactory.gen_alphanumeric()),
+            "userid": fauxfactory.gen_alphanumeric(start="rest_").lower(),
+            "name": fauxfactory.gen_alphanumeric(15, start="REST User "),
             "password": password,
             "group": {"id": new_group.id}
         }]
@@ -1729,7 +1729,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
         """
         response_len = len(orchestration_templates)
         new = [{
-            'description': 'Updated Test Template {}'.format(fauxfactory.gen_alphanumeric(5))
+            'description': fauxfactory.gen_alphanumeric(26, start="Updated Test Template ")
         } for _ in range(response_len)]
         if from_detail:
             edited = []
@@ -1817,7 +1817,7 @@ class TestOrchestrationTemplatesRESTAPI(object):
         new = []
         for _ in range(num_orch_templates):
             new.append({
-                "name": "test_copied_{}".format(fauxfactory.gen_alphanumeric(5))
+                "name": fauxfactory.gen_alphanumeric(18, start="test_copied_")
             })
         if from_detail:
             for i in range(num_orch_templates):
@@ -2198,8 +2198,8 @@ def automate_env_setup(klass):
     dialog_field["values"] = {1 => "one", 2 => "two", 10 => "ten", 7 => "seven", 50 => "fifty"}
     """
     method = klass.methods.create(
-        name=fauxfactory.gen_alphanumeric(),
-        display_name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="meth_"),
+        display_name=fauxfactory.gen_alphanumeric(start="meth_"),
         location="inline",
         script=script,
     )
@@ -2207,8 +2207,8 @@ def automate_env_setup(klass):
     klass.schema.add_fields({"name": "meth", "type": "Method", "data_type": "Integer"})
 
     instance = klass.instances.create(
-        name=fauxfactory.gen_alphanumeric(),
-        display_name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(start="inst_"),
+        display_name=fauxfactory.gen_alphanumeric(start="inst_"),
         description=fauxfactory.gen_alphanumeric(),
         fields={"meth": {"value": method.name}},
     )
@@ -2223,7 +2223,7 @@ def get_service_template(appliance, request, automate_env_setup):
     instance = automate_env_setup
     data = {
         "buttons": "submit, cancel",
-        "label": "dialog_{}".format(fauxfactory.gen_alpha()),
+        "label": fauxfactory.gen_alpha(12, start="dialog_"),
         "dialog_tabs": [
             {
                 "display": "edit",

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -118,7 +118,7 @@ def test_order_catalog_bundle(appliance, provider, catalog_item, request):
         lambda: appliance.collections.infra_vms.instantiate(
             "{}0001".format(vm_name), provider).cleanup_on_provider()
     )
-    bundle_name = fauxfactory.gen_alphanumeric()
+    bundle_name = fauxfactory.gen_alphanumeric(12, start="bundle_")
     catalog_bundle = appliance.collections.catalog_bundles.create(
         bundle_name, description="catalog_bundle",
         display_in=True, catalog=catalog_item.catalog,
@@ -150,7 +150,7 @@ def test_no_template_catalog_item(provider, provisioning, dialog, catalog, appli
         initialEstimate: 1/8h
         tags: service
     """
-    item_name = fauxfactory.gen_alphanumeric()
+    item_name = fauxfactory.gen_alphanumeric(15, start="cat_item_")
     catalog_item = appliance.collections.catalogs.instantiate(
         # TODO pass catalog class for instantiation
         item_type=provider.catalog_name, name=item_name,

--- a/cfme/tests/services/test_service_customer_bz.py
+++ b/cfme/tests/services/test_service_customer_bz.py
@@ -59,7 +59,7 @@ def test_edit_bundle_entry_point(appliance, provider, catalog_item, request):
         lambda: appliance.collections.infra_vms.instantiate(
             "{}0001".format(vm_name), provider).cleanup_on_provider()
     )
-    bundle_name = fauxfactory.gen_alphanumeric()
+    bundle_name = fauxfactory.gen_alphanumeric(12, start="bundle_")
     catalog_bundle = appliance.collections.catalog_bundles.create(
         bundle_name,
         catalog_items=[catalog_item.name],

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -31,7 +31,7 @@ def create_domain(request, appliance):
     """Create new domain and copy instance from ManageIQ to this domain"""
 
     dc = DomainCollection(appliance)
-    new_domain = dc.create(name=fauxfactory.gen_alphanumeric(), enabled=True)
+    new_domain = dc.create(name=fauxfactory.gen_alphanumeric(12, start="domain_"), enabled=True)
     request.addfinalizer(new_domain.delete_if_exists)
     instance = (dc.instantiate(name='ManageIQ')
         .namespaces.instantiate(name='Service')

--- a/cfme/tests/services/test_service_rbac.py
+++ b/cfme/tests/services/test_service_rbac.py
@@ -14,19 +14,19 @@ pytestmark = [
 # todo: turn all below methods into fixtures with teardown steps
 def new_role(appliance, product_features):
     collection = appliance.collections.roles
-    return collection.create(name='role_{}'.format(fauxfactory.gen_alphanumeric()),
+    return collection.create(name=fauxfactory.gen_alphanumeric(start="role_"),
                              vm_restriction=None, product_features=product_features)
 
 
 def new_group(appliance, role):
     collection = appliance.collections.groups
-    return collection.create(description='group_{}'.format(fauxfactory.gen_alphanumeric()),
+    return collection.create(description=fauxfactory.gen_alphanumeric(start="group_"),
                              role=role, tenant="My Company")
 
 
 def new_user(appliance, group, credential):
     collection = appliance.collections.users
-    return collection.create(name='user_{}'.format(fauxfactory.gen_alphanumeric()),
+    return collection.create(name=fauxfactory.gen_alphanumeric(start="user_"),
                              credential=credential,
                              email='xyz@redhat.com',
                              groups=group,
@@ -149,7 +149,7 @@ def test_service_rbac_orchestration(appliance, role_user_group):
         appliance.server.login(user)
         collection = appliance.collections.orchestration_templates
         template = collection.create(
-            template_name=fauxfactory.gen_alphanumeric(),
+            template_name=fauxfactory.gen_alphanumeric(start="temp_"),
             template_type='Amazon CloudFormation',
             template_group='CloudFormation Templates',
             description='template description',

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -48,7 +48,7 @@ def enable_candu(appliance):
 @pytest.fixture(scope="module")
 def new_compute_rate(appliance, enable_candu):
     # Create a new Compute Chargeback rate
-    desc = '{}custom_'.format(fauxfactory.gen_alphanumeric())
+    desc = fauxfactory.gen_alphanumeric(12, start="custom_")
     try:
         compute = appliance.collections.compute_rates.create(
             description=desc,

--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -43,7 +43,7 @@ def test_service_catalog_crud_ssui(appliance, setup_provider,
 
     catalog_item = order_service
     with appliance.context.use(context):
-        dialog_values = {'service_name': "ssui_{}".format(fauxfactory.gen_alphanumeric())}
+        dialog_values = {'service_name': fauxfactory.gen_alphanumeric(start="ssui_")}
         service = ServiceCatalogs(appliance, name=catalog_item.name,
                                   dialog_values=dialog_values)
         service.add_to_shopping_cart()

--- a/cfme/tests/ssui/test_ssui_service_dialog.py
+++ b/cfme/tests/ssui/test_ssui_service_dialog.py
@@ -11,7 +11,7 @@ from cfme.utils.appliance.implementations.ssui import navigate_to
 @pytest.fixture(scope="function")
 def tagcontrol_dialog(appliance):
     service_dialog = appliance.collections.service_dialogs
-    dialog = "dialog_{}".format(fauxfactory.gen_alphanumeric())
+    dialog = fauxfactory.gen_alphanumeric(12, start="dialog_")
     element_data = {
         'element_information': {
             'ele_label': "Service Level",
@@ -25,9 +25,9 @@ def tagcontrol_dialog(appliance):
         }
     }
     sd = service_dialog.create(label=dialog, description="my dialog")
-    tab = sd.tabs.create(tab_label='tab_{}'.format(fauxfactory.gen_alphanumeric()),
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
                          tab_desc="my tab desc")
-    box = tab.boxes.create(box_label='box_{}'.format(fauxfactory.gen_alphanumeric()),
+    box = tab.boxes.create(box_label=fauxfactory.gen_alphanumeric(start="box_"),
                            box_desc="my box desc")
     box.elements.create(element_data=[element_data])
     yield sd
@@ -36,7 +36,7 @@ def tagcontrol_dialog(appliance):
 
 @pytest.fixture(scope="function")
 def catalog(appliance):
-    catalog = "cat_{}".format(fauxfactory.gen_alphanumeric())
+    catalog = fauxfactory.gen_alphanumeric(start="cat_")
     cat = appliance.collections.catalogs.create(name=catalog, description="my catalog")
     yield cat
     if cat.exists:
@@ -47,7 +47,7 @@ def catalog(appliance):
 def catalog_item(appliance, tagcontrol_dialog, catalog):
     catalog_item = appliance.collections.catalog_items.create(
         appliance.collections.catalog_items.GENERIC,
-        name=fauxfactory.gen_alphanumeric(),
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
         description="my catalog", display_in=True, catalog=catalog,
         dialog=tagcontrol_dialog)
     yield catalog_item

--- a/cfme/tests/storage/test_object_store_container.py
+++ b/cfme/tests/storage/test_object_store_container.py
@@ -23,7 +23,7 @@ def container(appliance, provider):
         # Maintaining at least one container as creation not possible with UI for OSP.
 
         cont = collection.instantiate(
-            key="cont_{}".format(fauxfactory.gen_alpha(3)), provider=provider
+            key=fauxfactory.gen_alpha(start="cont_"), provider=provider
         )
         provider.mgmt.create_container(cont.key)
         collection.manager.refresh()

--- a/cfme/tests/storage/test_object_store_object.py
+++ b/cfme/tests/storage/test_object_store_object.py
@@ -24,12 +24,12 @@ def storage_object(appliance, provider):
         # Note: Like to avoid creation with api client multiple time.
         # Maintaining at least one object as creation not possible with CFME UI for OSP.
 
-        cont_key = "cont_{}".format(fauxfactory.gen_alpha(3))
+        cont_key = fauxfactory.gen_alpha(start="cont_")
         provider.mgmt.create_container(cont_key)
 
         temp_file = tempfile.NamedTemporaryFile(suffix=".pdf")
         obj = collection.instantiate(
-            key="obj_{}".format(fauxfactory.gen_alpha(3)), provider=provider
+            key=fauxfactory.gen_alpha(start="obj_"), provider=provider
         )
         provider.mgmt.create_object(
             container_name=cont_key, path=temp_file.name, object_name=obj.key

--- a/cfme/tests/storage/test_volume.py
+++ b/cfme/tests/storage/test_volume.py
@@ -78,7 +78,7 @@ def instance_fixture(appliance, provider, small_template):
     if not instance.exists_on_provider:
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
     elif instance.provider.one_of(EC2Provider) and instance.mgmt.state == VmState.DELETED:
-        instance.mgmt.rename('test_terminated_{}'.format(fauxfactory.gen_alphanumeric(8)))
+        instance.mgmt.rename(fauxfactory.gen_alphanumeric(20, start="test_terminated_"))
         instance.create_on_provider(allow_skip="default", find_in_cfme=True)
     yield instance
     instance.cleanup_on_provider()
@@ -87,7 +87,7 @@ def instance_fixture(appliance, provider, small_template):
 def create_volume(appliance, provider, is_from_manager=False, az=None, cancel=False,
                   should_assert=False):
     volume_collection = appliance.collections.volumes
-    name = fauxfactory.gen_alpha()
+    name = fauxfactory.gen_alpha(start="vol_")
     if provider.one_of(OpenStackProvider):
         if appliance.version < "5.11":
             volume = volume_collection.create(name=name,
@@ -160,7 +160,7 @@ def test_storage_volume_crud(appliance, provider, from_manager):
 
     # update volume
     old_name = volume.name
-    new_name = fauxfactory.gen_alpha()
+    new_name = fauxfactory.gen_alpha(12, start="edited_")
     if provider.one_of(OpenStackProvider):
         updates = {'volume_name': new_name}
     else:

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -26,20 +26,20 @@ def backup(appliance, provider):
     backup_collection = appliance.collections.volume_backups.filter({'provider': provider})
     # create new volume
     if appliance.version >= "5.11":   # has mandatory availability zone
-        volume = volume_collection.create(name=fauxfactory.gen_alpha(),
+        volume = volume_collection.create(name=fauxfactory.gen_alpha(start="vol_"),
                                           tenant=provider.data['provisioning']['cloud_tenant'],
                                           volume_size=STORAGE_SIZE,
                                           az=provider.data['provisioning']['availability_zone'],
                                           provider=provider)
     else:
-        volume = volume_collection.create(name=fauxfactory.gen_alpha(),
+        volume = volume_collection.create(name=fauxfactory.gen_alpha(start="vol_"),
                                           tenant=provider.data['provisioning']['cloud_tenant'],
                                           volume_size=STORAGE_SIZE,
                                           provider=provider)
 
     # create new backup for crated volume
     if volume.status == 'available':
-        backup_name = fauxfactory.gen_alpha()
+        backup_name = fauxfactory.gen_alpha(start="bkup_")
         volume.create_backup(backup_name)
         backup = backup_collection.instantiate(backup_name, provider)
         yield backup

--- a/cfme/tests/storage/test_volume_snapshot.py
+++ b/cfme/tests/storage/test_volume_snapshot.py
@@ -30,7 +30,7 @@ STORAGE_SIZE = 1
 def volume(appliance, provider):
     # create new volume
     volume_collection = appliance.collections.volumes
-    name = fauxfactory.gen_alpha()
+    name = fauxfactory.gen_alpha(start="vol_")
     volume_kwargs = {
         'name': name,
         'volume_size': STORAGE_SIZE,
@@ -64,7 +64,7 @@ def volume(appliance, provider):
 @pytest.fixture(scope='function')
 def snapshot(volume):
     # create new snapshot for crated volume
-    snapshot_name = fauxfactory.gen_alpha()
+    snapshot_name = fauxfactory.gen_alpha(start="snap_")
     snapshot = volume.create_snapshot(snapshot_name)
 
     try:
@@ -104,7 +104,7 @@ def test_storage_snapshot_create_cancelled_validation(volume, snapshot_create_fr
         casecomponent: Cloud
     """
 
-    snapshot_name = fauxfactory.gen_alpha()
+    snapshot_name = fauxfactory.gen_alpha(start="snap_")
     volume.create_snapshot(snapshot_name, cancel=True, from_manager=snapshot_create_from)
     if snapshot_create_from:
         view = volume.browser.create_view(StorageManagerVolumeAllView, additional_context={
@@ -135,7 +135,7 @@ def test_storage_snapshot_create_reset_validation(volume, snapshot_create_from):
         casecomponent: Cloud
     """
 
-    snapshot_name = fauxfactory.gen_alpha()
+    snapshot_name = fauxfactory.gen_alpha(start="snap_")
     volume.create_snapshot(snapshot_name, reset=True, from_manager=snapshot_create_from)
     view = volume.create_view(VolumeSnapshotView)
     view.flash.assert_message('All changes have been reset')
@@ -161,7 +161,7 @@ def test_storage_volume_snapshot_crud(volume, provider, snapshot_create_from):
 
     # create new snapshot
     initial_snapshot_count = volume.snapshots_count
-    snapshot_name = fauxfactory.gen_alpha()
+    snapshot_name = fauxfactory.gen_alpha(start="snap_")
     snapshot = volume.create_snapshot(snapshot_name, from_manager=snapshot_create_from)
     view = volume.create_view(VolumeDetailsView, wait='10s')
     view.flash.assert_success_message(

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -143,7 +143,7 @@ def test_update_password(context, request, appliance):
     """
 
     # First, create a temporary new user
-    username = 'user_temp_{}'.format(fauxfactory.gen_alphanumeric(4).lower())
+    username = fauxfactory.gen_alphanumeric(15, start="user_temp_").lower()
     new_creds = Credential(principal=username, secret='redhat')
     user_group = appliance.collections.groups.instantiate(description="EvmGroup-vm_user")
     user = appliance.collections.users.create(

--- a/cfme/tests/v2v/test_migration_throttling.py
+++ b/cfme/tests/v2v/test_migration_throttling.py
@@ -61,8 +61,8 @@ def test_migration_throttling(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         vm_list=mapping_data_multiple_vm_obj_single_datastore.vm_list,
     )

--- a/cfme/tests/v2v/test_post_migrations.py
+++ b/cfme/tests/v2v/test_post_migrations.py
@@ -59,8 +59,8 @@ def test_migration_post_attribute(appliance, provider, mapping_data_vm_obj_mini,
     source_cpu, source_socket, source_core, source_memory = re.findall(r"\d+", summary)
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping_data_vm_obj_mini.infra_mapping_data.get("name"),
         target_provider=provider,
         vm_list=mapping_data_vm_obj_mini.vm_list

--- a/cfme/tests/v2v/test_v2v_ansible.py
+++ b/cfme/tests/v2v/test_v2v_ansible.py
@@ -143,8 +143,8 @@ def test_migration_playbooks(request, appliance, source_provider, provider,
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         vm_list=mapping_data_vm_obj_single_datastore.vm_list,
         target_provider=provider,

--- a/cfme/tests/v2v/test_v2v_cancel_migrations.py
+++ b/cfme/tests/v2v/test_v2v_cancel_migrations.py
@@ -38,8 +38,8 @@ pytestmark = [
 def cancel_migration_plan(appliance, provider, mapping_data_vm_obj_mini):
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping_data_vm_obj_mini.infra_mapping_data.get("name"),
         target_provider=provider,
         vm_list=mapping_data_vm_obj_mini.vm_list
@@ -102,8 +102,8 @@ def test_dual_vm_cancel_migration(request, appliance, soft_assert, provider,
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_multiple_vm_obj_single_datastore.vm_list,
@@ -161,8 +161,8 @@ def test_cancel_migration_attachments(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=[vm_obj])

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -79,8 +79,8 @@ def test_single_datastore_single_vm_migration(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_vm_obj_single_datastore.vm_list,
@@ -130,8 +130,8 @@ def test_single_network_single_vm_migration(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_vm_obj_single_network.vm_list,
@@ -186,8 +186,8 @@ def test_dual_datastore_dual_vm_migration(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_dual_vm_obj_dual_datastore.vm_list,
@@ -238,8 +238,8 @@ def test_dual_nics_migration(request, appliance, provider, mapping_data_vm_obj_d
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_vm_obj_dual_nics.vm_list,
@@ -282,8 +282,8 @@ def test_dual_disk_vm_migration(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_vm_obj_single_datastore.vm_list,
@@ -343,8 +343,8 @@ def test_migrations_different_os_templates(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_multiple_vm_obj_single_datastore.vm_list,

--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -70,8 +70,8 @@ def test_single_vm_migration_power_state_tags_retirement(appliance, provider,
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping_data_vm_obj_mini.infra_mapping_data.get("name"),
         vm_list=mapping_data_vm_obj_mini.vm_list,
         target_provider=provider
@@ -117,8 +117,8 @@ def test_multi_host_multi_vm_migration(request, appliance, provider, soft_assert
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         vm_list=mapping_data_multiple_vm_obj_single_datastore.vm_list,
         target_provider=provider
@@ -171,8 +171,8 @@ def test_migration_special_char_name(appliance, provider, request,
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(start="plan_desc_"),
         infra_map=mapping_data_vm_obj_mini.infra_mapping_data.get("name"),
         vm_list=mapping_data_vm_obj_mini.vm_list,
         target_provider=provider
@@ -231,8 +231,8 @@ def test_migration_long_name(request, appliance, provider, source_provider):
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="long_name_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_long_name{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(20, start="long_name_"),
+        description=fauxfactory.gen_alphanumeric(25, start="desc_long_name_"),
         infra_map=mapping.name,
         vm_list=[vm_obj],
         target_provider=provider
@@ -271,8 +271,8 @@ def test_migration_with_edited_mapping(request, appliance, source_provider, prov
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         vm_list=mapping_data_vm_obj_single_datastore.vm_list,
         target_provider=provider)
@@ -315,8 +315,8 @@ def test_migration_restart(request, appliance, provider, mapping_data_vm_obj_sin
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_vm_obj_single_datastore.vm_list,

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -490,10 +490,10 @@ def test_duplicate_plan_name(appliance, mapping_data_vm_obj_mini, provider, requ
             1. Plan with duplicate name shows error message
     """
     migration_plan_collection = appliance.collections.v2v_migration_plans
-    name = "plan_{}".format(fauxfactory.gen_alphanumeric())
+    name = fauxfactory.gen_alphanumeric(start="plan_")
     migration_plan = migration_plan_collection.create(
         name=name,
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping_data_vm_obj_mini.infra_mapping_data.get("name"),
         target_provider=provider,
         vm_list=mapping_data_vm_obj_mini.vm_list,
@@ -554,8 +554,8 @@ def test_migration_with_no_conversion(appliance, delete_conversion_hosts, source
     """
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping_data_vm_obj_mini.infra_mapping_data.get("name"),
         target_provider=provider,
         vm_list=mapping_data_vm_obj_mini.vm_list,
@@ -608,8 +608,8 @@ def test_v2v_custom_attribute(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         osp_security_group=map_security_group,
         osp_flavor=map_flavor,

--- a/cfme/tests/v2v/test_v2v_schedule_migrations.py
+++ b/cfme/tests/v2v/test_v2v_schedule_migrations.py
@@ -52,8 +52,8 @@ def test_schedule_migration(appliance, provider, mapping_data_vm_obj_mini, soft_
     migration_plan_collection = appliance.collections.v2v_migration_plans
     src_vm_obj = mapping_data_vm_obj_mini.vm_list[0]
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping_data_vm_obj_mini.infra_mapping_data.get("name"),
         target_provider=provider,
         vm_list=mapping_data_vm_obj_mini.vm_list,

--- a/cfme/tests/v2v/test_v2v_smoke.py
+++ b/cfme/tests/v2v/test_v2v_smoke.py
@@ -62,8 +62,8 @@ def test_single_vm_migration_with_ssh_and_vddk(
 
     migration_plan_collection = appliance.collections.v2v_migration_plans
     migration_plan = migration_plan_collection.create(
-        name="plan_{}".format(fauxfactory.gen_alphanumeric()),
-        description="desc_{}".format(fauxfactory.gen_alphanumeric()),
+        name=fauxfactory.gen_alphanumeric(start="plan_"),
+        description=fauxfactory.gen_alphanumeric(15, start="plan_desc_"),
         infra_map=mapping.name,
         target_provider=provider,
         vm_list=mapping_data_multiple_vm_obj_single_datastore.vm_list,

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -184,7 +184,7 @@ def test_automate_can_edit_copied_method(appliance, request):
     """
 
     domain = appliance.collections.domains.create(
-        name=fauxfactory.gen_alpha(),
+        name=fauxfactory.gen_alpha(12, start="domain_"),
         description=fauxfactory.gen_alpha(),
         enabled=False)
     request.addfinalizer(domain.delete_if_exists)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -522,7 +522,7 @@ class IPAppliance(object):
             short_tb = "{}: {}".format(exc_type.__name__, str(exc_val))
             full_tb = "{}\n{}".format(full_tb, short_tb)
 
-            g_id = "appliance-cm-screenshot-{}".format(fauxfactory.gen_alpha(length=6))
+            g_id = fauxfactory.gen_alpha(length=30, start="appliance-cm-screenshot-")
 
             fire_art_hook(
                 config, 'filedump',

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -509,7 +509,7 @@ class SSHClient(paramiko.SSHClient):
             self.run_command('mv {} {}'.format(tempfilename, remote_file))
             return scp
         elif self.is_pod and not ensure_host:
-            tmp_folder_name = 'automation-{}'.format(fauxfactory.gen_alpha().lower())
+            tmp_folder_name = fauxfactory.gen_alpha(15, start="automation-").lower()
             logger.info('For this purpose, temporary folder name is /tmp/%s', tmp_folder_name)
             # Clean up container's temporary folder
             self.run_command('rm -rf /tmp/{0}'.format(tmp_folder_name))
@@ -517,7 +517,7 @@ class SSHClient(paramiko.SSHClient):
             self.run_command(
                 'rm -rf /tmp/{0}; mkdir -p /tmp/{0}'.format(tmp_folder_name), ensure_host=True)
             # Now upload the file to the openshift host
-            tmp_file_name = 'file-{}'.format(fauxfactory.gen_alpha().lower())
+            tmp_file_name = fauxfactory.gen_alpha(start="file-").lower()
             tmp_full_name = '/tmp/{}/{}'.format(tmp_folder_name, tmp_file_name)
             scp = SCPClient(self.get_transport(), progress=self._progress_callback).put(
                 local_file, tmp_full_name, **kwargs)
@@ -547,7 +547,7 @@ class SSHClient(paramiko.SSHClient):
         logger.info("Transferring remote file %r to local %r", remote_file, local_path)
         base_name = os_path.basename(remote_file)
         if self.is_container:
-            tmp_file_name = 'temp_{}'.format(fauxfactory.gen_alpha())
+            tmp_file_name = fauxfactory.gen_alpha(start="temp_")
             tempfilename = '/share/{}'.format(tmp_file_name)
             logger.info('For this purpose, temporary file name is %r', tempfilename)
             self.run_command('cp {} {}'.format(remote_file, tempfilename))
@@ -560,8 +560,8 @@ class SSHClient(paramiko.SSHClient):
                 os_path.join(local_path, base_name)])
             return scp
         elif self.is_pod:
-            tmp_folder_name = 'automation-{}'.format(fauxfactory.gen_alpha().lower())
-            tmp_file_name = 'file-{}'.format(fauxfactory.gen_alpha().lower())
+            tmp_folder_name = fauxfactory.gen_alpha(start="automation-").lower()
+            tmp_file_name = fauxfactory.gen_alpha(start="file-").lower()
             tmp_full_name = '/tmp/{}/{}'.format(tmp_folder_name, tmp_file_name)
             logger.info('For this purpose, temporary file name is %r', tmp_full_name)
             # Clean up container's temporary folder


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- Removed string formatting with fauxfactory and move to `start` arg
- Improved some know attributes

Main intention of this PR to move `.format` usecase with fauxfactory

fixes #9135 
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
