### PR TITLE
[RFR] Update Sprout Appliances Context Manager to Handle Unconfigured Appl 

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -64,8 +64,10 @@ def sprout_appliances(
             logger.info("Initiating appliance update on temp appliance ...")
             urls = config.getoption("update_urls")
             app.update_rhel(*urls, reboot=True)
-            logger.info("Appliance update finished on temp appliance, waiting for UI ...")
-            app.wait_for_web_ui()
+            # Web UI not available on unconfigured appliances
+            if preconfigured:
+                logger.info("Appliance update finished on temp appliance, waiting for UI ...")
+                app.wait_for_web_ui()
             logger.info("Appliance update finished on temp appliance...")
 
     try:


### PR DESCRIPTION
No web ui for an unconfigured appliances

{{ pytest: cfme/tests/cli/test_appliance_console.py::test_appliance_console_internal_db -v --use-template-cache --use-provider complete --sprout-user-key sprout  --update-url http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/RHEL-7.8-20190912.3/compose/Server/x86_64/os --update-url http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/RHEL-7.8-20190912.3/compose/Server-optional/x86_64/os -k 'not junkasdf' -m rhel_testing --long-running --ui-coverage --update-appliance }}
