### PR TITLE
[1LP][RFR] New Test: Testing domain import via git from different branch than master

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -110,34 +110,6 @@ def test_automate_check_quota_regression():
 
 
 @pytest.mark.tier(3)
-def test_automate_git_import_without_master():
-    """
-    Git repository doesn't have to have master branch
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        tags: automate
-        testSteps:
-            1. Create git repository with different default branch than master.
-            2. Add some valid code, for example exported one.
-            3. Navigate to Automation -> Automate -> Import/Export
-            4. Enter credentials and hit the submit button.
-        expectedResults:
-            1.
-            2.
-            3.
-            4. Domain was imported from git
-
-    Bugzilla:
-        1508881
-    """
-    pass
-
-
-@pytest.mark.tier(3)
 def test_automate_git_import_deleted_tag():
     """
 

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -420,3 +420,32 @@ def test_automate_git_domain_import_connection(request, temp_appliance_preconfig
         msg = "Error during repository fetch: hostname does not match certificate"
         with pytest.raises(AssertionError, match=msg):
             repo.import_domain_from(branch="origin/master")
+
+
+@pytest.mark.tier(3)
+@pytest.mark.meta(automates=[1508881])
+def test_automate_git_import_without_master(appliance, request):
+    """
+    Bugzilla:
+        1508881
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: Automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        tags: automate
+        testSteps:
+            1. Create git repository with different default branch than master.
+            2. Add some valid automate code.
+            3. Import domain by navigating to Automation -> Automate -> Import/Export
+        expectedResults:
+            1.
+            2.
+            3. Domain was imported from git
+    """
+    repo = appliance.collections.automate_import_exports.instantiate(
+        import_type="git", url=GIT_REPO_URL, verify_ssl=False
+    )
+    domain = repo.import_domain_from(branch="origin/testbranch")
+    request.addfinalizer(domain.delete_if_exists)


### PR DESCRIPTION

## Purpose or Intent
- Testing domain import via git from different branch than master
- Git repository doesn't have to have master branch
### PRT Run
{{ pytest: cfme/tests/automate/test_git_import.py::test_automate_git_import_without_master --use-template-cache -qsvvv }}