### PR TITLE
[1LP][RFR] Passed template name as string instead of function

### DIFF
--- a/cfme/fixtures/templates.py
+++ b/cfme/fixtures/templates.py
@@ -1,6 +1,7 @@
 from collections import Mapping
 
 import pytest
+from aenum import NamedConstant
 
 from cfme.fixtures.templateloader import TEMPLATES
 from cfme.utils.log import logger
@@ -8,6 +9,21 @@ from cfme.utils.log import logger
 
 # TODO restructure these to indirectly parametrize the name, and provide name constants here
 # These are getting improperly imported and used as functions
+
+class Templates(NamedConstant):
+    DPORTGROUP_TEMPLATE = "dportgroup_template"
+    DPORTGROUP_TEMPLATE_MODSCOPE = "dportgroup_template_modscope"
+    DUAL_DISK_TEMPLATE = "dual_disk_template"
+    DUAL_NETWORK_TEMPLATE = "dual_network_template"
+    RHEL69_TEMPLATE = "rhel69_template"
+    RHEL7_MINIMAL = "rhel7_minimal"
+    RHEL7_MINIMAL_MODSCOPE = "rhel7_minimal_modscope"
+    UBUNTU16_TEMPLATE = "ubuntu16_template"
+    WIN7_TEMPLATE = "win7_template"
+    WIN10_TEMPLATE = "win10_template"
+    WIN2016_TEMPLATE = "win2016_template"
+    WIN2012_TEMPLATE = "win2012_template"
+
 
 @pytest.fixture(scope="function")
 def template(template_location, provider):

--- a/cfme/tests/v2v/test_migration_throttling.py
+++ b/cfme/tests/v2v/test_migration_throttling.py
@@ -4,9 +4,7 @@ from widgetastic.widget import NoSuchElementException
 
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.fixtures.templates import rhel69_template
-from cfme.fixtures.templates import rhel7_minimal
-from cfme.fixtures.templates import ubuntu16_template
+from cfme.fixtures.templates import Templates
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
@@ -33,15 +31,16 @@ pytestmark = [
 
 
 @pytest.mark.parametrize(
-    "mapping_data_multiple_vm_obj_single_datastore",
+    "source_type, dest_type, template_type",
     [
-        ["nfs", "nfs", [rhel7_minimal, rhel69_template, ubuntu16_template]],
+        ["nfs", "nfs", [Templates.RHEL7_MINIMAL,
+                        Templates.RHEL69_TEMPLATE,
+                        Templates.UBUNTU16_TEMPLATE]],
     ],
-    indirect=True,
 )
-def test_migration_throttling(
-    request, appliance, provider, mapping_data_multiple_vm_obj_single_datastore
-):
+def test_migration_throttling(request, appliance, provider,
+                              source_type, dest_type, template_type,
+                              mapping_data_multiple_vm_obj_single_datastore):
     """
     Polarion:
         assignee: sshveta

--- a/cfme/tests/v2v/test_v2v_ansible.py
+++ b/cfme/tests/v2v/test_v2v_ansible.py
@@ -3,7 +3,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.fixtures.templates import rhel7_minimal
+from cfme.fixtures.templates import Templates
 from cfme.fixtures.v2v_fixtures import cleanup_target
 from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
@@ -85,10 +85,12 @@ def catalog_item(request, appliance, machine_credential, ansible_repository, pla
 
 
 @pytest.mark.parametrize(
-    "mapping_data_vm_obj_single_datastore", [["nfs", "nfs", rhel7_minimal]], indirect=True
+    "source_type, dest_type, template_type",
+    [["nfs", "nfs", Templates.RHEL7_MINIMAL]]
 )
 def test_migration_playbooks(request, appliance, source_provider, provider,
-                             ansible_repository, mapping_data_vm_obj_single_datastore):
+                             ansible_repository, source_type, dest_type,
+                             template_type, mapping_data_vm_obj_single_datastore):
     """
     Test for migrating vms with pre and post playbooks
 

--- a/cfme/tests/v2v/test_v2v_cancel_migrations.py
+++ b/cfme/tests/v2v/test_v2v_cancel_migrations.py
@@ -5,7 +5,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.fixtures.templates import rhel7_minimal
+from cfme.fixtures.templates import Templates
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
@@ -71,10 +71,11 @@ def cancel_migration_plan(appliance, provider, mapping_data_vm_obj_mini):
 
 
 @pytest.mark.tier(1)
-@pytest.mark.parametrize('mapping_data_multiple_vm_obj_single_datastore', [['nfs', 'nfs',
-    [rhel7_minimal, rhel7_minimal]]],
-    indirect=True)
+@pytest.mark.parametrize('source_type, dest_type, template_type',
+                         [['nfs', 'nfs', [Templates.RHEL7_MINIMAL,
+                                          Templates.RHEL7_MINIMAL]]])
 def test_dual_vm_cancel_migration(request, appliance, soft_assert, provider,
+                                  source_type, dest_type, template_type,
                                   mapping_data_multiple_vm_obj_single_datastore):
     """
     Polarion:
@@ -136,9 +137,12 @@ def test_dual_vm_cancel_migration(request, appliance, soft_assert, provider,
 
 @pytest.mark.tier(2)
 @pytest.mark.parametrize(
-    "mapping_data_vm_obj_single_datastore", [["nfs", "nfs", rhel7_minimal]], indirect=True)
+    "source_type, dest_type, template_type",
+    [["nfs", "nfs", Templates.RHEL7_MINIMAL]])
 def test_cancel_migration_attachments(
-        request, appliance, soft_assert, provider, mapping_data_vm_obj_single_datastore):
+        request, appliance, soft_assert, provider,
+        source_type, dest_type, template_type,
+        mapping_data_vm_obj_single_datastore):
     """
     Test to cancel migration and check attached instance, volume and port is removed from provider
     Polarion:

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -6,7 +6,7 @@ from widgetastic.utils import partial_match
 
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.fixtures.templates import rhel7_minimal
+from cfme.fixtures.templates import Templates
 from cfme.fixtures.v2v_fixtures import cleanup_target
 from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.fixtures.v2v_fixtures import infra_mapping_default_data
@@ -376,8 +376,9 @@ def test_v2v_rbac(appliance, new_credential):
 
 @pytest.mark.tier(1)
 @pytest.mark.parametrize(
-    'mapping_data_vm_obj_single_datastore', [['iscsi', 'iscsi', rhel7_minimal]], indirect=True)
+    'source_type, dest_type, template_type', [['iscsi', 'iscsi', Templates.RHEL7_MINIMAL]])
 def test_v2v_infra_map_edit(request, appliance, source_provider, provider,
+                            source_type, dest_type, template_type,
                             mapping_data_vm_obj_single_datastore, soft_assert):
     """
     Test migration by editing migration mapping fields
@@ -575,9 +576,10 @@ def test_migration_with_no_conversion(appliance, delete_conversion_hosts, source
                       required_flags=["v2v"], override=True, scope='module')
 @pytest.mark.parametrize("attribute", ["flavor", "security_group"])
 @pytest.mark.parametrize(
-    "mapping_data_vm_obj_single_datastore", [["nfs", "nfs", rhel7_minimal]], indirect=True)
-def test_v2v_custom_attribute(
-        request, appliance, provider, attribute, mapping_data_vm_obj_single_datastore):
+    "source_type, dest_type, template_type", [["nfs", "nfs", Templates.RHEL7_MINIMAL]])
+def test_v2v_custom_attribute(request, appliance, provider,
+                              source_type, dest_type, template_type,
+                              attribute, mapping_data_vm_obj_single_datastore):
     """
     Test V2V with custom attributes of openstack provider projects
     Polarion:

--- a/cfme/tests/v2v/test_v2v_smoke.py
+++ b/cfme/tests/v2v/test_v2v_smoke.py
@@ -4,7 +4,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
-from cfme.fixtures.templates import rhel7_minimal
+from cfme.fixtures.templates import Templates
 from cfme.fixtures.v2v_fixtures import cleanup_target
 from cfme.fixtures.v2v_fixtures import get_migrated_vm
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
@@ -31,21 +31,17 @@ pytestmark = [
 ]
 
 
+@pytest.mark.parametrize("mapping_data_multiple_vm_obj_single_datastore",
+                         ['SSH', 'VDDK'], indirect=True)
 @pytest.mark.parametrize(
-    "v2v_provider_setup, mapping_data_multiple_vm_obj_single_datastore",
+    "source_type, dest_type, template_type",
     [
-        [
-            "SSH", ["nfs", "nfs", [rhel7_minimal]]
-        ],
-        [
-            "VDDK", ["nfs", "nfs", [rhel7_minimal]]
-        ]
-    ],
-    indirect=True,
+        ["nfs", "nfs", Templates.RHEL7_MINIMAL]
+    ]
 )
-def test_single_vm_migration_with_ssh_and_vddk(
-    request, appliance, provider, mapping_data_multiple_vm_obj_single_datastore
-):
+def test_single_vm_migration_with_ssh_and_vddk(request, appliance, provider,
+                                               source_type, dest_type, template_type,
+                                               mapping_data_multiple_vm_obj_single_datastore):
     """
     Polarion:
         assignee: sshveta


### PR DESCRIPTION
{{ pytest: cfme/tests/v2v/test_v2v_migrations_single_vcenter.py --use-provider rhv43 --use-provider vsphere67-ims --provider-limit 2 -vvvv --long-running -k test_migration_long_name }}

Made changes to pass template name as string instead of function to fix test failure


             vm_obj = collection.instantiate(
            >           vm_name, source_provider, template_name=template["name"] )
            E       TypeError: 'function' object is not subscriptable`
 