### PR TITLE
[1LP][RFR] fixed calls for removed session fixtures

### DIFF
--- a/cfme/fixtures/authentication.py
+++ b/cfme/fixtures/authentication.py
@@ -111,10 +111,7 @@ def ensure_resolvable_hostname(temp_appliance_preconfig_long):
 
 
 @pytest.fixture(scope='function')
-def configure_auth(
-    temp_appliance_preconfig_long,
-    auth_mode, auth_provider, user_type, request, fix_missing_hostname
-):
+def configure_auth(temp_appliance_preconfig_long, auth_mode, auth_provider, user_type, request):
     """Given auth_mode, auth_provider, user_type parametrization, configure auth for login
     testing.
 

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -11,8 +11,6 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.version import UPSTREAM
 
-pytestmark = pytest.mark.usefixtures('browser')
-
 
 @pytest.mark.rhel_testing
 @test_requirements.drift


### PR DESCRIPTION
{{pytest: --long-running cfme/tests/test_login.py cfme/tests/integration/test_cfme_auth.py}}