### PR TITLE
[1LP][RFR] New Test: Testing proper error flash message for playbook type domain imports

### DIFF
--- a/cfme/automate/import_export.py
+++ b/cfme/automate/import_export.py
@@ -71,6 +71,7 @@ class AutomateImportExportView(AutomateImportExportBaseView):
 
 
 class FileImportSelectorView(AutomateImportExportBaseView):
+    flash = V2VFlashMessages(locator="div.import-flash-message")
     import_into = BootstrapSelect(id="selected_domain_to_import_to")
     import_from = BootstrapSelect(
         locator=".//div[contains(@class, 'bootstrap-select importing-domains')]"

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -329,7 +329,7 @@ def setup_ansible_repository(appliance, wait_for_ansible):
         timeout=60,
         fail_func=view.toolbar.refresh.click
     )
-    yield
+    yield repository
     repository.delete_if_exists()
 
 
@@ -471,5 +471,9 @@ def test_import_domain_containing_playbook_method(request, appliance, setup_ansi
     domain = datastore.import_domain_from(import_data.from_domain, import_data.to_domain)
     request.addfinalizer(domain.delete_if_exists)
     view = appliance.browser.create_view(FileImportSelectorView)
-    error_msg = "Playbook 'invalid_1677575.yml' not found in repository 'test_playbooks_automate'"
-    assert error_msg in view.flash.read()[0]
+    # setup_ansible_repository.name is ansible repository name already there in datastore yml which
+    # we are going to import.
+    error_msg = (
+        f"Playbook 'invalid_1677575.yml' not found in repository '{setup_ansible_repository.name}'"
+    )
+    view.flash.assert_message(text=error_msg, partial=True)

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -202,37 +202,6 @@ def test_domain_import_git(
     assert domain.exists
 
 
-@pytest.mark.manual
-@pytest.mark.tier(1)
-@pytest.mark.ignore_stream("5.10")
-@pytest.mark.meta(coverage=[1677575])
-def test_import_export_domain_with_ansible_method():
-    """This test case tests support of Export/Import of Domain with Ansible Method
-
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/8h
-        caseimportance: high
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.11
-        casecomponent: Automate
-        tags: automate
-        setup:
-            1. Start server_roles - 'git_owner'
-        testSteps:
-            1. Navigate to Automation > Automate > Import/Export
-            2. Import/Export 'Domain' using ansible method
-        expectedResults:
-            1.
-            2. Domain should get imported and seen in domain list
-
-    Bugzilla:
-        1677575
-    """
-    pass
-
-
 @pytest.mark.tier(1)
 @pytest.mark.meta(automates=[BZ(1714493)])
 def test_refresh_git_current_user(imported_domain, new_user):


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

## Purpose or Intent
- Testing proper error flash message for playbook type domain imports

### PRT Run
{{ pytest: cfme/tests/ansible/test_embedded_ansible_automate.py::test_import_domain_containing_playbook_method --use-template-cache -qsvv --long-running }}