### PR TITLE
[RFR] SUI:Automate chargeback test for service with multiple VMs

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -19,8 +19,6 @@ from cfme.rest.gen_data import service_templates_rest as _service_templates
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaUI
-from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data
 from cfme.utils.ftp import FTPClientWrapper
 from cfme.utils.generators import random_vm_name
@@ -162,7 +160,8 @@ def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
 @pytest.fixture
 def order_service(appliance, provider, provisioning, dialog, catalog, request):
     # BZ 1646333 - Delete this request button is not shown in service Request details page
-    # The above BZ got closed because of  INSUFFICIENT_DATA.
+    # The above BZ got closed because of  INSUFFICIENT_DATA, so I havve reported the same issue
+    # in BZ 775779.
     """ Orders service once the catalog item is created"""
     if hasattr(request, 'param'):
         vm_count = request.param['vm_count'] if 'vm_count' in request.param else '1'
@@ -178,9 +177,8 @@ def order_service(appliance, provider, provisioning, dialog, catalog, request):
     assert provision_request.is_succeeded()
     if provision_request.exists():
         provision_request.wait_for_request()
-        if not BZ(1775779, forced_streams=['5.10', '5.11']).blocks:
-            view = navigate_to(provision_request, "Details")
-            view.toolbar.delete.click(handle_alert=not False)
+        # Provision request is being removed through REST API because of BZ 775779.
+        provision_request.remove_request(method='rest')
     yield catalog_item
     service = MyService(appliance, catalog_item.name)
     if service.exists:

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -19,6 +19,7 @@ from cfme.rest.gen_data import service_templates_rest as _service_templates
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaUI
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data
 from cfme.utils.ftp import FTPClientWrapper
@@ -178,14 +179,15 @@ def order_service(appliance, provider, provisioning, dialog, catalog, request):
     if provision_request.exists():
         provision_request.wait_for_request()
         if not BZ(1775779, forced_streams=['5.10', '5.11']).blocks:
-            provision_request.remove_request()
+            view = navigate_to(provision_request, "Details")
+            view.toolbar.delete.click(handle_alert=not False)
     yield catalog_item
     service = MyService(appliance, catalog_item.name)
     if service.exists:
         service.delete()
     name = catalog_item.prov_data['catalog']['vm_name']
-    for i in range(vm_count):
-        vm_name = f'{name}000'f'{i+1}'
+    for i in range(int(vm_count)):
+        vm_name = f'{name}000{i+1}'
         vm = appliance.collections.infra_vms.instantiate(vm_name, provider)
         vm.cleanup_on_provider()
 

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -80,7 +80,7 @@ def generic_catalog_item(request, appliance, dialog_modscope, catalog_modscope):
 
 
 def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
-        console_test=False):
+         vm_count='1', console_test=False,):
     provision_type, template, host, datastore, iso_file, vlan = map(provisioning.get,
         ('provision_type', 'template', 'host', 'datastore', 'iso_file', 'vlan'))
     if console_test:
@@ -92,7 +92,8 @@ def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
         provisioning_data = {
             'catalog': {'catalog_name': {'name': catalog_name, 'provider': provider.name},
                         'vm_name': random_vm_name('serv'),
-                        'provision_type': provision_type},
+                        'provision_type': provision_type,
+                        'num_vms': vm_count},
             'environment': {'host_name': {'name': host},
                             'datastore_name': {'name': datastore}},
             'network': {'vlan': partial_match(vlan)},
@@ -160,11 +161,12 @@ def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
 @pytest.fixture
 def order_service(appliance, provider, provisioning, dialog, catalog, request):
     """ Orders service once the catalog item is created"""
-
     if hasattr(request, 'param'):
         param = request.param
         catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog,
-                                           console_test=True if 'console_test' in param else None)
+                                           vm_count='2',
+                                           console_test=True if 'console_test' in param else None
+                                           )
     else:
         catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog)
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -164,7 +164,8 @@ def order_service(appliance, provider, provisioning, dialog, catalog, request):
     if hasattr(request, 'param'):
         pytest.set_trace()
         param = request.param
-        vm_count = param if 'vm_count' in param else '1'
+        if 'vm_count' in param:
+            vm_count = '2' if '2' in param else '1'
         catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog,
                                            vm_count=vm_count,
                                            console_test=True if 'console_test' in param else None

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -160,6 +160,8 @@ def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
 
 @pytest.fixture
 def order_service(appliance, provider, provisioning, dialog, catalog, request):
+    # BZ 1646333 - Delete this request button is not shown in service Request details page
+    # The above BZ got closed because of  INSUFFICIENT_DATA.
     """ Orders service once the catalog item is created"""
     if hasattr(request, 'param'):
         vm_count = request.param['vm_count'] if 'vm_count' in request.param else '1'
@@ -175,7 +177,7 @@ def order_service(appliance, provider, provisioning, dialog, catalog, request):
     assert provision_request.is_succeeded()
     if provision_request.exists():
         provision_request.wait_for_request()
-        if not BZ(1646333, forced_streams=['5.10']).blocks:
+        if not BZ(1775779, forced_streams=['5.10', '5.11']).blocks:
             provision_request.remove_request()
     yield catalog_item
     service = MyService(appliance, catalog_item.name)

--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -19,11 +19,11 @@ from cfme.rest.gen_data import service_templates_rest as _service_templates
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaUI
-from cfme.utils.blockers import BZ
 from cfme.utils.conf import cfme_data
 from cfme.utils.ftp import FTPClientWrapper
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
+# from cfme.utils.blockers import BZ
 
 
 @pytest.fixture(scope="function")
@@ -80,7 +80,7 @@ def generic_catalog_item(request, appliance, dialog_modscope, catalog_modscope):
 
 
 def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
-         vm_count='1', console_test=False,):
+         vm_count='1', console_test=False):
     provision_type, template, host, datastore, iso_file, vlan = map(provisioning.get,
         ('provision_type', 'template', 'host', 'datastore', 'iso_file', 'vlan'))
     if console_test:
@@ -162,9 +162,11 @@ def create_catalog_item(appliance, provider, provisioning, dialog, catalog,
 def order_service(appliance, provider, provisioning, dialog, catalog, request):
     """ Orders service once the catalog item is created"""
     if hasattr(request, 'param'):
+        pytest.set_trace()
         param = request.param
+        vm_count = param if 'vm_count' in param else '1'
         catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog,
-                                           vm_count='2',
+                                           vm_count=vm_count,
                                            console_test=True if 'console_test' in param else None
                                            )
     else:
@@ -175,8 +177,8 @@ def order_service(appliance, provider, provisioning, dialog, catalog, request):
     assert provision_request.is_succeeded()
     if provision_request.exists():
         provision_request.wait_for_request()
-        if not BZ(1646333, forced_streams=['5.10']).blocks:
-            provision_request.remove_request()
+        # if not BZ(1646333, forced_streams=['5.10']).blocks:
+        #    provision_request.remove_request()
     yield catalog_item
     service = MyService(appliance, catalog_item.name)
     if service.exists:

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -111,7 +111,7 @@ def verify_vm_uptime(appliance, provider, vmname):
 def run_service_chargeback_report(provider, appliance, assign_chargeback_rate,
                                   order_service):
     catalog_item = order_service
-    vmname = '{}0001'.format(catalog_item.prov_data['catalog']["vm_name"])
+    vmname = catalog_item.prov_data['catalog']['vm_name']
 
     def verify_records_rollups_table(appliance, provider):
         # Verify that hourly rollups are present in the metric_rollups table
@@ -123,7 +123,8 @@ def run_service_chargeback_report(provider, appliance, assign_chargeback_rate,
             result = (
                 appliance.db.client.session.query(rollups.id)
                 .join(ems, rollups.parent_ems_id == ems.id)
-                .filter(rollups.capture_interval_name == 'hourly', rollups.resource_name == vmname,
+                .filter(rollups.capture_interval_name == 'hourly',
+                rollups.resource_name.contains(vmname),
                 ems.name == provider.name, rollups.timestamp >= date.today())
             )
 
@@ -242,7 +243,6 @@ def test_monthly_charges(appliance, has_no_providers_modscope, setup_provider, c
 def test_service_chargeback_multiple_vms(appliance, has_no_providers_modscope, setup_provider,
         context, order_service, run_service_chargeback_report):
     """Tests chargeback data for a service with multiple VMs
-
     Polarion:
         assignee: nachandr
         casecomponent: SelfServiceUI
@@ -252,7 +252,7 @@ def test_service_chargeback_multiple_vms(appliance, has_no_providers_modscope, s
     with appliance.context.use(context):
         dashboard = Dashboard(appliance)
         monthly_charges = dashboard.monthly_charges()
-        logger.info('Monthly charges is {}'.format(monthly_charges))
+        logger.info(f'Monthly charges is {monthly_charges}')
         assert monthly_charges != '$0'
 
 

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -235,6 +235,26 @@ def test_monthly_charges(appliance, has_no_providers_modscope, setup_provider, c
         assert monthly_charges != '$0'
 
 
+@pytest.mark.long_running
+@pytest.mark.parametrize('context', [ViaSSUI])
+@pytest.mark.parametrize('order_service', [['vm_count']], indirect=True)
+def test_service_chargeback_multiple_vm(appliance, has_no_providers_modscope, setup_provider,
+        context, order_service, run_service_chargeback_report):
+    """Tests chargeback data for a service with multiple VMs
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: SelfServiceUI
+        caseimportance: high
+        initialEstimate: 1/2h
+    """
+    with appliance.context.use(context):
+        dashboard = Dashboard(appliance)
+        monthly_charges = dashboard.monthly_charges()
+        logger.info('Monthly charges is {}'.format(monthly_charges))
+        assert monthly_charges != '$0'
+
+
 @pytest.mark.parametrize('context', [ViaSSUI])
 def test_total_requests(appliance, context):
     """Tests total requests displayed.

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -238,7 +238,7 @@ def test_monthly_charges(appliance, has_no_providers_modscope, setup_provider, c
 @pytest.mark.long_running
 @pytest.mark.parametrize('context', [ViaSSUI])
 @pytest.mark.parametrize('order_service', ['vm_count_1', 'vm_count_2'], indirect=True)
-def test_service_chargeback_multiple_vm(appliance, has_no_providers_modscope, setup_provider,
+def test_service_chargeback_multiple_vms(appliance, has_no_providers_modscope, setup_provider,
         context, order_service, run_service_chargeback_report):
     """Tests chargeback data for a service with multiple VMs
 

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -237,7 +237,8 @@ def test_monthly_charges(appliance, has_no_providers_modscope, setup_provider, c
 
 @pytest.mark.long_running
 @pytest.mark.parametrize('context', [ViaSSUI])
-@pytest.mark.parametrize('order_service', ['vm_count_1', 'vm_count_2'], indirect=True)
+@pytest.mark.parametrize('order_service', [{'vm_count': '1'}, {'vm_count': '2'}], indirect=True,
+                ids=['vm-count1', 'vm-count2'])
 def test_service_chargeback_multiple_vms(appliance, has_no_providers_modscope, setup_provider,
         context, order_service, run_service_chargeback_report):
     """Tests chargeback data for a service with multiple VMs

--- a/cfme/tests/ssui/test_ssui_dashboard.py
+++ b/cfme/tests/ssui/test_ssui_dashboard.py
@@ -237,7 +237,7 @@ def test_monthly_charges(appliance, has_no_providers_modscope, setup_provider, c
 
 @pytest.mark.long_running
 @pytest.mark.parametrize('context', [ViaSSUI])
-@pytest.mark.parametrize('order_service', [['vm_count']], indirect=True)
+@pytest.mark.parametrize('order_service', ['vm_count_1', 'vm_count_2'], indirect=True)
 def test_service_chargeback_multiple_vm(appliance, has_no_providers_modscope, setup_provider,
         context, order_service, run_service_chargeback_report):
     """Tests chargeback data for a service with multiple VMs

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -128,7 +128,7 @@ def test_service_start(appliance, setup_provider, context,
 
 @pytest.mark.long_running
 @pytest.mark.parametrize('context', [ViaSSUI])
-@pytest.mark.parametrize('order_service', [['console_test']], indirect=True)
+@pytest.mark.parametrize('order_service', [{'console_test': True}], indirect=True)
 def test_vm_console(request, appliance, setup_provider, context, configure_websocket,
         configure_console_vnc, order_service, take_screenshot,
         console_template, provider):


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
1)Automated chargeback test for a service with multiple VMs
2)Parametrized the order_service fixture on vm_count
3)Fixed the test_vm_console test so that it passes a key value pair to the vm_count parameter to the order_service fixture

### PRT Run
{{ pytest: --long-running cfme/tests/ssui/test_ssui_dashboard.py::test_service_chargeback_multiple_vms cfme/tests/ssui/test_ssui_myservice.py::test_vm_console }}

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
PRT Results:
510 - PASS
511 - PASS