### PR TITLE
[1LP][RFR] New Replication Automation tests

### DIFF
--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -4,12 +4,14 @@ import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
 from widgetastic.exceptions import RowNotFound
+from widgetastic.exceptions import UnexpectedAlertPresentException
 from widgetastic.widget import Checkbox
 from widgetastic.widget import Text
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import BootstrapSwitch
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
+from widgetastic_patternfly import Kebab
 
 from cfme.base.ui import RegionView
 from cfme.modeling.base import BaseCollection
@@ -23,6 +25,7 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
 from cfme.utils.update import Updateable
+from cfme.utils.wait import wait_for
 from widgetastic_manageiq import Dropdown
 from widgetastic_manageiq import DynamicTable
 from widgetastic_manageiq import SummaryFormItem
@@ -955,7 +958,13 @@ class ReplicationView(RegionView):
 class ReplicationGlobalView(ReplicationView):
     """ Replication Global setup View"""
     add_subscription = Button('Add Subscription')
-    subscription_table = VanillaTable('//form[@id="form_div"]//table[contains(@class, "table")]')
+    subscription_table = VanillaTable(
+        '//form[@id="form_div"]//table[contains(@class, "table")]',
+        column_widgets={
+            "Actions": Button("Update"),
+            10: Kebab(locator='//td[10]/div[contains(@class, "dropdown-kebab-pf")]')
+        }
+    )
 
     @property
     def is_displayed(self):
@@ -1071,6 +1080,34 @@ class Replication(NavigatableMixin):
         """
         row = self._global_replication_row(host)
         return int(row.backlog.text.split(' ')[0])
+
+    def remove_global_appliance(self, host=None):
+        """ Remove the remote appliance subscription from the Global region
+
+            Args:
+                host: host value
+            Returns: True once the subsciption is removed
+        """
+        row = self._global_replication_row(host)
+        view = self.create_view(ReplicationGlobalView)
+
+        try:
+            row[10].widget.item_select("Delete")
+        except UnexpectedAlertPresentException:
+            view.browser.handle_alert()
+
+        view.save_button.click()
+
+        def _row_exists(self):
+            try:
+                self._global_replication_row(host)
+                return True
+            except RowNotFound:
+                return False
+
+        # wait until the row no longer exists
+        wait_for(lambda: _row_exists, fail_condition=True, num_sec=60, delay=2)
+        return True
 
 
 @navigator.register(Replication, 'Details')

--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -1098,15 +1098,16 @@ class Replication(NavigatableMixin):
 
         view.save_button.click()
 
-        def _row_exists(self):
+        def _row_exists():
             try:
+                view.browser.refresh()
                 self._global_replication_row(host)
                 return True
             except RowNotFound:
                 return False
 
         # wait until the row no longer exists
-        wait_for(lambda: _row_exists, fail_condition=True, num_sec=60, delay=2)
+        wait_for(_row_exists, fail_condition=True, num_sec=60, delay=2)
         return True
 
 

--- a/cfme/tests/test_replication.py
+++ b/cfme/tests/test_replication.py
@@ -31,6 +31,8 @@ def setup_replication(configured_appliance, unconfigured_appliance):
     global_app.set_pglogical_replication(replication_type=":global")
     global_app.add_pglogical_replication_subscription(remote_app.hostname)
 
+    return configured_appliance, unconfigured_appliance
+
 
 @pytest.mark.manual
 def test_replication_powertoggle():
@@ -113,9 +115,8 @@ def test_replication_re_add_deleted_remote(setup_replication):
     assert region.replication.get_replication_status(host=remote_app.hostname)
 
 
-@pytest.mark.manual
 @pytest.mark.tier(3)
-def test_replication_delete_remote_from_global():
+def test_replication_delete_remote_from_global(setup_replication):
     """
     Delete remote subscription from global region
 
@@ -131,7 +132,12 @@ def test_replication_delete_remote_from_global():
             1.
             2. No error. Appliance unsubscribed.
     """
-    pass
+    remote_app, global_app = setup_replication
+    region = global_app.collections.regions.instantiate()
+
+    # Remove the Remote subscription from Global
+    region.replication.remove_global_appliance(host=remote_app.hostname)
+    assert not region.replication.get_replication_status(host=remote_app.hostname)
 
 
 @pytest.mark.manual
@@ -172,9 +178,8 @@ def test_replication_remote_to_global_by_ip_pglogical():
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(1)
-def test_replication_appliance_set_type_global_ui():
+def test_replication_appliance_set_type_global_ui(setup_replication):
     """
     Set appliance replication type to "Global" and add subscription in the
     UI
@@ -193,7 +198,6 @@ def test_replication_appliance_set_type_global_ui():
             1.
             2. No error, appliance subscribed.
     """
-    pass
 
 
 @pytest.mark.manual

--- a/cfme/tests/test_replication.py
+++ b/cfme/tests/test_replication.py
@@ -1,4 +1,5 @@
 import pytest
+from widgetastic.exceptions import RowNotFound
 
 from cfme import test_requirements
 from cfme.configure.configuration.region_settings import ReplicationGlobalView
@@ -137,20 +138,8 @@ def test_replication_delete_remote_from_global(setup_replication):
 
     # Remove the Remote subscription from Global
     region.replication.remove_global_appliance(host=remote_app.hostname)
-    assert not region.replication.get_replication_status(host=remote_app.hostname)
-
-
-@pytest.mark.manual
-def test_replication_low_bandwidth():
-    """
-    ~5MB/s up/down
-
-    Polarion:
-        assignee: mnadeem
-        casecomponent: Replication
-        initialEstimate: 1/4h
-    """
-    pass
+    with pytest.raises(RowNotFound):
+        region.replication.get_replication_status(host=remote_app.hostname)
 
 
 @pytest.mark.manual
@@ -198,6 +187,7 @@ def test_replication_appliance_set_type_global_ui(setup_replication):
             1.
             2. No error, appliance subscribed.
     """
+    pass
 
 
 @pytest.mark.manual


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. test_replication_re_add_deleted_remote
    2. test_replication_delete_remote_from_global
- __Removing tests__
    1. test_replication_low_bandwidth
- __Enhancement__ 
    1. Make `setup_replication` a fixture instead of a function.
    2. Add a new method `remove_global_appliance` to `Replication`.
    3. Enhance the `subscription_table`.


### PRT Run

{{ pytest: cfme/tests/test_replication.py --long-running  -vvv }}
