### PR TITLE
[RFR] Update Rest API Calls to find_by() instead of get() for Container Images

### DIFF
--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -71,7 +71,7 @@ class Image(BaseEntity, Taggable, Labelable, LoadDetailsMixin, PolicyProfileAssi
         try:
             # API does not accept a unicode string, setting the image name to a string
             return (self.appliance.rest_api.collections.container_images.
-                    get(name=str(self.name)).last_scan_attempt_on)
+                    find_by(image_ref=str(self.id)).resources[0].last_scan_attempt_on)
         # If no scan has been performed on the image, it will return an AttributeError
         except AttributeError:
             return None
@@ -141,7 +141,7 @@ class Image(BaseEntity, Taggable, Labelable, LoadDetailsMixin, PolicyProfileAssi
 
         # API does not accept a unicode string, setting the image name to a string
         return (self.appliance.rest_api.collections.container_images.
-                get(name=str(self.name)).action.scan())
+                find_by(image_ref=str(self.id)).resources[0].action.scan())
 
 
 @attr.s


### PR DESCRIPTION
When there are multiple container images with the same name, the ManageIQ rest api returns the first one in the list. This may not always be the correct images. 

{{ pytest: cfme/tests/containers/test_containers_smartstate_analysis.py::test_containers_smartstate_analysis_api --use-provider ocp-39-hawk }}