### PR TITLE
[1LP][RFR] New Test: Test tag delete using automate method

### DIFF
--- a/cfme/tests/automate/__init__.py
+++ b/cfme/tests/automate/__init__.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from textwrap import dedent
 
+import fauxfactory
+
 user_list_hash_data = dedent(
     """
 module Demo
@@ -64,4 +66,24 @@ if __FILE__ == $PROGRAM_NAME
   Demo::Automate::System::Request::Test::AvailableUsers.new.main
 end
         """
+)
+
+tag_values = [fauxfactory.gen_alphanumeric(start="tag_", length=12).lower(), "{tag_exist}"]
+tag_delete_from_category = (
+    f"""
+    # Create tag under category - 'Location'
+    $evm.execute(
+'tag_create', 'location', :name => '{tag_values[0]}', :description => 'Testing tag {tag_values[0]}'
+)
+    # Check if tag exists
+    tag_exist = $evm.execute('tag_exists?', 'location', '{tag_values[0]}')
+    $evm.log(:info, "Tag exists: #{tag_values[1]}")
+
+    # Delete the tag
+    $evm.execute('tag_delete', 'location', '{tag_values[0]}')
+
+    # Check if deleted tag exists
+    tag_exist = $evm.execute('tag_exists?', 'location', '{tag_values[0]}')
+    $evm.log(:info, "Tag exists: #{tag_values[1]}")
+    """
 )

--- a/cfme/tests/cloud_infra_common/test_power_control_manual.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_manual.py
@@ -316,59 +316,6 @@ def test_power_states_with_respective_provider():
     pass
 
 
-@pytest.mark.tier(1)
-def test_archived_instance_status():
-    """Tests archived instance status
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: Cloud
-        caseimportance: high
-        initialEstimate: 1/8h
-        tags: power
-        testSteps:
-            1. Add cloud provider(rhos, ec2 or azure)
-            2. Provision instance and retire it
-            3. Navigate to cloud > instance > Instance by provider > archived
-            4. See any instance power state
-        expectedResults:
-            1.
-            2.
-            3. Cloud instances should be present
-            4. Power state of cloud instances should be changed to 'archived'
-
-    Bugzilla:
-        1701188
-    """
-
-
-@pytest.mark.tier(1)
-def test_orphaned_instance_status():
-    """Tests orphaned instance status
-
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/10h
-        casecomponent: Cloud
-        initialEstimate: 1/8h
-        tags: power
-        testSteps:
-            1. Add cloud provider(rhos, ec2 or azure)
-            2. Delete provider
-            3. Navigate to cloud > instance > Instance by provider > orphaned
-            4. See any instance power state
-        expectedResults:
-            1.
-            2.
-            3. Cloud instances should be present
-            4. Power state of cloud instances should be changed to 'orphaned'
-
-    Bugzilla:
-        1701188
-    """
-    pass
-
-
 @pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1740285])
 def test_power_operations_on_paused_provider():


### PR DESCRIPTION

## Purpose or Intent
-  Testing ```tag_delete``` method introduced for deletion of tags under category
- This test case also goes through methods like ```test_create```, ```tag_exists``` etc
- **Note**: Test cases ```test_archived_instance_status``` and ```test_orphaned_instance_status``` are already automated in test case ```test_power_options_on_archived_instance_all_page```

### PRT Run
{{ pytest: cfme/tests/automate/test_method.py::test_delete_tag_from_category --use-template-cache -qsvvv }}