### PR TITLE
[1LP][RFR] Manual test cleanup and qe-test-coverage test cases

### DIFF
--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -38,64 +38,6 @@ def test_reports_generate_custom_conditional_filter_report():
 @pytest.mark.manual
 @test_requirements.report
 @pytest.mark.tier(1)
-def test_date_should_be_change_in_editing_reports_scheduled():
-    """
-    Bugzilla:
-        1446052
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/16h
-        startsin: 5.3
-        setup:
-            1. Create a report schedule which runs once.
-            2. Select the schedule and edit it.
-        testSteps:
-            1. Under "Timer" Select "monthly"  every "month"
-            2. Try to change "Starting Date"
-        expectedResults:
-            1. "Timer" must change accordingly.
-            2. "Starting Date" must change accordingly.
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
-@pytest.mark.tier(2)
-@pytest.mark.parametrize(
-    "report_type", ["hosts", "vm_operation", "policy_events", "custom"]
-)
-def test_custom_reports_with_timelines(report_type):
-    """
-    Cloud Intel->Reports allows to copy existing reports with timelines or
-    create new ones from scratch.
-    Such custom reports appear in Cloud Intel -> Timelines after creation.
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: low
-        initialEstimate: 1/3h
-        setup:
-            1. Navigate to Cloud Intel > Reports > All Reports.
-            2. In the `All Reports` accordion, trace the report based on report_type.
-                and copy the report or create a new report if the report_type is `custom`.
-            3. Navigate to Cloud Intel > Timelines.
-        testSteps:
-            1. Check the Timelines tree.
-        expectedResults:
-            1. The copied/new report must appear under in the tree.
-                under [My Company (All Groups), Custom].
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.report
-@pytest.mark.tier(1)
 def test_vm_volume_free_space_less_than_20_percent():
     """
     Polarion:

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -145,14 +145,14 @@ def test_service_refresh_dialog_fields_default_values():
 
 @pytest.mark.manual
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1486765, 1730813])
+@pytest.mark.meta(coverage=[1486765, 1740340])
 @pytest.mark.parametrize(
     "scheduler", ["2", "2019-08-14 17:41:06 UTC"], ids=["number_of_days", "exact_time"]
 )
 def test_schedule_automation_request(scheduler):
     """
     Bugzilla:
-        1730813
+        1740340
         1486765
 
     Polarion:

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -3,6 +3,8 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.utils.appliance.implementations.rest import ViaREST
+from cfme.utils.appliance.implementations.ui import ViaUI
 
 
 @pytest.mark.manual
@@ -71,8 +73,8 @@ def test_notification_url_parallel_requests():
 @pytest.mark.manual
 @pytest.mark.meta(coverage=[1761836])
 @pytest.mark.tier(3)
-@pytest.mark.parametrize("implementation", ["UI", "Rest"])
-def test_widget_generate_content_via_rest(implementation):
+@pytest.mark.parametrize("context", [ViaUI, ViaREST])
+def test_widget_generate_content_via_rest(context):
     """
     Bugzilla:
        1761836

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -104,3 +104,40 @@ def test_widget_generate_content_via_rest(implementation):
             4. Both values must be different, value must be updated.
     """
     pass
+
+
+@pytest.mark.manual
+@pytest.mark.meta(coverage=[1730813])
+@pytest.mark.tier(2)
+def test_service_refresh_dialog_fields_default_values():
+    """
+    Bugzilla:
+        1730813
+
+    Polarion:
+        assignee: pvala
+        caseimportance: high
+        casecomponent: Rest
+        initialEstimate: 1/4h
+        setup:
+            1. Import dialog `RTP Testgear Client Provision` from the BZ attachments and create
+                a service_template and service catalog to attach it.
+        testSteps:
+            1. Start monitoring the evm log and look for fields `tag_1_region` and `tag_0_function`.
+            2. Perform action `refresh_dialog_fields` by sending a request
+                POST /api/service_catalogs/<:id>/sevice_templates/<:id>
+                    {
+                    "action": "refresh_dialog_fields",
+                    "resource": {
+                        "fields": [
+                            "tag_1_region",
+                            "tag_0_function"
+                            ]
+                        }
+                    }
+        expectedResults:
+            1.
+            2. Request must be successful and evm must have the default values
+                for the fields mentioned in testStep 1.
+    """
+    pass

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -185,3 +185,29 @@ def test_schedule_automation_request(scheduler):
             2.Difference between the two dates must be equal to scheduler
     """
     pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+@pytest.mark.meta(coverage=[1596142])
+def test_update_roles_via_rest_name_change():
+    """
+    Bugzilla:
+        1596142
+
+    Polarion:
+        assignee: pvala
+        caseimportance: high
+        casecomponent: Rest
+        initialEstimate: 1/4h
+        setup:
+            1. Change the current server name to something other than the default.
+        testSteps:
+            1. Send a PATCH request to update the server roles via REST using
+                `appliance.update_advanced_settings({"server": {"role": :roles}})`
+            2. Check if the server name was set to default.
+        expectedResults:
+            1. Request was successful.
+            2. Server name remains the same.
+    """
+    pass

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -27,34 +27,6 @@ def test_create_rhev_provider_with_metric():
     pass
 
 
-@pytest.mark.manual
-@test_requirements.rest
-def test_automation_request_task():
-    """
-    Polarion:
-        assignee: pvala
-        caseimportance: medium
-        casecomponent: Rest
-        initialEstimate: 1/4h
-        testSteps:
-            1. Create an automation request.
-            2. Edit the automation request task:
-                POST /api/automation_requests/:id/request_tasks/:request_task_id
-                {
-                "action" : "edit",
-                "resource" : {
-                    "options" : {
-                    "request_param_a" : "value_a",
-                    "request_param_b" : "value_b"
-                    }
-                }
-        expectedResults:
-            1.
-            2. Task must be edited successfully.
-    """
-    pass
-
-
 @test_requirements.rest
 @pytest.mark.manual()
 @pytest.mark.tier(1)
@@ -94,3 +66,4 @@ def test_notification_url_parallel_requests():
         1700378
     """
     pass
+

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -67,3 +67,40 @@ def test_notification_url_parallel_requests():
     """
     pass
 
+
+@pytest.mark.manual
+@pytest.mark.meta(coverage=[1761836])
+@pytest.mark.tier(3)
+@pytest.mark.parametrize("implementation", ["UI", "Rest"])
+def test_widget_generate_content_via_rest(implementation):
+    """
+    Bugzilla:
+       1761836
+       1623607
+       1753682
+
+    Polarion:
+        assignee: pvala
+        caseimportance: medium
+        casecomponent: Rest
+        initialEstimate: 1/4h
+        testSteps:
+            1. Depending on the implementation -
+                i. GET /api/widgtes/:id and note the `last_generated_content_on`.
+                ii. Navigate to Dashboard and note the `last_generated_content_on` for the widget.
+            2. POST /api/widgets/:id
+                {
+                    "action": "generate_content"
+                }
+            3. Wait until the task completes.
+            4. Depending on the implementation
+                i. GET /api/widgets/:id and compare the value of `last_generated_content_on`
+                    with the value noted in step 1.
+                ii.  Navigate to the dashboard and check if the value was updated for the widget.
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Both values must be different, value must be updated.
+    """
+    pass

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -141,3 +141,47 @@ def test_service_refresh_dialog_fields_default_values():
                 for the fields mentioned in testStep 1.
     """
     pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(2)
+@pytest.mark.meta(coverage=[1486765, 1730813])
+@pytest.mark.parametrize(
+    "scheduler", ["2", "2019-08-14 17:41:06 UTC"], ids=["number_of_days", "exact_time"]
+)
+def test_schedule_automation_request(scheduler):
+    """
+    Bugzilla:
+        1730813
+        1486765
+
+    Polarion:
+        assignee: pvala
+        caseimportance: high
+        casecomponent: Rest
+        initialEstimate: 1/4h
+        testSteps:
+            1. Send a request POST /api/automation_requests
+                {
+                    "uri_parts" : {
+                        "namespace" : "System",
+                        "class"     : "Request",
+                        "instance"  : "InspectME",
+                        "message"   : "create"
+                    },
+                    "parameters" : {
+                        "var1" : "value 1",
+                        "var2" : "value 2",
+                        "minimum_memory" : 2048,
+                        "schedule_time": scheduler
+                    },
+                    "requester" : {
+                        "auto_approve" : true
+                    }
+                }
+            2. Compare the `created_on` and `options::schedule_time` from the response.
+        expectedResults:
+            1. Request must be successful.
+            2.Difference between the two dates must be equal to scheduler
+    """
+    pass

--- a/cfme/tests/webui/test_general_ui_manual.py
+++ b/cfme/tests/webui/test_general_ui_manual.py
@@ -8,9 +8,9 @@ from cfme.common.provider import BaseProvider
 from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
 
 pytestmark = [
-    pytest.mark.ignore_stream('upstream'),
+    pytest.mark.ignore_stream("upstream"),
     pytest.mark.manual,
-    test_requirements.general_ui
+    test_requirements.general_ui,
 ]
 
 
@@ -58,7 +58,7 @@ def test_notification_window_can_be_closed_by_clicking_x():
     pass
 
 
-@pytest.mark.manual('manualonly')
+@pytest.mark.manual("manualonly")
 @pytest.mark.tier(1)
 def test_infrastructure_provider_left_panel_titles():
     """
@@ -112,7 +112,7 @@ def test_pdf_summary_provider(provider):
     pass
 
 
-@pytest.mark.manual('manualonly')
+@pytest.mark.manual("manualonly")
 @pytest.mark.tier(1)
 @pytest.mark.ignore_stream("5.10")
 @pytest.mark.meta(coverage=[1740131])
@@ -185,5 +185,31 @@ def test_compliance_column_header():
             1.
             2.
             3. There should be no 500 Internal Server Error and the page must be displayed as is.
+    """
+    pass
+
+
+@pytest.mark.tier(1)
+@pytest.mark.meta(coverage=[1733120])
+def test_compare_vm_from_datastore_relationships():
+    """
+    Bugzilla:
+        1733120
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Infra
+        caseimportance: medium
+        initialEstimate: 1/18h
+        setup:
+            1. Add an infra provider.
+        testSteps:
+            1. Select a datastore with at least 2 VMS, and navigate to a it's Details page.
+            2. Click on Managed VMs from the relationships table.
+            3. Select at least 2 VMs and click on `Configuration > Compare the selected items`
+        expectedResults:
+            1.
+            2.
+            3. Comparison page should be displayed, there should be no exception on the page.
     """
     pass


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. test_widget_generate_content_via_rest - [BZ 1761836](https://bugzilla.redhat.com/show_bug.cgi?id=1761836)
    2. test_service_refresh_dialog_fields_default_values - [BZ 1730813](https://bugzilla.redhat.com/show_bug.cgi?id=1730813)
    3. test_schedule_automation_request - [BZ 1740340](https://bugzilla.redhat.com/show_bug.cgi?id=1740340)
    4. test_update_roles_via_rest_name_change - [BZ 1596142](https://bugzilla.redhat.com/show_bug.cgi?id=1596142)
    5. test_compare_vm_from_datastore_relationships -  [BZ 1733120](https://bugzilla.redhat.com/show_bug.cgi?id=1733120)

- __Removing tests__
    1. test_automation_request_task [already automated]
    2. test_date_should_be_change_in_editing_reports_scheduled [already automated]
    3. test_custom_reports_with_timelines