### PR TITLE
[1LP][RFR]  Adding new test of service retire manual approval

### DIFF
--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -250,22 +250,15 @@ class AllGenericObjectInstanceView(BaseLoggedInPage):
 
 
 @MiqImplementationContext.external_for(MyService.retire, ViaUI)
-def retire(self):
+def retire(self, wait=True):
     view = navigate_to(self, 'Details')
     view.toolbar.lifecycle.item_select('Retire this Service', handle_alert=True)
     view.flash.assert_no_error()
 
-    # wait for service to retire
-    if self.appliance.version < '5.10':
-        wait_for(
-            lambda: view.entities.lifecycle.get_text_of('Retirement State') == 'Retired',
-            fail_func=view.toolbar.reload.click,
-            num_sec=10 * 60, delay=3,
-            message='Service Retirement wait')
-    else:
-        request_descr = f"Service Retire for: {self.name}"
+    if wait:
         service_request = self.appliance.collections.requests.instantiate(
-            description=request_descr)
+            description=f"Service Retire for: {self.name}"
+        )
         service_request.wait_for_request()
 
 

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -6,8 +6,12 @@ from cfme import test_requirements
 from cfme.automate.explorer.domain import DomainCollection
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
+from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
+from cfme.services.requests import RequestDetailsToolBar
 from cfme.services.service_catalogs import ServiceCatalogs
+from cfme.utils.appliance import ViaUI
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.update import update
@@ -24,6 +28,28 @@ pytestmark = [
                                           ['provisioning', 'datastore']],
                          scope="module"),
 ]
+
+
+@pytest.fixture(scope='function')
+def service_retirement_request(domain):
+    domain.parent.instantiate(name="ManageIQ").namespaces.instantiate(
+        name="Service").namespaces.instantiate(
+        name="Retirement").namespaces.instantiate(
+        name="StateMachines").classes.instantiate(
+        name="ServiceRetirementRequestApproval").instances.instantiate(
+        name="Default").copy_to(domain.name)
+
+    method = domain.namespaces.instantiate(
+        name="Service").namespaces.instantiate(
+        name="Retirement").namespaces.instantiate(
+        name="StateMachines").classes.instantiate(
+        name="ServiceRetirementRequestApproval").instances.instantiate(
+        name="Default")
+
+    with update(method):
+        method.fields = {"approval_type": {"value": "manual"}}
+
+    return method
 
 
 @pytest.fixture(scope="function")
@@ -87,3 +113,56 @@ def test_service_manual_approval(appliance, provider, modify_instance,
                                                                  partial_check=True)
     service_request.update(method='ui')
     assert service_request.row.approval_state.text == 'Pending Approval'
+
+
+@pytest.mark.meta(automates=[BZ(1697600)])
+@pytest.mark.provider([VMwareProvider], scope="module")
+@pytest.mark.customer_scenario
+def test_service_retire_manual_approval(request, appliance, service_retirement_request, service_vm):
+    """ Test service retirement manual approval
+
+    Bugzilla:
+        1697600
+
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/2h
+        caseposneg: positive
+        testtype: functional
+        startsin: 5.9
+        casecomponent: Services
+        setup:
+            1. Set Service retirement manual approval instead of auto
+        testSteps:
+            1. Add Service Catalog, Order the Service
+            2. Retire the service
+            3. Navigate to Service retirement request Details page
+            4. Manually approve the service retirement request
+        expectedResults:
+            1.
+            2.
+            3.
+            4. Admin should be able to approve the retirement request
+    """
+    service, _ = service_vm
+    with appliance.context.use(ViaUI):
+        service.retire(wait=False)
+        request_description = f"Service Retire for: {service.name}"
+        service_request = appliance.collections.requests.instantiate(
+            description=request_description,
+            partial_check=True)
+        service_request.update(method='ui')
+        assert service_request.row.approval_state.text == 'Pending Approval'
+        # TODO(BZ-1721479): Remove the work-around once this BZ got fixed
+        navigate_to(service_request, "Details")
+        view = appliance.browser.create_view(RequestDetailsToolBar)
+        if not view.approve.is_displayed and BZ(1721479, forced_streams=['5.10', '5.11']).blocks:
+            navigate_to(appliance.server, "Dashboard")
+            service_request.approve_request(method='ui', reason="Approved")
+        else:
+            service_request.approve_request(method='ui', reason="Approved")
+        assert service_request.row.approval_state.text == 'Approved'
+        service_request.wait_for_request()
+        msg = "Request failed with the message {}".format(service_request.rest.message)
+        request.addfinalizer(service_request.remove_request)
+        assert service_request.is_succeeded(), msg


### PR DESCRIPTION
{{ pytest: cfme/tests/services/test_service_manual_approval.py -k 'test_service_retire_manual_approval' --long-running --use-template-cache -sqvvv }}