### PR TITLE
[RFR] Fixed network failure for OSP

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -636,6 +636,9 @@ def component_generator(selector, source_provider, provider, source_type=None, t
             [partial_match(sources[0])], [partial_match(targets[0])]
         )
     else:
+        if provider.one_of(OpenStackProvider):
+            # default lan for OSP
+            target_type = "public"
         sources = [v for v in source_data if v == source_type]
         targets = [v for v in target_data if v == target_type]
         component = InfraMapping.NetworkComponent(


### PR DESCRIPTION
{{ pytest: cfme/tests/v2v/test_v2v_migrations.py --use-provider osp13-ims --use-provider vsphere67-ims --provider-limit 2 -vvvv --long-running -k test_dual_nics_migration }}

OSP Tests fail when VM networks are passed in parameters for V2V tests as it has only one lan.This PR fixes it