### PR TITLE
[1LP][RFR] Update authentication for bz util, add clone coverage

### DIFF
--- a/cfme/scripting/bz.py
+++ b/cfme/scripting/bz.py
@@ -51,6 +51,7 @@ def get_report(directory):
         "--long-running",
         "--use-template-cache",
         "--collect-only",
+        "--dummy-appliance",
         "-q",
         "--generate-bz-report", directory
     ])


### PR DESCRIPTION
handle api_key authentication to bugzilla
remove contextmanager for login, the underlying library should authenticate when URL is passed
Add scan for clone BZs to the method used for BZ coverage reports

At this time, it takes a while (several minutes) to run when collecting clone BZ's. May be able to do some filtering to optimize, based on cross-cloning of BZ's.

Additional coverage list generated by this change:
```
    id: 1155295, qe_test_coverage: ?
    id: 1232022, qe_test_coverage: ?
    id: 1236683, qe_test_coverage: ?
    id: 1316137, qe_test_coverage: -
    id: 1335529, qe_test_coverage: -
    id: 1357013, qe_test_coverage: -
    id: 1382845, qe_test_coverage: -
    id: 1382847, qe_test_coverage: -
    id: 1385897, qe_test_coverage: -
    id: 1386782, qe_test_coverage: -
    id: 1388152, qe_test_coverage: -
    id: 1393120, qe_test_coverage: -
    id: 1396210, qe_test_coverage: -
    id: 1410828, qe_test_coverage: -
    id: 1411473, qe_test_coverage: -
    id: 1412364, qe_test_coverage: -
    id: 1413119, qe_test_coverage: -
    id: 1414887, qe_test_coverage: -
    id: 1433435, qe_test_coverage: -
    id: 1434965, qe_test_coverage: -
    id: 1437922, qe_test_coverage: -
    id: 1437925, qe_test_coverage: -
    id: 1437926, qe_test_coverage: -
    id: 1440574, qe_test_coverage: -
    id: 1441249, qe_test_coverage: -
    id: 1441251, qe_test_coverage: -
    id: 1442865, qe_test_coverage: -
    id: 1445900, qe_test_coverage: -
    id: 1446618, qe_test_coverage: -
    id: 1449366, qe_test_coverage: -
    id: 1450502, qe_test_coverage: -
    id: 1460316, qe_test_coverage: -
    id: 1460366, qe_test_coverage: -
    id: 1460809, qe_test_coverage: -
    id: 1470773, qe_test_coverage: -
    id: 1480377, qe_test_coverage: -
    id: 1498544, qe_test_coverage: -
    id: 1500051, qe_test_coverage: -
    id: 1500052, qe_test_coverage: -
    id: 1520977, qe_test_coverage: -
    id: 1521036, qe_test_coverage: -
    id: 1521043, qe_test_coverage: -
    id: 1524698, qe_test_coverage: -
    id: 1526081, qe_test_coverage: -
    id: 1532332, qe_test_coverage: -
    id: 1534770, qe_test_coverage: -
    id: 1535154, qe_test_coverage: -
    id: 1549241, qe_test_coverage: -
    id: 1553393, qe_test_coverage: -
    id: 1553396, qe_test_coverage: -
    id: 1553768, qe_test_coverage: -
    id: 1560098, qe_test_coverage: -
    id: 1560099, qe_test_coverage: -
    id: 1565139, qe_test_coverage: -
    id: 1569103, qe_test_coverage: -
    id: 1569104, qe_test_coverage: -
    id: 1571976, qe_test_coverage: -
    id: 1572711, qe_test_coverage: -
    id: 1578400, qe_test_coverage: -
    id: 1581287, qe_test_coverage: -
    id: 1583710, qe_test_coverage: -
    id: 1583711, qe_test_coverage: -
    id: 1588038, qe_test_coverage: -
    id: 1594839, qe_test_coverage: -
    id: 1595445, qe_test_coverage: -
    id: 1625376, qe_test_coverage: -
    id: 1634809, qe_test_coverage: -
    id: 1639364, qe_test_coverage: -
    id: 1641670, qe_test_coverage: -
    id: 1643263, qe_test_coverage: -
    id: 1646561, qe_test_coverage: -
    id: 1653710, qe_test_coverage: -
    id: 1672693, qe_test_coverage: -
    id: 1672694, qe_test_coverage: -
    id: 1693727, qe_test_coverage: -
    id: 1702075, qe_test_coverage: -
    id: 1704772, qe_test_coverage: -
    id: 1710578, qe_test_coverage: -
    id: 1722817, qe_test_coverage: -
    id: 1725894, qe_test_coverage: -
    id: 1728889, qe_test_coverage: -
    id: 1731992, qe_test_coverage: -
    id: 1732117, qe_test_coverage: -
    id: 1733376, qe_test_coverage: -
    id: 1733384, qe_test_coverage: -
    id: 1737123, qe_test_coverage: -
    id: 1740769, qe_test_coverage: -
    id: 1740844, qe_test_coverage: -
    id: 1741944, qe_test_coverage: -
    id: 1741945, qe_test_coverage: -
    id: 1767018, qe_test_coverage: ?
    id: 1767784, qe_test_coverage: ?
    id: 1767786, qe_test_coverage: ?
    id: 1767811, qe_test_coverage: ?
    id: 1767835, qe_test_coverage: ?
    id: 1773666, qe_test_coverage: ?
    id: 1773667, qe_test_coverage: ?
    id: 1774063, qe_test_coverage: ?

```