### PR TITLE
[RFR] Add evmserverd restart so that NTP properly syncs

### DIFF
--- a/cfme/fixtures/authentication.py
+++ b/cfme/fixtures/authentication.py
@@ -145,6 +145,9 @@ def configure_auth(
     temp_appliance_preconfig_long.server.authentication.auth_settings = original_config
     temp_appliance_preconfig_long.evmserverd.restart()
     temp_appliance_preconfig_long.wait_for_web_ui()
+    # after waiting for web ui to reappear we are greeted with an API logout message
+    # and stuck on the login screen without the login widgets having loaded
+    sleep(30)
     # After evmserverd restart, we need to logout from the appliance in the UI.
     # Otherwise the UI would be in a bad state and produce errors while testing.
     temp_appliance_preconfig_long.server.logout()

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -157,7 +157,7 @@ def test_login_evm_group(
     evm_group_names = [group for group in auth_user.groups if 'evmgroup' in group.lower()]
     with user_obj:
         logger.info('Logging in as user %s, member of groups %s', user_obj, evm_group_names)
-        view = navigate_to(temp_appliance_preconfig_long.server, 'Dashboard')
+        view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
         assert view.is_displayed, 'user {} failed login'.format(user_obj)
         soft_assert(user_obj.name == view.current_fullname,
                     'user {} is not in view fullname'.format(user_obj))

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2437,6 +2437,11 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         if auth_provider.host1 not in self.server.settings.ntp_servers_values:
             self.server.settings.update_ntp_servers({'ntp_server_1': auth_provider.host1})
 
+        # the evmserverd restart is necessary for the NTP sync to properly go through
+        # in the subsequent command (appliance console IPA configuration)
+        self.evmserverd.restart()
+        self.wait_for_web_ui()
+
         # backend appliance configuration of ext auth provider
         self.appliance_console_cli.configure_ipa(**auth_provider.as_external_value())
 

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2441,6 +2441,9 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         # in the subsequent command (appliance console IPA configuration)
         self.evmserverd.restart()
         self.wait_for_web_ui()
+        # since the browser will be stuck on the server settings page, and logout on next click
+        # after the evmserverd restart, quit the browser before the next step.
+        self.browser.quit_browser()
 
         # backend appliance configuration of ext auth provider
         self.appliance_console_cli.configure_ipa(**auth_provider.as_external_value())


### PR DESCRIPTION
Sometimes configuring freeipa01 failed with a timeout because NTP was not properly synced. 

{{ pytest: --long-running cfme/tests/integration/test_cfme_auth.py::test_login_evm_group -k "external-freeipa01" }}
