### PR TITLE
[1LP][RFR] Fix restore tests third part

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -261,9 +261,11 @@ def ha_appliances_with_providers(ha_multiple_preupdate_appliances, app_creds):
     return ha_multiple_preupdate_appliances
 
 
-def replicated_appliances_with_providers(multiple_preupdate_appliances):
-    """Returns two database-owning appliances, configures with providers."""
-    appl1, appl2 = multiple_preupdate_appliances
+def replicated_appliances_with_providers(multiple_appliances):
+    """ Accpets two unconfigured appliance at least.
+    Configures them with different region and sets the Global/Remote kind of
+    replication on them. Configures first appliance with two providers. """
+    appl1, appl2 = multiple_appliances
     # configure appliances
     appl1.configure(region=0)
     appl1.wait_for_web_ui()
@@ -276,7 +278,7 @@ def replicated_appliances_with_providers(multiple_preupdate_appliances):
     # Add infra/cloud providers
     provider_app_crud(VMwareProvider, appl1).setup()
     provider_app_crud(EC2Provider, appl1).setup()
-    return multiple_preupdate_appliances
+    return multiple_appliances
 
 
 @pytest.fixture

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -1,6 +1,5 @@
 import re
 from collections import namedtuple
-from re import escape as resc
 
 import fauxfactory
 import pytest
@@ -214,12 +213,12 @@ def restore_db(appl, location=''):
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=40)
         interaction.answer('Choose the advanced setting: ', '6')
-        interaction.answer(resc('Choose the restore database file source: |1| '), '1')
-        interaction.answer(resc('Enter the location of the local restore file: '
+        interaction.answer(re.escape('Choose the restore database file source: |1| '), '1')
+        interaction.answer(re.escape('Enter the location of the local restore file: '
                                 '|/tmp/evm_db.backup| '), location)
-        interaction.answer(resc('Should this file be deleted after completing the restore? '
+        interaction.answer(re.escape('Should this file be deleted after completing the restore? '
                                 '(Y/N): '), 'N')
-        interaction.answer(resc(
+        interaction.answer(re.escape(
             'Are you sure you would like to restore the database? (Y/N): '), 'Y')
         interaction.answer('Press any key to continue.', '', timeout=60)
 
@@ -290,14 +289,14 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
         interaction.answer('Press any key to continue.', '', timeout=40)
         interaction.answer('Choose the advanced setting: ', '6')
         interaction.answer(
-            resc('Choose the restore database file source: |1| '), '')
+            re.escape('Choose the restore database file source: |1| '), '')
         interaction.answer(
-            resc('Enter the location of the local restore file: |/tmp/evm_db.backup| '),
+            re.escape('Enter the location of the local restore file: |/tmp/evm_db.backup| '),
             backup_file_name)
         interaction.answer(
-            resc('Should this file be deleted after completing the restore? (Y/N): '), 'n')
+            re.escape('Should this file be deleted after completing the restore? (Y/N): '), 'n')
         interaction.answer(
-            resc('Are you sure you would like to restore the database? (Y/N): '), 'y')
+            re.escape('Are you sure you would like to restore the database? (Y/N): '), 'y')
         interaction.answer('Press any key to continue.', '', timeout=80)
 
     appl2.evmserverd.start()
@@ -590,7 +589,7 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
             nfs_dump_file_name)
         # Enter the location to save the remote backup file to
         interaction.answer(
-            resc('Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '),
+            re.escape('Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '),
             nfs_restore_dir_path)
         # Running Database backup to nfs://XX.XX.XX.XX/srv/export...
         interaction.answer('Press any key to continue.', '', timeout=240)
@@ -661,11 +660,11 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
             smb_dump_file_name)
         # Enter the location to save the remote backup file to
         interaction.answer(
-            resc('Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '),
+            re.escape('Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '),
             smb_restore_dir_path)
         # Enter the username with access to this file.
-        interaction.answer(resc("Example: 'mydomain.com/user': "), usr)
-        interaction.answer(resc('Enter the password for {}: '.format(usr)), pwd)
+        interaction.answer(re.escape("Example: 'mydomain.com/user': "), usr)
+        interaction.answer(re.escape('Enter the password for {}: '.format(usr)), pwd)
         # Running Database backup to nfs://10.8.198.142/srv/export...
         interaction.answer('Press any key to continue.', '', timeout=120)
 
@@ -681,11 +680,11 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
         interaction.answer(r'Choose the restore database file source: \|1\| ', '3')
         # Enter the location of the remote backup file
         interaction.answer(
-            resc('Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '),
+            re.escape('Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '),
             smb_restore_file_path)
         # Enter the username with access to this file.
-        interaction.answer(resc("Example: 'mydomain.com/user': "), usr)
-        interaction.answer(resc('Enter the password for {}: '.format(usr)), pwd)
+        interaction.answer(re.escape("Example: 'mydomain.com/user': "), usr)
+        interaction.answer(re.escape('Enter the password for {}: '.format(usr)), pwd)
         interaction.answer(r'Are you sure you would like to restore the database\? \(Y\/N\): ', 'y')
         interaction.answer('Press any key to continue.', '', timeout=80)
 

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -159,8 +159,7 @@ def get_ha_appliances_with_providers(unconfigured_appliances, app_creds):
     appl3.evmserverd.wait_for_running()
     appl3.wait_for_web_ui()
     # Configure primary replication node
-    command_set = ('ap', '', '8', '1', '1', '', '', pwd, pwd, app0_ip,
-        TimedCommand('y', 60), '')
+    command_set = ('ap', '', '8', '1', '1', '', '', pwd, pwd, app0_ip, TimedCommand('y', 60), '')
     appl1.appliance_console.run_commands(command_set)
 
     # Configure secondary replication node
@@ -211,17 +210,18 @@ def two_appliances_one_with_providers(temp_appliances_preconfig_funcscope):
 
 
 def restore_db(appl, location=''):
-    interaction = SSHExpect(appl)
-    interaction.send('ap')
-    interaction.answer('Press any key to continue.', '', timeout=40)
-    interaction.answer('Choose the advanced setting: ', '6')
-    interaction.answer(resc('Choose the restore database file source: |1| '), '1')
-    interaction.answer(resc('Enter the location of the local restore file: '
-                            '|/tmp/evm_db.backup| '), location)
-    interaction.answer(resc('Should this file be deleted after completing the restore? '
-                            '(Y/N): '), 'N')
-    interaction.answer(resc('Are you sure you would like to restore the database? (Y/N): '), 'Y')
-    interaction.answer('Press any key to continue.', '', timeout=60)
+    with SSHExpect(appl) as interaction:
+        interaction.send('ap')
+        interaction.answer('Press any key to continue.', '', timeout=40)
+        interaction.answer('Choose the advanced setting: ', '6')
+        interaction.answer(resc('Choose the restore database file source: |1| '), '1')
+        interaction.answer(resc('Enter the location of the local restore file: '
+                                '|/tmp/evm_db.backup| '), location)
+        interaction.answer(resc('Should this file be deleted after completing the restore? '
+                                '(Y/N): '), 'N')
+        interaction.answer(resc(
+            'Are you sure you would like to restore the database? (Y/N): '), 'Y')
+        interaction.answer('Press any key to continue.', '', timeout=60)
 
 
 @pytest.mark.rhel_testing
@@ -285,25 +285,25 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
     appl2.db.drop()
     appl2.db.create()
 
-    interaction = SSHExpect(appl2)
-    interaction.send('ap')
-    interaction.expect('Press any key to continue.', timeout=40)
-    interaction.send('')
-    interaction.expect('Choose the advanced setting: ')
-    interaction.send('6')
-    interaction.expect(re.escape(
-        'Choose the restore database file source: |1| '))
-    interaction.send('')
-    interaction.expect(re.escape(
-        'Enter the location of the local restore file: |/tmp/evm_db.backup| '))
-    interaction.send(backup_file_name)
-    interaction.expect(re.escape(
-        'Should this file be deleted after completing the restore? (Y/N): '))
-    interaction.send('n')
-    interaction.expect(re.escape(
-        'Are you sure you would like to restore the database? (Y/N): '))
-    interaction.send('y')
-    interaction.expect('Press any key to continue.', timeout=80)
+    with SSHExpect(appl2) as interaction:
+        interaction.send('ap')
+        interaction.expect('Press any key to continue.', timeout=40)
+        interaction.send('')
+        interaction.expect('Choose the advanced setting: ')
+        interaction.send('6')
+        interaction.expect(re.escape(
+            'Choose the restore database file source: |1| '))
+        interaction.send('')
+        interaction.expect(re.escape(
+            'Enter the location of the local restore file: |/tmp/evm_db.backup| '))
+        interaction.send(backup_file_name)
+        interaction.expect(re.escape(
+            'Should this file be deleted after completing the restore? (Y/N): '))
+        interaction.send('n')
+        interaction.expect(re.escape(
+            'Are you sure you would like to restore the database? (Y/N): '))
+        interaction.send('y')
+        interaction.expect('Press any key to continue.', timeout=80)
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
@@ -585,22 +585,22 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
     fetch_v2key(appl1, appl2)
 
     # Do the backup
-    interaction = SSHExpect(appl1)
-    interaction.send('ap')
-    interaction.expect('Press any key to continue.', timeout=40)
-    interaction.send('')
-    interaction.expect('Choose the advanced setting: ')
-    interaction.send('4')
-    interaction.expect(r'Choose the backup output file destination: \|1\| ')
-    interaction.send('2')
-    interaction.expect(r'Enter the location to save the backup file to: \|.*\| ')
-    interaction.send(nfs_dump_file_name)
-    # Enter the location to save the remote backup file to
-    interaction.expect(re.escape(
-        'Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '))
-    interaction.send(nfs_restore_dir_path)
-    # Running Database backup to nfs://XX.XX.XX.XX/srv/export...
-    interaction.expect('Press any key to continue.', timeout=240)
+    with SSHExpect(appl1) as interaction:
+        interaction.send('ap')
+        interaction.expect('Press any key to continue.', timeout=40)
+        interaction.send('')
+        interaction.expect('Choose the advanced setting: ')
+        interaction.send('4')
+        interaction.expect(r'Choose the backup output file destination: \|1\| ')
+        interaction.send('2')
+        interaction.expect(r'Enter the location to save the backup file to: \|.*\| ')
+        interaction.send(nfs_dump_file_name)
+        # Enter the location to save the remote backup file to
+        interaction.expect(re.escape(
+            'Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '))
+        interaction.send(nfs_restore_dir_path)
+        # Running Database backup to nfs://XX.XX.XX.XX/srv/export...
+        interaction.expect('Press any key to continue.', timeout=240)
 
     # Restore DB on the second appliance
     appl2.evmserverd.stop()

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -608,21 +608,21 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
     appl2.db.drop()
     appl2.db.create()
 
-    interaction = SSHExpect(appl2)
-    interaction.send('ap')
-    interaction.expect('Press any key to continue.', timeout=40)
-    interaction.send('')
-    interaction.expect('Choose the advanced setting: ')
-    interaction.send('6')
-    interaction.expect(r'Choose the restore database file source: \|1\| ')
-    interaction.send('2')
-    # Enter the location of the remote backup file
-    interaction.expect(re.escape(
-        'Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '))
-    interaction.send(nfs_restore_file_path)
-    interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
-    interaction.send('y')
-    interaction.expect('Press any key to continue.', timeout=60)
+    with SSHExpect(appl2) as interaction:
+        interaction.send('ap')
+        interaction.expect('Press any key to continue.', timeout=40)
+        interaction.send('')
+        interaction.expect('Choose the advanced setting: ')
+        interaction.send('6')
+        interaction.expect(r'Choose the restore database file source: \|1\| ')
+        interaction.send('2')
+        # Enter the location of the remote backup file
+        interaction.expect(re.escape(
+            'Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '))
+        interaction.send(nfs_restore_file_path)
+        interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
+        interaction.send('y')
+        interaction.expect('Press any key to continue.', timeout=80)
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
@@ -664,53 +664,53 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
     fetch_v2key(appl1, appl2)
 
     # Do the backup
-    interaction = SSHExpect(appl1)
-    interaction.send('ap')
-    interaction.expect('Press any key to continue.', timeout=40)
-    interaction.send('')
-    interaction.expect('Choose the advanced setting: ')
-    interaction.send('4')
-    interaction.expect(r'Choose the backup output file destination: \|1\| ')
-    interaction.send('3')
-    interaction.expect(r'Enter the location to save the backup file to: \|.*\| ')
-    interaction.send(smb_dump_file_name)
-    # Enter the location to save the remote backup file to
-    interaction.expect(re.escape(
-        'Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '))
-    interaction.send(smb_restore_dir_path)
-    # Enter the username with access to this file.
-    interaction.expect(re.escape("Example: 'mydomain.com/user': "))
-    interaction.send(usr)
-    interaction.expect(re.escape('Enter the password for {}: '.format(usr)))
-    interaction.send(pwd)
-    # Running Database backup to nfs://10.8.198.142/srv/export...
-    interaction.expect('Press any key to continue.', timeout=240)
+    with SSHExpect(appl1) as interaction:
+        interaction.send('ap')
+        interaction.expect('Press any key to continue.', timeout=40)
+        interaction.send('')
+        interaction.expect('Choose the advanced setting: ')
+        interaction.send('4')
+        interaction.expect(r'Choose the backup output file destination: \|1\| ')
+        interaction.send('3')
+        interaction.expect(r'Enter the location to save the backup file to: \|.*\| ')
+        interaction.send(smb_dump_file_name)
+        # Enter the location to save the remote backup file to
+        interaction.expect(re.escape(
+            'Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '))
+        interaction.send(smb_restore_dir_path)
+        # Enter the username with access to this file.
+        interaction.expect(re.escape("Example: 'mydomain.com/user': "))
+        interaction.send(usr)
+        interaction.expect(re.escape('Enter the password for {}: '.format(usr)))
+        interaction.send(pwd)
+        # Running Database backup to nfs://10.8.198.142/srv/export...
+        interaction.expect('Press any key to continue.', timeout=120)
 
     # Restore DB on the second appliance
     appl2.evmserverd.stop()
     appl2.db.drop()
     appl2.db.create()
 
-    interaction = SSHExpect(appl2)
-    interaction.send('ap')
-    interaction.expect('Press any key to continue.', timeout=40)
-    interaction.send('')
-    interaction.expect('Choose the advanced setting: ')
-    interaction.send('6')
-    interaction.expect(r'Choose the restore database file source: \|1\| ')
-    interaction.send('3')
-    # Enter the location of the remote backup file
-    interaction.expect(re.escape(
-        'Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '))
-    interaction.send(smb_restore_file_path)
-    # Enter the username with access to this file.
-    interaction.expect(re.escape("Example: 'mydomain.com/user': "))
-    interaction.send(usr)
-    interaction.expect(re.escape('Enter the password for {}: '.format(usr)))
-    interaction.send(pwd)
-    interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
-    interaction.send('y')
-    interaction.expect('Press any key to continue.', timeout=80)
+    with SSHExpect(appl2) as interaction:
+        interaction.send('ap')
+        interaction.expect('Press any key to continue.', timeout=40)
+        interaction.send('')
+        interaction.expect('Choose the advanced setting: ')
+        interaction.send('6')
+        interaction.expect(r'Choose the restore database file source: \|1\| ')
+        interaction.send('3')
+        # Enter the location of the remote backup file
+        interaction.expect(re.escape(
+            'Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '))
+        interaction.send(smb_restore_file_path)
+        # Enter the username with access to this file.
+        interaction.expect(re.escape("Example: 'mydomain.com/user': "))
+        interaction.send(usr)
+        interaction.expect(re.escape('Enter the password for {}: '.format(usr)))
+        interaction.send(pwd)
+        interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
+        interaction.send('y')
+        interaction.expect('Press any key to continue.', timeout=80)
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -71,9 +71,9 @@ def get_replicated_appliances_with_providers(temp_appliances_unconfig_funcscope_
 
     """
     appl1, appl2 = replicated_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm)
-    appl1.ssh_client.run_command("pg_basebackup -x -Ft -z -D /tmp/backup")
+    appl1.ssh_client.run_command("pg_basebackup -X fetch -U root -Ft -z -D /tmp/backup")
     appl1.db.backup()
-    appl2.ssh_client.run_command("pg_basebackup -x -Ft -z -D /tmp/backup")
+    appl2.ssh_client.run_command("pg_basebackup -X fetch -U root -Ft -z -D /tmp/backup")
     appl2.db.backup()
     return temp_appliances_unconfig_funcscope_rhevm
 

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -287,23 +287,18 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
 
     with SSHExpect(appl2) as interaction:
         interaction.send('ap')
-        interaction.expect('Press any key to continue.', timeout=40)
-        interaction.send('')
-        interaction.expect('Choose the advanced setting: ')
-        interaction.send('6')
-        interaction.expect(re.escape(
-            'Choose the restore database file source: |1| '))
-        interaction.send('')
-        interaction.expect(re.escape(
-            'Enter the location of the local restore file: |/tmp/evm_db.backup| '))
-        interaction.send(backup_file_name)
-        interaction.expect(re.escape(
-            'Should this file be deleted after completing the restore? (Y/N): '))
-        interaction.send('n')
-        interaction.expect(re.escape(
-            'Are you sure you would like to restore the database? (Y/N): '))
-        interaction.send('y')
-        interaction.expect('Press any key to continue.', timeout=80)
+        interaction.answer('Press any key to continue.', '', timeout=40)
+        interaction.answer('Choose the advanced setting: ', '6')
+        interaction.answer(
+            resc('Choose the restore database file source: |1| '), '')
+        interaction.answer(
+            resc('Enter the location of the local restore file: |/tmp/evm_db.backup| '),
+            backup_file_name)
+        interaction.answer(
+            resc('Should this file be deleted after completing the restore? (Y/N): '), 'n')
+        interaction.answer(
+            resc('Are you sure you would like to restore the database? (Y/N): '), 'y')
+        interaction.answer('Press any key to continue.', '', timeout=80)
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
@@ -588,20 +583,17 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
     # Do the backup
     with SSHExpect(appl1) as interaction:
         interaction.send('ap')
-        interaction.expect('Press any key to continue.', timeout=40)
-        interaction.send('')
-        interaction.expect('Choose the advanced setting: ')
-        interaction.send('4')
-        interaction.expect(r'Choose the backup output file destination: \|1\| ')
-        interaction.send('2')
-        interaction.expect(r'Enter the location to save the backup file to: \|.*\| ')
-        interaction.send(nfs_dump_file_name)
+        interaction.answer('Press any key to continue.', '', timeout=40)
+        interaction.answer('Choose the advanced setting: ', '4')
+        interaction.answer(r'Choose the backup output file destination: \|1\| ', '2')
+        interaction.answer(r'Enter the location to save the backup file to: \|.*\| ',
+            nfs_dump_file_name)
         # Enter the location to save the remote backup file to
-        interaction.expect(re.escape(
-            'Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '))
-        interaction.send(nfs_restore_dir_path)
+        interaction.answer(
+            resc('Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '),
+            nfs_restore_dir_path)
         # Running Database backup to nfs://XX.XX.XX.XX/srv/export...
-        interaction.expect('Press any key to continue.', timeout=240)
+        interaction.answer('Press any key to continue.', '', timeout=240)
 
     # Restore DB on the second appliance
     appl2.evmserverd.stop()
@@ -610,19 +602,15 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
 
     with SSHExpect(appl2) as interaction:
         interaction.send('ap')
-        interaction.expect('Press any key to continue.', timeout=40)
-        interaction.send('')
-        interaction.expect('Choose the advanced setting: ')
-        interaction.send('6')
-        interaction.expect(r'Choose the restore database file source: \|1\| ')
-        interaction.send('2')
+        interaction.answer('Press any key to continue.', '', timeout=40)
+        interaction.answer('Choose the advanced setting: ', '6')
+        interaction.answer(r'Choose the restore database file source: \|1\| ', '2')
         # Enter the location of the remote backup file
-        interaction.expect(re.escape(
-            'Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '))
-        interaction.send(nfs_restore_file_path)
-        interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
-        interaction.send('y')
-        interaction.expect('Press any key to continue.', timeout=80)
+        interaction.answer(
+            re.escape('Example: nfs://host.mydomain.com/exported/my_exported_folder/db.backup: '),
+            nfs_restore_file_path)
+        interaction.answer(r'Are you sure you would like to restore the database\? \(Y\/N\): ', 'y')
+        interaction.answer('Press any key to continue.', '', timeout=80)
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
@@ -666,25 +654,20 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
     # Do the backup
     with SSHExpect(appl1) as interaction:
         interaction.send('ap')
-        interaction.expect('Press any key to continue.', timeout=40)
-        interaction.send('')
-        interaction.expect('Choose the advanced setting: ')
-        interaction.send('4')
-        interaction.expect(r'Choose the backup output file destination: \|1\| ')
-        interaction.send('3')
-        interaction.expect(r'Enter the location to save the backup file to: \|.*\| ')
-        interaction.send(smb_dump_file_name)
+        interaction.answer('Press any key to continue.', '', timeout=40)
+        interaction.answer('Choose the advanced setting: ', '4')
+        interaction.answer(r'Choose the backup output file destination: \|1\| ', '3')
+        interaction.answer(r'Enter the location to save the backup file to: \|.*\| ',
+            smb_dump_file_name)
         # Enter the location to save the remote backup file to
-        interaction.expect(re.escape(
-            'Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '))
-        interaction.send(smb_restore_dir_path)
+        interaction.answer(
+            resc('Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '),
+            smb_restore_dir_path)
         # Enter the username with access to this file.
-        interaction.expect(re.escape("Example: 'mydomain.com/user': "))
-        interaction.send(usr)
-        interaction.expect(re.escape('Enter the password for {}: '.format(usr)))
-        interaction.send(pwd)
+        interaction.answer(resc("Example: 'mydomain.com/user': "), usr)
+        interaction.answer(resc('Enter the password for {}: '.format(usr)), pwd)
         # Running Database backup to nfs://10.8.198.142/srv/export...
-        interaction.expect('Press any key to continue.', timeout=120)
+        interaction.answer('Press any key to continue.', '', timeout=120)
 
     # Restore DB on the second appliance
     appl2.evmserverd.stop()
@@ -693,24 +676,18 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
 
     with SSHExpect(appl2) as interaction:
         interaction.send('ap')
-        interaction.expect('Press any key to continue.', timeout=40)
-        interaction.send('')
-        interaction.expect('Choose the advanced setting: ')
-        interaction.send('6')
-        interaction.expect(r'Choose the restore database file source: \|1\| ')
-        interaction.send('3')
+        interaction.answer('Press any key to continue.', '', timeout=40)
+        interaction.answer('Choose the advanced setting: ', '6')
+        interaction.answer(r'Choose the restore database file source: \|1\| ', '3')
         # Enter the location of the remote backup file
-        interaction.expect(re.escape(
-            'Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '))
-        interaction.send(smb_restore_file_path)
+        interaction.answer(
+            resc('Example: smb://host.mydomain.com/my_share/daily_backup/db.backup: '),
+            smb_restore_file_path)
         # Enter the username with access to this file.
-        interaction.expect(re.escape("Example: 'mydomain.com/user': "))
-        interaction.send(usr)
-        interaction.expect(re.escape('Enter the password for {}: '.format(usr)))
-        interaction.send(pwd)
-        interaction.expect(r'Are you sure you would like to restore the database\? \(Y\/N\): ')
-        interaction.send('y')
-        interaction.expect('Press any key to continue.', timeout=80)
+        interaction.answer(resc("Example: 'mydomain.com/user': "), usr)
+        interaction.answer(resc('Enter the password for {}: '.format(usr)), pwd)
+        interaction.answer(r'Are you sure you would like to restore the database\? \(Y\/N\): ', 'y')
+        interaction.answer('Press any key to continue.', '', timeout=80)
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -533,8 +533,8 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
     providers_before_restore = set(appl3.managed_provider_names)
     # Restore DB on the second appliance
     appl3.evmserverd.stop()
-    appl1.rh_postgresql95_repmgr.stop()
-    appl2.rh_postgresql95_repmgr.stop()
+    appl1.repmgr.stop()
+    appl2.repmgr.stop()
     appl1.db.drop()
     appl1.db.create()
     fetch_v2key(appl3, appl1)

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -483,7 +483,7 @@ def test_appliance_console_restore_db_replicated(
 
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream('upstream')
-@pytest.mark.meta(automates=[1740515])
+@pytest.mark.meta(automates=[1740515, 1693189])
 def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_creds):
     """Configure HA environment with providers, run backup/restore on configuration,
     Confirm that ha failover continues to work correctly and providers still exist.
@@ -494,6 +494,7 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
         casecomponent: Appliance
         initialEstimate: 1/4h
     Bugzilla:
+        1693189
         1740515
     """
     pwd = app_creds["password"]

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -318,7 +318,7 @@ def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansi
     manager.quit()
     appl1.evmserverd.start()
     appl1.wait_for_web_ui()
-    assert appl1.is_embedded_ansible_running
+    appl1.wait_for_embedded_ansible()
     repositories = appl1.collections.ansible_repositories
     try:
         repository = repositories.create(

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -581,6 +581,8 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
     # Transfer v2_key and db backup from first appliance to second appliance
     fetch_v2key(appl1, appl2)
 
+    appl1_provider_names = set(appl1.managed_provider_names)
+
     # Do the backup
     with SSHExpect(appl1) as interaction:
         appl1.evmserverd.stop()
@@ -623,7 +625,7 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
     # Assert providers on the second appliance
-    assert set(appl2.managed_provider_names) == set(appl1.managed_provider_names), (
+    assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'
     )
     # Verify that existing provider can detect new VMs on the second appliance
@@ -658,6 +660,8 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
     usr = credentials[creds_key]['username']
     # Transfer v2_key and db backup from first appliance to second appliance
     fetch_v2key(appl1, appl2)
+
+    appl1_provider_names = set(appl1.managed_provider_names)
 
     # Do the backup
     with SSHExpect(appl1) as interaction:
@@ -707,7 +711,7 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
     # Assert providers on the second appliance
-    assert set(appl2.managed_provider_names) == set(appl1.managed_provider_names), (
+    assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'
     )
     # Verify that existing provider can detect new VMs on the second appliance

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -66,8 +66,8 @@ def get_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm):
 @pytest.fixture
 def get_appliance_with_ansible(temp_appliance_preconfig_funcscope):
     """Returns database-owning appliance, enables embedded ansible,
-    takes a backup prior to running tests.
-
+    waits for the ansbile to get ready, takes a backup prior to running
+    tests.
     """
     appl1 = temp_appliance_preconfig_funcscope
     # enable embedded ansible and create pg_basebackup
@@ -318,11 +318,7 @@ def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansi
     manager.quit()
     appl1.evmserverd.start()
     appl1.wait_for_web_ui()
-    appl1.reboot()
-    appl1.evmserverd.start()
-    appl1.wait_for_web_ui()
-    appl1.ssh_client.run_command(
-        'curl -kL https://localhost/ansibleapi | grep "Ansible Tower REST API"')
+    assert appl1.is_embedded_ansible_running
     repositories = appl1.collections.ansible_repositories
     try:
         repository = repositories.create(

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -458,7 +458,8 @@ def test_appliance_console_restore_db_replicated(
     # reconfigure replication between appliances which switches to "disabled"
     # during restore
     appl2.set_pglogical_replication(replication_type=':none')
-    assert not appl2.managed_provider_names
+    expected_providers = [] if appl2.version < '5.11' else ['Embedded Ansible']
+    assert appl2.managed_provider_names == expected_providers
 
     # Start the replication again
     appl2.set_pglogical_replication(replication_type=':global')

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -477,13 +477,14 @@ def test_appliance_console_restore_db_replicated(
     # Start the replication again
     appl2.set_pglogical_replication(replication_type=':global')
     appl2.add_pglogical_replication_subscription(appl1.hostname)
+
     # Assert providers exist after restore and replicated to second appliances
-    assert providers_before_restore == set(appl1.managed_provider_names), (
-        'Restored DB is missing some providers'
+    assert providers_before_restore == set(appl1.managed_provider_names)
+    wait_for(
+        lambda: providers_before_restore == set(appl2.managed_provider_names),
+        timeout=20
     )
-    assert providers_before_restore == set(appl2.managed_provider_names), (
-        'Restored DB is missing some providers'
-    )
+
     # Verify that existing provider can detect new VMs on both apps
     virtual_crud_appl1 = provider_app_crud(VMwareProvider, appl1)
     virtual_crud_appl2 = provider_app_crud(VMwareProvider, appl2)

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -19,6 +19,8 @@ from cfme.utils.conf import credentials
 from cfme.utils.log import logger
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.ssh_expect import SSHExpect
+from cfme.utils.version import LOWEST
+from cfme.utils.version import VersionPicker
 
 pytestmark = [
     test_requirements.restore
@@ -201,7 +203,10 @@ def restore_db(appl, location=''):
     with SSHExpect(appl) as interaction:
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=40)
-        interaction.answer('Choose the advanced setting: ', '6')
+        interaction.answer('Choose the advanced setting: ', VersionPicker({
+            LOWEST: '6',
+            '5.11.2.1': 4
+        }))
         interaction.answer(re.escape('Choose the restore database file source: |1| '), '1')
         interaction.answer(re.escape('Enter the location of the local restore file: '
                                 '|/tmp/evm_db.backup| '), location)
@@ -276,7 +281,10 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
     with SSHExpect(appl2) as interaction:
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=40)
-        interaction.answer('Choose the advanced setting: ', '6')
+        interaction.answer('Choose the advanced setting: ', VersionPicker({
+            LOWEST: '6',
+            '5.11.2.1': 4
+        }))
         interaction.answer(
             re.escape('Choose the restore database file source: |1| '), '')
         interaction.answer(
@@ -575,9 +583,13 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
 
     # Do the backup
     with SSHExpect(appl1) as interaction:
+        appl1.evmserverd.stop()
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=40)
-        interaction.answer('Choose the advanced setting: ', '4')
+        interaction.answer('Choose the advanced setting: ', VersionPicker({
+            LOWEST: '4',
+            '5.11.2.1': 2
+        }))
         interaction.answer(r'Choose the backup output file destination: \|1\| ', '2')
         interaction.answer(r'Enter the location to save the backup file to: \|.*\| ',
             nfs_dump_file_name)
@@ -596,7 +608,10 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
     with SSHExpect(appl2) as interaction:
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=40)
-        interaction.answer('Choose the advanced setting: ', '6')
+        interaction.answer('Choose the advanced setting: ', VersionPicker({
+            LOWEST: '6',
+            '5.11.2.1': 4
+        }))
         interaction.answer(r'Choose the restore database file source: \|1\| ', '2')
         # Enter the location of the remote backup file
         interaction.answer(
@@ -646,9 +661,13 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
 
     # Do the backup
     with SSHExpect(appl1) as interaction:
+        appl1.evmserverd.stop()
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=40)
-        interaction.answer('Choose the advanced setting: ', '4')
+        interaction.answer('Choose the advanced setting: ', VersionPicker({
+            LOWEST: '4',
+            '5.11.2.1': 2
+        }))
         interaction.answer(r'Choose the backup output file destination: \|1\| ', '3')
         interaction.answer(r'Enter the location to save the backup file to: \|.*\| ',
             smb_dump_file_name)
@@ -670,7 +689,10 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
     with SSHExpect(appl2) as interaction:
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=40)
-        interaction.answer('Choose the advanced setting: ', '6')
+        interaction.answer('Choose the advanced setting: ', VersionPicker({
+            LOWEST: '6',
+            '5.11.2.1': 4
+        }))
         interaction.answer(r'Choose the restore database file source: \|1\| ', '3')
         # Enter the location of the remote backup file
         interaction.answer(

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -351,7 +351,11 @@ def test_update_ha(ha_appliances_with_providers, appliance, update_strategy, req
              num_sec=900, delay=20, handle_exception=True,
              message='Waiting for appliance to update')
 
-    assert ha_appliances_with_providers[2].evm_failover_monitor.running
+    with LogValidator(evm_log,
+                      matched_patterns=['Starting database failover monitor'],
+                      hostname=ha_appliances_with_providers[2].hostname).waiting(wait=60):
+        ha_appliances_with_providers[2].evm_failover_monitor.restart()
+        assert ha_appliances_with_providers[2].evm_failover_monitor.running
 
     with LogValidator(evm_log,
                       matched_patterns=['Starting to execute failover'],

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -230,9 +230,8 @@ def test_update_embedded_ansible_webui(enabled_embedded_appliance, appliance, ol
         wait_for(do_appliance_versions_match, func_args=(appliance, enabled_embedded_appliance),
                 num_sec=900, delay=20, handle_exception=True,
                 message='Waiting for appliance to update')
+        enabled_embedded_appliance.wait_for_embedded_ansible()
         if enabled_embedded_appliance.version < '5.11':
-            assert wait_for(func=lambda: enabled_embedded_appliance.is_embedded_ansible_running,
-                            num_sec=180)
             assert wait_for(func=lambda: enabled_embedded_appliance.rabbitmq_server.running,
                             num_sec=60)
             assert wait_for(func=lambda: enabled_embedded_appliance.nginx.running,

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -230,12 +230,13 @@ def test_update_embedded_ansible_webui(enabled_embedded_appliance, appliance, ol
         wait_for(do_appliance_versions_match, func_args=(appliance, enabled_embedded_appliance),
                 num_sec=900, delay=20, handle_exception=True,
                 message='Waiting for appliance to update')
-    assert wait_for(func=lambda: enabled_embedded_appliance.is_embedded_ansible_running,
-                    num_sec=180)
-    assert wait_for(func=lambda: enabled_embedded_appliance.rabbitmq_server.running,
-                    num_sec=60)
-    assert wait_for(func=lambda: enabled_embedded_appliance.nginx.running,
-                    num_sec=60)
+        if enabled_embedded_appliance.version < '5.11':
+            assert wait_for(func=lambda: enabled_embedded_appliance.is_embedded_ansible_running,
+                            num_sec=180)
+            assert wait_for(func=lambda: enabled_embedded_appliance.rabbitmq_server.running,
+                            num_sec=60)
+            assert wait_for(func=lambda: enabled_embedded_appliance.nginx.running,
+                            num_sec=60)
     enabled_embedded_appliance.wait_for_web_ui()
 
     with enabled_embedded_appliance:

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -6,6 +6,7 @@ import pytest
 from cfme.fixtures.cli import do_appliance_versions_match
 from cfme.fixtures.cli import provider_app_crud
 from cfme.fixtures.cli import provision_vm
+from cfme.fixtures.cli import replicated_appliances_with_providers
 from cfme.fixtures.cli import update_appliance
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.test_framework.sprout.client import AuthException
@@ -287,7 +288,7 @@ def test_update_distributed_webui(ext_appliances_with_providers, appliance,
 
 
 @pytest.mark.ignore_stream("upstream")
-def test_update_replicated_webui(get_replicated_appliances_with_providers, appliance, request,
+def test_update_replicated_webui(multiple_preupdate_appliances, appliance, request,
                                  old_version, soft_assert):
     """ Tests updating an appliance with providers, also confirms that the
             provisioning continues to function correctly after the update has completed
@@ -298,29 +299,29 @@ def test_update_replicated_webui(get_replicated_appliances_with_providers, appli
         casecomponent: Appliance
         initialEstimate: 1/4h
     """
-    replicated_appliances_with_providers = get_replicated_appliances_with_providers
-    providers_before_upgrade = set(replicated_appliances_with_providers[0].managed_provider_names)
-    update_appliance(replicated_appliances_with_providers[0])
-    update_appliance(replicated_appliances_with_providers[1])
+    preupdate_appls = replicated_appliances_with_providers(multiple_preupdate_appliances)
+    providers_before_upgrade = set(preupdate_appls[0].managed_provider_names)
+    update_appliance(preupdate_appls[0])
+    update_appliance(preupdate_appls[1])
     wait_for(do_appliance_versions_match,
-             func_args=(appliance, replicated_appliances_with_providers[0]),
+             func_args=(appliance, preupdate_appls[0]),
              num_sec=900, delay=20, handle_exception=True,
              message='Waiting for appliance to update')
     wait_for(do_appliance_versions_match,
-             func_args=(appliance, replicated_appliances_with_providers[1]),
+             func_args=(appliance, preupdate_appls[1]),
              num_sec=900, delay=20, handle_exception=True,
              message='Waiting for appliance to update')
-    replicated_appliances_with_providers[0].evmserverd.wait_for_running()
-    replicated_appliances_with_providers[1].evmserverd.wait_for_running()
-    replicated_appliances_with_providers[0].wait_for_web_ui()
-    replicated_appliances_with_providers[1].wait_for_web_ui()
+    preupdate_appls[0].evmserverd.wait_for_running()
+    preupdate_appls[1].evmserverd.wait_for_running()
+    preupdate_appls[0].wait_for_web_ui()
+    preupdate_appls[1].wait_for_web_ui()
 
-    # Assert providers exist after upgrade and replicated to second appliances
+    # Assert providers exist after upgrade and replicated to second preupdate_appls
     assert providers_before_upgrade == set(
-        replicated_appliances_with_providers[1].managed_provider_names), 'Providers are missing'
+        preupdate_appls[1].managed_provider_names), 'Providers are missing'
     # Verify that existing provider can detect new VMs on both apps
-    virtual_crud_appl1 = provider_app_crud(VMwareProvider, replicated_appliances_with_providers[0])
-    virtual_crud_appl2 = provider_app_crud(VMwareProvider, replicated_appliances_with_providers[1])
+    virtual_crud_appl1 = provider_app_crud(VMwareProvider, preupdate_appls[0])
+    virtual_crud_appl2 = provider_app_crud(VMwareProvider, preupdate_appls[1])
     vm1 = provision_vm(request, virtual_crud_appl1)
     vm2 = provision_vm(request, virtual_crud_appl2)
     soft_assert(vm1.provider.mgmt.does_vm_exist(vm1.name), "vm not provisioned")

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -357,9 +357,7 @@ def test_update_ha(ha_appliances_with_providers, appliance, update_strategy, req
                       matched_patterns=['Starting to execute failover'],
                       hostname=ha_appliances_with_providers[2].hostname).waiting(wait=450):
         # Cause failover to occur
-        result = ha_appliances_with_providers[0].ssh_client.run_command(
-            'systemctl stop $APPLIANCE_PG_SERVICE', timeout=15)
-        assert result.success, "Failed to stop APPLIANCE_PG_SERVICE: {}".format(result.output)
+        ha_appliances_with_providers[0].db_service.stop()
 
     ha_appliances_with_providers[2].evmserverd.wait_for_running()
     ha_appliances_with_providers[2].wait_for_web_ui()

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -124,23 +124,23 @@ class IPAppliance(object):
     """
     _nav_steps = {}
 
+    appliance_console = console.ApplianceConsole.declare()
+    appliance_console_cli = console.ApplianceConsoleCli.declare()
     auditd = SystemdService.declare(unit_name='auditd')
     chronyd = SystemdService.declare(unit_name='chronyd')
     collectd = SystemdService.declare(unit_name='collectd')
+    db = ApplianceDB.declare()
     evminit = SystemdService.declare(unit_name='evminit')
     evmserverd = SystemdService.declare(unit_name='evmserverd')
     evm_failover_monitor = SystemdService.declare(unit_name='evm-failover-monitor')
+    firewalld = SystemdService.declare(unit_name='firewalld')
     httpd = SystemdService.declare(unit_name='httpd')
     nginx = SystemdService.declare(unit_name='nginx')
     rabbitmq_server = SystemdService.declare(unit_name='rabbitmq-server')
-    rh_postgresql95_repmgr = SystemdService.declare(unit_name='rh-postgresql95-repmgr')
+    repmgr = SystemdService.declare()
     sssd = SystemdService.declare(unit_name='sssd')
     sshd = SystemdService.declare(unit_name='sshd')
     supervisord = SystemdService.declare(unit_name='supervisord')
-    firewalld = SystemdService.declare(unit_name='firewalld')
-    db = ApplianceDB.declare()
-    appliance_console = console.ApplianceConsole.declare()
-    appliance_console_cli = console.ApplianceConsoleCli.declare()
 
     CONFIG_MAPPING = {
         'hostname': 'hostname',
@@ -172,6 +172,13 @@ class IPAppliance(object):
     @cached_property
     def db_service(self):
         return SystemdService(self, unit_name=self.db.service_name)
+
+    @cached_property
+    def repmgr(self):
+        return VersionPicker({
+            '5.10': SystemdService(self, unit_name='rh-postgresql95-repmgr'),
+            '5.11': SystemdService(self, unit_name='repmgr10')}
+        ).pick(self.version)
 
     @property
     def as_json(self):

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1690,16 +1690,19 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         supervisord = self.supervisord.running if self.version < '5.11' else True
         return self.is_embedded_ansible_role_enabled and supervisord
 
-    def wait_for_embedded_ansible(self, timeout=1200):
+    def wait_for_embedded_ansible(self, timeout=None):
         """Waits for embedded ansible to be ready
 
         Args:
-            timeout: Number of seconds to wait until timeout (default ``1200``)
+            timeout: Number of seconds to wait until timeout (default value is
+            picked based on the appliance version or whether it is a pod)
         """
-        if self.is_pod:
-            # openshift's ansible pod gets ready very long first time.
-            # it even gets restarted once or twice
-            timeout *= 2
+        if timeout is None:
+            timeout = 2400 if self.version < '5.11' else 120
+            if self.is_pod:
+                # openshift's ansible pod gets ready very long first time.
+                # it even gets restarted once or twice
+                timeout *= 2
 
         wait_for(
             func=lambda: self.is_embedded_ansible_running,

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -67,8 +67,11 @@ class ApplianceConsole(AppliancePlugin):
         2. '' clears info screen,
         3. '14' Hardens appliance using SCAP configuration,
         4. '' complete."""
-        command_set = ('ap', '', '13', '')
-        self.appliance.appliance_console.run_commands(command_set)
+        with SSHExpect(self.appliance) as interaction:
+            interaction.send('ap')
+            interaction.answer('Press any key to continue.', '', timeout=20)
+            interaction.answer('Choose the advanced setting: ', '15')
+            interaction.answer('Press any key to continue.', '', timeout=20)
 
     def scap_check_rules(self):
         """Check that rules have been applied correctly."""

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -74,9 +74,9 @@ class ApplianceConsole(AppliancePlugin):
         4. '' complete."""
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
-            interaction.answer('Press any key to continue.', '', timeout=20)
+            interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
             interaction.answer('Choose the advanced setting: ', '15')
-            interaction.answer('Press any key to continue.', '', timeout=20)
+            interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
 
     def scap_check_rules(self):
         """Check that rules have been applied correctly."""
@@ -123,7 +123,7 @@ class ApplianceConsole(AppliancePlugin):
         # Configure primary replication node
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
-            interaction.answer('Press any key to continue.', '', timeout=20)
+            interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
             # 6/8 for Configure Database Replication
             interaction.answer('Choose the advanced setting: ',
                                '6' if self.appliance.version < '5.10' else '8')
@@ -140,7 +140,7 @@ class ApplianceConsole(AppliancePlugin):
         # Configure primary replication node
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
-            interaction.answer('Press any key to continue.', '', timeout=20)
+            interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
             interaction.answer('Choose the advanced setting: ',
                                '6' if self.appliance.version < '5.10' else '8')
             # 6/8 for Configure Database Replication
@@ -160,7 +160,7 @@ class ApplianceConsole(AppliancePlugin):
         # Configure secondary (standby) replication node
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
-            interaction.answer('Press any key to continue.', '', timeout=20)
+            interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
             interaction.answer('Choose the advanced setting: ',
                                '6' if self.appliance.version < '5.10' else '8')
             # 6/8 for Configure Database Replication
@@ -228,13 +228,13 @@ class ApplianceConsole(AppliancePlugin):
             interaction.answer(re.escape('Continue with configuration? (Y/N): '), 'y')
             interaction.answer(
                 re.escape('Apply this Replication Server Configuration? (Y/N): '), 'y')
-            interaction.answer('Press any key to continue.', '', timeout=20)
+            interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
 
     def configure_automatic_failover(self, primary_ip):
         # Configure automatic failover on EVM appliance
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
-            interaction.answer('Press any key to continue.', '', timeout=20)
+            interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
             interaction.expect('Choose the advanced setting: ')
 
             with waiting_for_ha_monitor_started(self.appliance, primary_ip, timeout=300):
@@ -297,7 +297,7 @@ def configure_appliances_ha(appliances, pwd):
     # Configure first appliance as dedicated database
     with SSHExpect(apps0) as interaction:
         interaction.send('ap')
-        interaction.answer('Press any key to continue.', '', timeout=20)
+        interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
         interaction.answer('Choose the advanced setting: ',
                            '5' if apps0.version < '5.10' else '7')  # Configure Database
         interaction.answer(re.escape('Choose the encryption key: |1| '), '1')
@@ -327,7 +327,7 @@ def configure_appliances_ha(appliances, pwd):
     # Configure EVM webui appliance with create region in dedicated database
     with SSHExpect(apps2) as interaction:
         interaction.send('ap')
-        interaction.answer('Press any key to continue.', '', timeout=20)
+        interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
         interaction.answer('Choose the advanced setting: ',
                            '5' if apps2.version < '5.10' else '7')  # Configure Database
         interaction.answer(re.escape('Choose the encryption key: |1| '), '2')

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -377,7 +377,7 @@ class ApplianceConsoleCli(AppliancePlugin):
             " --dbname {dbname} --verbose --fetch-key {fetch_key} --sshlogin {sshlogin}"
             " --sshpassword {sshpass}".format(dbhostname=dbhostname, username=username,
                 password=password, dbname=dbname, fetch_key=fetch_key, sshlogin=sshlogin,
-                sshpass=sshpass), timeout=300)
+                sshpass=sshpass), timeout=500)
 
     def configure_appliance_external_create(self, region, dbhostname,
             username, password, dbname, fetch_key, sshlogin, sshpass):

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -10,6 +10,7 @@ from cfme.utils.log import logger
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.path import scripts_path
 from cfme.utils.ssh_expect import SSHExpect
+from cfme.utils.version import LOWEST
 from cfme.utils.version import Version
 from cfme.utils.version import VersionPicker
 from cfme.utils.wait import wait_for
@@ -73,7 +74,10 @@ class ApplianceConsole(AppliancePlugin):
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
             interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
-            interaction.answer('Choose the advanced setting: ', '15')
+            interaction.answer('Choose the advanced setting: ', VersionPicker({
+                LOWEST: 15,
+                '5.11.2.1': 13
+            }))
             interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
 
     def scap_check_rules(self):
@@ -127,8 +131,11 @@ class ApplianceConsole(AppliancePlugin):
             interaction.send('ap')
             interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
             # 6/8 for Configure Database Replication
-            interaction.answer('Choose the advanced setting: ',
-                               '6' if self.appliance.version < '5.10' else '8')
+            interaction.answer('Choose the advanced setting: ', VersionPicker({
+                LOWEST: 6,
+                '5.10': 8,
+                '5.11.2.1': 6
+            }))
             interaction.answer('Choose the database replication operation: ', '1')
             answer_cluster_related_questions(interaction, node_uid='1',
                 db_name='', db_username='', db_password=pwd)
@@ -143,8 +150,11 @@ class ApplianceConsole(AppliancePlugin):
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
             interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
-            interaction.answer('Choose the advanced setting: ',
-                               '6' if self.appliance.version < '5.10' else '8')
+            interaction.answer('Choose the advanced setting: ', VersionPicker({
+                LOWEST: '6',
+                '5.10': 8,
+                '5.11.2.1': 6
+            }))
             # 6/8 for Configure Database Replication
 
             interaction.answer('Choose the database replication operation: ', '1')
@@ -163,8 +173,11 @@ class ApplianceConsole(AppliancePlugin):
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
             interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
-            interaction.answer('Choose the advanced setting: ',
-                               '6' if self.appliance.version < '5.10' else '8')
+            interaction.answer('Choose the advanced setting: ', VersionPicker({
+                LOWEST: '6',
+                '5.10': 8,
+                '5.11.2.1': 6
+            }))
             # 6/8 for Configure Database Replication
 
             # Configure Server as Standby
@@ -197,8 +210,11 @@ class ApplianceConsole(AppliancePlugin):
             interaction.send('ap')
             # When reconfiguring, the ap command may hang for 60s even.
             interaction.answer('Press any key to continue.', '', timeout=120)
-            interaction.answer('Choose the advanced setting: ',
-                               '6' if self.appliance.version < '5.10' else '8')
+            interaction.answer('Choose the advanced setting: ', VersionPicker({
+                LOWEST: '6',
+                '5.10': 8,
+                '5.11.2.1': 6
+            }))
             # 6/8 for Configure Database Replication
 
             # Configure Server as Standby
@@ -241,7 +257,12 @@ class ApplianceConsole(AppliancePlugin):
 
             with waiting_for_ha_monitor_started(self.appliance, primary_ip, timeout=300):
                 # Configure Application Database Failover Monitor
-                interaction.send('8' if self.appliance.version < '5.10' else '10')
+                interaction.send(VersionPicker({
+                    LOWEST: 8,
+                    '5.10': 10,
+                    '5.11.2.1': 8
+                }))
+
                 interaction.answer('Choose the failover monitor configuration: ', '1')
                 # Failover Monitor Service configured successfully
                 interaction.answer('Press any key to continue.', '')
@@ -300,8 +321,11 @@ def configure_appliances_ha(appliances, pwd):
     with SSHExpect(apps0) as interaction:
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
-        interaction.answer('Choose the advanced setting: ',
-                           '5' if apps0.version < '5.10' else '7')  # Configure Database
+        interaction.answer('Choose the advanced setting: ', VersionPicker({
+            LOWEST: 5,
+            '5.10': 7,
+            '5.11.2.1': 5
+        }))  # Configure Database
         interaction.answer(re.escape('Choose the encryption key: |1| '), '1')
         interaction.answer('Choose the database operation: ', '1')
         # On 5.10, rhevm provider:
@@ -330,8 +354,11 @@ def configure_appliances_ha(appliances, pwd):
     with SSHExpect(apps2) as interaction:
         interaction.send('ap')
         interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
-        interaction.answer('Choose the advanced setting: ',
-                           '5' if apps2.version < '5.10' else '7')  # Configure Database
+        interaction.answer('Choose the advanced setting: ', VersionPicker({
+            LOWEST: 5,
+            '5.10': 7,
+            '5.11.2.1': 5
+        }))  # Configure Database
         interaction.answer(re.escape('Choose the encryption key: |1| '), '2')
         interaction.send(app0_ip)
         interaction.answer(re.escape('Enter the appliance SSH login: |root| '), '')

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -1,8 +1,8 @@
 import os
+import re
 import socket
 import tempfile
 from contextlib import contextmanager
-from re import escape as resc
 
 import lxml
 import yaml
@@ -127,7 +127,8 @@ class ApplianceConsole(AppliancePlugin):
                 db_name='', db_username='', db_password=pwd)
             interaction.answer(r'Enter the primary database hostname or IP address: \|.*\| ',
                                self.appliance.hostname)
-            interaction.answer(resc('Apply this Replication Server Configuration? (Y/N): '), 'y')
+            interaction.answer(
+                re.escape('Apply this Replication Server Configuration? (Y/N): '), 'y')
             interaction.answer('Press any key to continue.', '')
 
     def reconfigure_primary_replication_node(self, pwd):
@@ -145,8 +146,9 @@ class ApplianceConsole(AppliancePlugin):
             interaction.answer(r'Enter the primary database hostname or IP address: \|.*\| ',
                                self.appliance.hostname)
             # Warning: File /etc/repmgr.conf exists. Replication is already configured
-            interaction.answer(resc('Continue with configuration? (Y/N): '), 'y')
-            interaction.answer(resc('Apply this Replication Server Configuration? (Y/N): '), 'y')
+            interaction.answer(re.escape('Continue with configuration? (Y/N): '), 'y')
+            interaction.answer(
+                re.escape('Apply this Replication Server Configuration? (Y/N): '), 'y')
             interaction.answer('Press any key to continue.', '')
 
     def configure_standby_replication_node(self, pwd, primary_ip):
@@ -160,22 +162,23 @@ class ApplianceConsole(AppliancePlugin):
 
             # Configure Server as Standby
             interaction.answer('Choose the database replication operation: ', '2')
-            interaction.answer(resc('Choose the encryption key: |1| '), '2')
+            interaction.answer(re.escape('Choose the encryption key: |1| '), '2')
             interaction.send(primary_ip)
-            interaction.answer(resc('Enter the appliance SSH login: |root| '), '')
+            interaction.answer(re.escape('Enter the appliance SSH login: |root| '), '')
             interaction.answer('Enter the appliance SSH password: ', pwd)
-            interaction.answer(resc('Enter the path of remote encryption key: '
+            interaction.answer(re.escape('Enter the path of remote encryption key: '
                                     '|/var/www/miq/vmdb/certs/v2_key| '), '')
-            interaction.answer(resc('Choose the standby database disk: '),
+            interaction.answer(re.escape('Choose the standby database disk: '),
                                '1' if self.appliance.version < '5.10' else '2')
             answer_cluster_related_questions(interaction, node_uid='2',
                 db_name='', db_username='', db_password=pwd)
             interaction.answer('Enter the primary database hostname or IP address: ', primary_ip)
             interaction.answer(r'Enter the Standby Server hostname or IP address: \|.*\| ',
                                self.appliance.hostname)
-            interaction.answer(resc('Configure Replication Manager (repmgrd) for automatic '
+            interaction.answer(re.escape('Configure Replication Manager (repmgrd) for automatic '
                                     r'failover? (Y/N): '), 'y')
-            interaction.answer(resc('Apply this Replication Server Configuration? (Y/N): '), 'y')
+            interaction.answer(
+                re.escape('Apply this Replication Server Configuration? (Y/N): '), 'y')
             interaction.answer('Press any key to continue.', '', timeout=10 * 60)
 
     def reconfigure_standby_replication_node(self, pwd, primary_ip, repmgr_reconfigure=False):
@@ -192,29 +195,30 @@ class ApplianceConsole(AppliancePlugin):
             interaction.answer('Choose the database replication operation: ', '2')
             # Would you like to remove the existing database before configuring as a standby server?
             # WARNING: This is destructive. This will remove all previous data from this server
-            interaction.answer(resc('Continue? (Y/N): '), 'y')
+            interaction.answer(re.escape('Continue? (Y/N): '), 'y')
             interaction.answer(
                 # Don't partition the disk
-                resc('Choose the standby database disk: |1| '),
+                re.escape('Choose the standby database disk: |1| '),
                 '1' if self.appliance.version < '5.10' else '2')
-            interaction.answer(resc(
+            interaction.answer(re.escape(
                 "Are you sure you don't want to partition the Standby "
                 "database disk? (Y/N): "), 'y')
             answer_cluster_related_questions(interaction, node_uid='2',
                 db_name='', db_username='', db_password=pwd)
             interaction.answer('Enter the primary database hostname or IP address: ', primary_ip)
             interaction.answer(r'Enter the Standby Server hostname or IP address: \|.*\| ', '')
-            interaction.answer(resc(
+            interaction.answer(re.escape(
                 'Configure Replication Manager (repmgrd) for automatic '
                 r'failover? (Y/N): '), 'y')
             # interaction.answer('An active standby node (10.8.198.223) with the node number 2
             # already exists\n')
             # 'Would you like to continue configuration by overwriting '
             # 'the existing node?
-            interaction.answer(resc('(Y/N): |N| '), 'y')
+            interaction.answer(re.escape('(Y/N): |N| '), 'y')
             # Warning: File /etc/repmgr.conf exists. Replication is already configured
-            interaction.answer(resc('Continue with configuration? (Y/N): '), 'y')
-            interaction.answer(resc('Apply this Replication Server Configuration? (Y/N): '), 'y')
+            interaction.answer(re.escape('Continue with configuration? (Y/N): '), 'y')
+            interaction.answer(
+                re.escape('Apply this Replication Server Configuration? (Y/N): '), 'y')
             interaction.answer('Press any key to continue.', '', timeout=20)
 
     def configure_automatic_failover(self, primary_ip):
@@ -287,7 +291,7 @@ def configure_appliances_ha(appliances, pwd):
         interaction.answer('Press any key to continue.', '', timeout=20)
         interaction.answer('Choose the advanced setting: ',
                            '5' if apps0.version < '5.10' else '7')  # Configure Database
-        interaction.answer(resc('Choose the encryption key: |1| '), '1')
+        interaction.answer(re.escape('Choose the encryption key: |1| '), '1')
         interaction.answer('Choose the database operation: ', '1')
         # On 5.10, rhevm provider:
         #
@@ -296,10 +300,10 @@ def configure_appliances_ha(appliances, pwd):
         #    1) /dev/sr0: 0 MB
         #    2) /dev/vdb: 4768 MB
         #    3) Don't partition the disk
-        interaction.answer(resc('Choose the database disk: '),
+        interaction.answer(re.escape('Choose the database disk: '),
                           '1' if apps0.version < '5.10' else '2')
         # Should this appliance run as a standalone database server?
-        interaction.answer(resc('? (Y/N): |N| '), 'y')
+        interaction.answer(re.escape('? (Y/N): |N| '), 'y')
         interaction.answer('Enter the database password on localhost: ', pwd)
         interaction.answer('Enter the database password again: ', pwd)
         # Configuration activated successfully.
@@ -313,22 +317,22 @@ def configure_appliances_ha(appliances, pwd):
         interaction.answer('Press any key to continue.', '', timeout=20)
         interaction.answer('Choose the advanced setting: ',
                            '5' if apps2.version < '5.10' else '7')  # Configure Database
-        interaction.answer(resc('Choose the encryption key: |1| '), '2')
+        interaction.answer(re.escape('Choose the encryption key: |1| '), '2')
         interaction.send(app0_ip)
-        interaction.answer(resc('Enter the appliance SSH login: |root| '), '')
+        interaction.answer(re.escape('Enter the appliance SSH login: |root| '), '')
         interaction.answer('Enter the appliance SSH password: ', pwd)
         interaction.answer(
-            resc('Enter the path of remote encryption key: |/var/www/miq/vmdb/certs/v2_key| '),
+            re.escape('Enter the path of remote encryption key: |/var/www/miq/vmdb/certs/v2_key| '),
             '')
         interaction.answer('Choose the database operation: ', '2', timeout=30)
         interaction.answer('Enter the database region number: ', '0')
         # WARNING: Creating a database region will destroy any existing data and
         # cannot be undone.
-        interaction.answer(resc('Are you sure you want to continue? (Y/N):'), 'y')
+        interaction.answer(re.escape('Are you sure you want to continue? (Y/N):'), 'y')
         interaction.answer('Enter the database hostname or IP address: ', app0_ip)
-        interaction.answer(resc('Enter the port number: |5432| '), '')
+        interaction.answer(re.escape('Enter the port number: |5432| '), '')
         interaction.answer(r'Enter the name of the database on .*: \|vmdb_production\| ', '')
-        interaction.answer(resc('Enter the username: |root| '), '')
+        interaction.answer(re.escape('Enter the username: |root| '), '')
         interaction.answer('Enter the database password on .*: ', pwd)
         # Configuration activated successfully.
         interaction.answer('Press any key to continue.', '', timeout=360)
@@ -349,8 +353,10 @@ def answer_cluster_related_questions(interaction, node_uid, db_name,
     # This seems to happen when (re)configuring the standby replication node.
     interaction.answer('.* the number uniquely identifying '
                        'this node in the replication cluster: ', node_uid)
-    interaction.answer(resc('Enter the cluster database name: |vmdb_production| '), db_name)
-    interaction.answer(resc('Enter the cluster database username: |root| '), db_username)
+    interaction.answer(re.escape('Enter the cluster database name: |vmdb_production| '),
+                       db_name)
+    interaction.answer(re.escape('Enter the cluster database username: |root| '),
+                       db_username)
     interaction.answer('Enter the cluster database password: ', db_password)
     interaction.answer('Enter the cluster database password: ', db_password)
 

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -195,7 +195,7 @@ class ApplianceDB(AppliancePlugin):
         interaction.answer(resc('Choose the backup output file destination: |1| '), '1')
         interaction.answer(resc('Enter the location to save the backup file to: '
                                 '|/tmp/evm_db.backup| '), database_path)
-        interaction.answer(resc('Press any key to continue.'), '', timeout=120)
+        interaction.answer(resc('Press any key to continue.'), '', timeout=240)
 
     def restore(self, database_path="/tmp/evm_db.backup"):
         """Restore VMDB database

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -191,7 +191,10 @@ class ApplianceDB(AppliancePlugin):
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
             interaction.answer(re.escape('Press any key to continue.'), '', timeout=40)
-            interaction.answer(re.escape('Choose the advanced setting: '), '4')
+            interaction.answer(re.escape('Choose the advanced setting: '), VersionPicker({
+                LOWEST: 4,
+                '5.11.2.1': 2
+            }))
             interaction.answer(re.escape('Choose the backup output file destination: |1| '), '1')
             interaction.answer(re.escape('Enter the location to save the backup file to: '
                                     '|/tmp/evm_db.backup| '), database_path)

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -1,3 +1,5 @@
+from re import escape as resc
+
 import attr
 import fauxfactory
 from cached_property import cached_property
@@ -8,8 +10,10 @@ from cfme.utils import datafile
 from cfme.utils import db
 from cfme.utils.appliance.plugin import AppliancePlugin
 from cfme.utils.appliance.plugin import AppliancePluginException
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
 from cfme.utils.path import scripts_path
+from cfme.utils.ssh_expect import SSHExpect
 from cfme.utils.version import LOWEST
 from cfme.utils.version import VersionPicker
 from cfme.utils.wait import wait_for
@@ -175,19 +179,23 @@ class ApplianceDB(AppliancePlugin):
             return self._ssh_client
 
     def backup(self, database_path="/tmp/evm_db.backup"):
-        """Backup VMDB database
-        Changed from Rake task due to a bug in 5.9
-
-        """
-        from cfme.utils.appliance import ApplianceException
-        self.logger.info('Backing up database')
-        result = self.appliance.ssh_client.run_command(
-            'pg_dump --format custom --file {} vmdb_production'.format(
-                database_path))
-        if result.failed:
-            msg = 'Failed to backup database'
-            self.logger.error(msg)
-            raise ApplianceException(msg)
+        """Backup VMDB database using appliance console"""
+        if BZ(1741481).blocks:
+            self.appliance.ssh_client.run_command("""
+                grep 'local replication all peer map=usermap' \
+                        /var/lib/pgsql/data/pg_hba.conf ||
+                echo 'local replication all peer map=usermap' \
+                        >> /var/lib/pgsql/data/pg_hba.conf""")
+            self.appliance.db_service.reload()
+        self.logger.info('Backing up database using appliance console')
+        interaction = SSHExpect(self.appliance)
+        interaction.send('ap')
+        interaction.answer(resc('Press any key to continue.'), '', timeout=40)
+        interaction.answer(resc('Choose the advanced setting: '), '4')
+        interaction.answer(resc('Choose the backup output file destination: |1| '), '1')
+        interaction.answer(resc('Enter the location to save the backup file to: '
+                                '|/tmp/evm_db.backup| '), database_path)
+        interaction.answer(resc('Press any key to continue.'), '', timeout=120)
 
     def restore(self, database_path="/tmp/evm_db.backup"):
         """Restore VMDB database

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -188,14 +188,14 @@ class ApplianceDB(AppliancePlugin):
                         >> /var/lib/pgsql/data/pg_hba.conf""")
             self.appliance.db_service.reload()
         self.logger.info('Backing up database using appliance console')
-        interaction = SSHExpect(self.appliance)
-        interaction.send('ap')
-        interaction.answer(resc('Press any key to continue.'), '', timeout=40)
-        interaction.answer(resc('Choose the advanced setting: '), '4')
-        interaction.answer(resc('Choose the backup output file destination: |1| '), '1')
-        interaction.answer(resc('Enter the location to save the backup file to: '
-                                '|/tmp/evm_db.backup| '), database_path)
-        interaction.answer(resc('Press any key to continue.'), '', timeout=240)
+        with SSHExpect(self.appliance) as interaction:
+            interaction.send('ap')
+            interaction.answer(resc('Press any key to continue.'), '', timeout=40)
+            interaction.answer(resc('Choose the advanced setting: '), '4')
+            interaction.answer(resc('Choose the backup output file destination: |1| '), '1')
+            interaction.answer(resc('Enter the location to save the backup file to: '
+                                    '|/tmp/evm_db.backup| '), database_path)
+            interaction.answer(resc('Press any key to continue.'), '', timeout=240)
 
     def restore(self, database_path="/tmp/evm_db.backup"):
         """Restore VMDB database

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -1,4 +1,4 @@
-from re import escape as resc
+import re
 
 import attr
 import fauxfactory
@@ -190,12 +190,12 @@ class ApplianceDB(AppliancePlugin):
         self.logger.info('Backing up database using appliance console')
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
-            interaction.answer(resc('Press any key to continue.'), '', timeout=40)
-            interaction.answer(resc('Choose the advanced setting: '), '4')
-            interaction.answer(resc('Choose the backup output file destination: |1| '), '1')
-            interaction.answer(resc('Enter the location to save the backup file to: '
+            interaction.answer(re.escape('Press any key to continue.'), '', timeout=40)
+            interaction.answer(re.escape('Choose the advanced setting: '), '4')
+            interaction.answer(re.escape('Choose the backup output file destination: |1| '), '1')
+            interaction.answer(re.escape('Enter the location to save the backup file to: '
                                     '|/tmp/evm_db.backup| '), database_path)
-            interaction.answer(resc('Press any key to continue.'), '', timeout=240)
+            interaction.answer(re.escape('Press any key to continue.'), '', timeout=240)
 
     def restore(self, database_path="/tmp/evm_db.backup"):
         """Restore VMDB database

--- a/cfme/utils/appliance/services.py
+++ b/cfme/utils/appliance/services.py
@@ -73,6 +73,13 @@ class SystemdService(AppliancePlugin):
             log_callback=log_callback
         )
 
+    def reload(self, log_callback=None):
+        return self._run_service_command(
+            'reload',
+            expected_exit_code=0,
+            log_callback=log_callback
+        )
+
     def enable(self, log_callback=None):
         return self._run_service_command(
             'enable',

--- a/cfme/utils/ssh_expect.py
+++ b/cfme/utils/ssh_expect.py
@@ -5,6 +5,7 @@ from paramiko_expect import SSHClientInteraction
 
 from cfme.exceptions import SSHExpectTimeoutError
 from cfme.utils.log import logger
+from cfme.utils.version import VersionPicker
 
 
 def logging_callback(appliance):
@@ -15,9 +16,15 @@ def logging_callback(appliance):
 
 class SSHExpect(SSHClientInteraction):
     def __init__(self, appliance):
+        self.appliance = appliance
         SSHClientInteraction.__init__(
             self, appliance.ssh_client, timeout=10, display=True,
             output_callback=logging_callback(appliance))
+
+    def send(self, send_string, *args, **kwargs):
+        if isinstance(send_string, VersionPicker):
+            send_string = send_string.pick(self.appliance.version)
+        super().send(str(send_string), *args, **kwargs)
 
     def answer(self, question, answer, timeout=None):
         self.expect(question, timeout=timeout)

--- a/scripts/scap.rb
+++ b/scripts/scap.rb
@@ -1,0 +1,83 @@
+# Based on https://gist.github.com/carbonin/410cc56663769c442e5df61938cdade5
+require 'yaml'
+require 'nokogiri'
+require 'openscap'
+require 'tempfile'
+require 'optimist'
+
+DEFAULT_SSG_XML_PATH = "/usr/share/xml/scap/ssg/content/ssg-rhel7-ds.xml"
+
+class ScapTest
+  PROFILE_ID = "xccdf_org.ssgproject.content_profile_linux-admin-scap".freeze
+
+  def initialize(ssg_path)
+      @ssg_path = ssg_path
+  end
+
+  def run(yaml_file)
+    scap_config = YAML.load_file(yaml_file)
+    rules = scap_config['rules']
+    values = scap_config['values']
+
+    with_ds_file(rules, values) do |ds_path|
+      begin
+        session = OpenSCAP::Xccdf::Session.new(ds_path)
+        session.load
+        session.profile = PROFILE_ID
+        session.evaluate
+        session.export_results(:xccdf_file => "scap-results.xccdf.xml")
+      ensure
+        session.destroy if session
+      end
+    end
+  end
+
+  def with_ds_file(rules, values)
+    Tempfile.create("scap_ds") do |f|
+      write_ds_xml(f, profile_xml(PROFILE_ID, rules, values))
+      f.close
+      yield f.path
+    end
+  end
+
+  def profile_xml(profile_id, rules, values)
+    builder = Nokogiri::XML::Builder.new do |xml|
+      xml.Profile(:id => profile_id) do
+        xml.title(profile_id)
+        xml.description(profile_id)
+        rules.each { |r| xml.select(:idref => r, :selected => "true") }
+        values.each { |k, v| xml.send("refine-value", :idref => k, :selector => v) }
+      end
+    end
+    builder.doc.root.to_xml
+  end
+
+  def write_ds_xml(io, profile_xml)
+    File.open(@ssg_path) do |f|
+      doc = Nokogiri::XML(f)
+      model_xml_element(doc).add_next_sibling("\n#{profile_xml}")
+      io.write(doc.root.to_xml)
+    end
+  end
+
+  def model_xml_element(doc)
+    doc.xpath("//ns:model[1]", "ns" => "http://checklists.nist.gov/xccdf/1.2")[0]
+  end
+end
+
+opts = Optimist::options do
+  opt :rulesfile, "The YAML formatted file with the SCAP rules to check", :type => :string, :required => true
+  opt :ssg_path, "The SSG path", :type => :string, :required => false, :default => DEFAULT_SSG_XML_PATH
+end
+
+Trollop.die "File #{opts[:rulesfile]} does not exist" unless File.exist?(opts[:rulesfile])
+
+ScapTest.new(opts[:ssg_path]).run(opts[:rulesfile])
+`oscap xccdf generate report scap-results.xccdf.xml > scap-report.html`
+
+# The rules file should be structured in YAML format as follows:
+#rules:
+#  - xccdf_org.ssgproject.content_group_sshd_set_idle_timeout
+#  - xccdf_org.ssgproject.content_group_sshd_use_approved_ciphers
+#values:
+#  xccdf_org.ssgproject.content_value_sshd_idle_timeout_value: 15_minutes


### PR DESCRIPTION
## Purpose or Intent

This is my last PR that makes the restore tests fixed.

- __Enhancement__ .. generalization of the repmgr attribute to support CFME 5.10 as well as 5.11
- __Fixing__ test_appliance_console_restore_db_replicated
- __Fixing__ timeout for the db backup to complete
- __Enhancement__ - close the ssh channel explicitly using with statement
- __Enhancement__ - make the restore_db_replicated more reliable by adding wait instead of just assert
- __Fix__ - the SCAP update test
- __Enhancement__ - convert some calls to use `interaction.answer`
- __Enhancement__ -  use `re.escape` rather then defining `resc`
- __Fix__ - use preupdate appliances in test_update_replicated_webui. I think appliances of the target version were used so no real update was made.

{{py.test: cfme/tests/cli/test_appliance_update.py cfme/tests/cli/test_appliance_console_db_restore.py -v  --use-provider 'complete' --collect-logs}}

Remaining unresolved failures on PRT:
 * `test_proxy_*` with azure providers
 * `test_appliance_console_restore_pg_basebackup_replicated` often fails to obtain additional VMs from sprout or is getting `connection reset by peer` while in configure()
