### PR TITLE
[1LP][RFR] Remove Red Hat Cloud tab from role_access

### DIFF
--- a/cfme/roles.py
+++ b/cfme/roles.py
@@ -636,7 +636,6 @@ role_access_ui_511z = {
         'Monitor': {
             'Alerts': ['Overview', 'All Alerts']
         },
-        'Red Hat Cloud': ['Services', 'Providers']
     },
     'evmgroup-administrator': {
         'Overview': ['Dashboard', 'Reports', 'Utilization', 'Chargeback'],


### PR DESCRIPTION
This tab was removed in CFME 5.11.1

{{ pytest: --long-running cfme/tests/integration/test_aws_iam_auth_and_roles.py -k "evmgroup-super_administrator-role_access0-ViaUI" }}