### PR TITLE
[1LP][RFR] Automate: test_update_roles_via_rest_name_change

### DIFF
--- a/cfme/tests/test_providerless_rest.py
+++ b/cfme/tests/test_providerless_rest.py
@@ -1,0 +1,64 @@
+"""This module contains REST API specific tests which do not require a provider setup.
+For tests that do require provider setup, add them to test_rest.py"""
+import pytest
+
+from cfme import test_requirements
+from cfme.utils.wait import wait_for
+
+pytestmark = [test_requirements.rest, pytest.mark.tier(1)]
+
+
+@pytest.fixture
+def change_company_name(appliance):
+    old_company_name = appliance.advanced_settings["server"]["company"]
+    updated_company_name = "REST Company Name"
+    appliance.update_advanced_settings({"server": {"company": updated_company_name}})
+
+    yield updated_company_name
+
+    appliance.update_advanced_settings({"server": {"company": old_company_name}})
+
+
+@pytest.mark.meta(automates=[1596142])
+@pytest.mark.customer_scenario
+def test_update_roles_via_rest_name_change(appliance, request, change_company_name):
+    """
+    Bugzilla:
+        1596142
+
+    Polarion:
+        assignee: pvala
+        caseimportance: high
+        casecomponent: Rest
+        initialEstimate: 1/4h
+        setup:
+            1. Change the current server name to something other than the default.
+        testSteps:
+            1. Send a PATCH request to update the server roles via REST using
+                `appliance.update_advanced_settings({"server": {"role": :roles}})`
+            2. Check if the server name was set to default.
+        expectedResults:
+            1. Request was successful.
+            2. Server name remains the same.
+    """
+    old_roles = appliance.advanced_settings["server"]["role"]
+
+    # enable_notifier is set to True, if we need to enable the notifier, else False
+    enable_notifier = "notifier" not in old_roles
+
+    # in case the role is already enabled, disable it
+    new_roles = f"{old_roles},notifier" if enable_notifier else old_roles.replace("notifier", "")
+
+    appliance.update_advanced_settings({"server": {"role": new_roles}})
+
+    request.addfinalizer(
+        lambda: appliance.update_advanced_settings({"server": {"role": old_roles}})
+    )
+
+    wait_for(
+        lambda: appliance.server_roles["notifier"] == enable_notifier,
+        delay=1,
+        num_sec=120,
+        message="Wait until the role change comes into effect.",
+    )
+    assert appliance.advanced_settings["server"]["company"] == change_company_name

--- a/cfme/tests/test_rest.py
+++ b/cfme/tests/test_rest.py
@@ -1,4 +1,5 @@
-"""This module contains REST API specific tests."""
+"""This module contains REST API specific tests which require a provider setup.
+For tests that do not require provider setup, add them to test_providerless_rest.py"""
 import os
 import random
 from datetime import datetime

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -171,33 +171,6 @@ def test_schedule_automation_request(scheduler):
     pass
 
 
-@pytest.mark.tier(1)
-@pytest.mark.customer_scenario
-@pytest.mark.meta(coverage=[1596142])
-@test_requirements.rest
-def test_update_roles_via_rest_name_change():
-    """
-    Bugzilla:
-        1596142
-
-    Polarion:
-        assignee: pvala
-        caseimportance: high
-        casecomponent: Rest
-        initialEstimate: 1/4h
-        setup:
-            1. Change the current server name to something other than the default.
-        testSteps:
-            1. Send a PATCH request to update the server roles via REST using
-                `appliance.update_advanced_settings({"server": {"role": :roles}})`
-            2. Check if the server name was set to default.
-        expectedResults:
-            1. Request was successful.
-            2. Server name remains the same.
-    """
-    pass
-
-
 @pytest.mark.customer_scenario
 @pytest.mark.meta(coverage=[1661445])
 @pytest.mark.tier(1)


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. `test_update_roles_via_rest_name_change`
- __Enhancement__ 
    1. Add a separate test file for rest test cases that do not require a provider setup.

### PRT Run

{{ pytest: cfme/tests/test_providerless_rest.py -vvv }}