### PR TITLE
[RFR] Serial marker for parallelizer

### DIFF
--- a/cfme/markers/serial.py
+++ b/cfme/markers/serial.py
@@ -1,0 +1,22 @@
+"""
+serial: Marker for marking test modules as "serial" tests. Serial is in quotes because this is not
+        meant to guarantee that tests will run in a specific order but instead meant to make sure
+        that all the tests in the test module will be sent to a single slave.
+
+        The parallelizer is designed to divy up tests to slaves according to their parametrization.
+        So tests with similar parameters end up going to the same slave. The problem this marker
+        seeks to address is when the same fixture is evaluated on multiple slaves. When the auth
+        tests were changed to use a temp appliance, this resulted in a new temp appliance being
+        pulled for each slave that the tests were sent to. This created an unnecessary load on
+        sprout and resulted in test errors due to not receiving an appliance.
+
+        IMPORTANT: The serial marker SHOULD NOT be used on provider parametrized test cases, this
+        will result in lengthy test runs due to having to constantly setup and tear down providers.
+"""
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        'serial: Mark a test case to run serially (all parameters on a single appliance)'
+    )

--- a/cfme/tests/control/test_basic.py
+++ b/cfme/tests/control/test_basic.py
@@ -24,7 +24,7 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.long_running,
-    test_requirements.control
+    test_requirements.control,
 ]
 
 EXPRESSIONS_TO_TEST = [

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -41,6 +41,7 @@ def pytest_generate_tests(metafunc):
 @pytest.mark.uncollectif(lambda appliance: appliance.is_dev,
                          reason="Test not valid for dev server")
 @pytest.mark.meta(automates=[BZ(1530683)])
+@pytest.mark.serial
 @test_requirements.auth
 def test_group_roles(temp_appliance_preconfig_long, setup_aws_auth_provider, group_name,
                      role_access, context, soft_assert):

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -33,6 +33,7 @@ pytestmark = [
         BZ(1593171)]),  # 510z groups page doesn't load
     pytest.mark.browser_isolation,
     pytest.mark.long_running,
+    pytest.mark.serial,
     pytest.mark.usefixtures(
         'prov_key', 'auth_mode', 'auth_provider', 'configure_auth', 'auth_user'
     ),

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ pytest_plugins = [
     "cfme.markers.rhel_tests",
     "cfme.markers.rhv",
     "cfme.markers.sauce",
+    "cfme.markers.serial",
     "cfme.markers.skipper",
     "cfme.markers.smoke",
     "cfme.markers.stream_excluder",


### PR DESCRIPTION
In some instances there are test cases that should be run against a single appliance (in order to avoid fixture duplication on multiple appliances). For instance, the auth tests require a temp appliance. But during jenkins test runs they are split between multiple slaves, each of which requires a temp appliance. 

This creates an unnecessary load on sprout -- resulting in test failures due to sprout being unable to provision appliances. This PR introduces a `serial` marker. By marking a test as a serial test with `pytest.mark.serial`, all the test cases generated by that test function will be sent to a single slave.

~Depends on #9580~  

{{ pytest: --long-running --use-sprout --sprout-appliances=2 cfme/tests/integration }}