### PR TITLE
[WIP] automate: test_tagvis_config_manager_provider

### DIFF
--- a/cfme/fixtures/tag.py
+++ b/cfme/fixtures/tag.py
@@ -106,10 +106,7 @@ def check_item_visibility(tag, user_restricted):
         Returns: None
         """
         if vis_expect:
-            vis_object.add_tag(tag=tag, exists_check=True)
-        else:
-            if tag in vis_object.get_tags():
-                vis_object.remove_tag(tag=tag)
+            vis_object.add_tag(tag=tag)
         with user_restricted:
             try:
                 if isinstance(vis_object, Host):
@@ -126,6 +123,8 @@ def check_item_visibility(tag, user_restricted):
             except Exception:
                 logger.debug('Tagged item is not visible')
                 actual_visibility = False
+        if vis_expect:
+            vis_object.remove_tag(tag=tag)
 
         assert actual_visibility == vis_expect
 

--- a/cfme/infrastructure/config_management.py
+++ b/cfme/infrastructure/config_management.py
@@ -365,7 +365,7 @@ class ConfigManager(Updateable, Pretty, NavigatableMixin, TaggableByEditTags):
                     config_profiles_loaded,
                     fail_func=self.refresh_relationships,
                     handle_exception=True,
-                    num_sec=180, delay=30)
+                    num_sec=270, delay=130)
 
     def update(self, updates, cancel=False, validate_credentials=False):
         """Updates the manager through UI

--- a/cfme/infrastructure/config_management.py
+++ b/cfme/infrastructure/config_management.py
@@ -54,6 +54,8 @@ class TaggableByEditTags(Taggable):
         """Overridden get_tags method to deal with the fact that some objects don't have a
         details view."""
         view = navigate_to(self, 'EditTags')
+        if self.appliance.version >= "5.11":
+            raise NotImplementedError("get_tags is not implemented for 5.11")
         return [
             self.appliance.collections.categories.instantiate(
                 display_name=r.category.text.replace('*', '').strip()).collections.tags.instantiate(
@@ -107,8 +109,9 @@ class ConfigManagementEntities(BaseEntitiesView):
 
 class ConfigManagementProfileEntities(BaseEntitiesView):
     """Entities view for the detail page"""
+
     @View.nested
-    class summary(WaitTab):                     # noqa
+    class summary(WaitTab):  # noqa
         TAB_NAME = 'Summary'
 
         properties = SummaryTable(title='Properties')
@@ -118,7 +121,7 @@ class ConfigManagementProfileEntities(BaseEntitiesView):
         smart_management = SummaryTable(title='Smart Management')
 
     @View.nested
-    class configured_systems(WaitTab):          # noqa
+    class configured_systems(WaitTab):  # noqa
         TAB_NAME = 'Configured Systems'
         elements = Table('//div[@id="main_div"]//div[@id="list_grid" or @id="gtl_div"]//table')
 
@@ -611,7 +614,7 @@ class ConfigProfile(Pretty, NavigatableMixin):
         return list()
 
 
-class ConfigSystem(Pretty, NavigatableMixin, Taggable):
+class ConfigSystem(Pretty, NavigatableMixin, TaggableByEditTags):
     """The tags pages of the config system"""
     pretty_attrs = ['name', 'manager_key']
 
@@ -619,17 +622,6 @@ class ConfigSystem(Pretty, NavigatableMixin, Taggable):
         self.appliance = appliance
         self.name = name
         self.profile = profile
-
-    def get_tags(self, tenant="My Company Tags"):
-        """Overridden get_tags method to deal with the fact that configured systems don't have a
-        details view."""
-        view = navigate_to(self, 'EditTags')
-        return [
-            self.appliance.collections.categories.instantiate(
-                display_name=r.category.text.replace('*', '').strip()).collections.tags.instantiate(
-                display_name=r.assigned_value.text.strip())
-            for r in view.form.tags
-        ]
 
 
 class Satellite(ConfigManager):

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -164,6 +164,20 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag, config_ma
     assert tag in job_template.get_tags(), "Added tag not found on configuration system"
 
 
+@test_requirements.tag
+@pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'invisible'])
+def test_tagvis_config_manager(config_manager, check_item_visibility, visibility):
+    """
+    Polarion:
+        assignee: anikifor
+        initialEstimate: 1/10h
+        casecomponent: Ansible
+        caseimportance: medium
+
+    """
+    check_item_visibility(config_manager, visibility)
+
+
 # def test_config_system_reprovision(config_system):
 #    # TODO specify machine per stream in yamls or use mutex (by tagging/renaming)
 #    pass

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -135,7 +135,7 @@ def test_config_system_tag(config_system, tag, appliance, config_manager, config
         initialEstimate: 1/4h
         casecomponent: Ansible
     """
-    config_system.add_tag(tag=tag, details=False)
+    config_system.add_tag(tag=tag)
     assert tag in config_system.get_tags(), "Added tag not found on configuration system"
 
 
@@ -159,7 +159,7 @@ def test_ansible_tower_job_templates_tag(request, config_manager, tag, config_ma
         job_template = config_manager.appliance.collections.ansible_tower_job_templates.all()[0]
     except IndexError:
         pytest.skip("No job template was found")
-    job_template.add_tag(tag=tag, details=False)
+    job_template.add_tag(tag=tag)
     request.addfinalizer(lambda: job_template.remove_tag(tag=tag))
     assert tag in job_template.get_tags(), "Added tag not found on configuration system"
 


### PR DESCRIPTION
{{ pytest: cfme/tests/cloud_infra_common/test_tag_objects.py -v }}
{{ pytest: cfme/tests/infrastructure/test_config_management.py::test_tagvis_config_manager -v  }}


Aside from automating the test, I have extracted TaggableFromEditTags. I did not need the get_tags method in the end for automating the test, but it doesn't work for 5.11 [for configured_system where it was]. I made it clear that it's not implemented for 5.11 in this PR. (I wasn't able to implement it in a reasonable amount of time)
