### PR TITLE
[1LP][RFR] Replace usage of entity.check() with entity.ensure_checked. Part 1.

### DIFF
--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -643,7 +643,8 @@ class PolicySimulationOnCollection(CFMENavigateStep):
     def step(self, *args, **kwargs):
         # click the checkbox of every object in the filtered collection
         for entity in self.obj.all():
-            self.prerequisite_view.entities.get_entity(name=entity.name, surf_pages=True).check()
+            self.prerequisite_view.entities.get_entity(name=entity.name,
+                                                       surf_pages=True).ensure_checked()
         self.prerequisite_view.toolbar.policy.item_select("Policy Simulation")
 
 

--- a/cfme/cloud/instance/__init__.py
+++ b/cfme/cloud/instance/__init__.py
@@ -318,7 +318,7 @@ class Instance(VM):
                 raise ItemNotFound(
                     'Failed to find instance in table: {}'.format(self.name)
                 )
-            row.check()
+            row.ensure_checked()
 
         # cancel is the kwarg, when true we want item_select to dismiss the alert, flip the bool
         view.toolbar.power.item_select(kwargs.get('option'),

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -266,7 +266,8 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name, 
+                                                   surf_pages=True).ensure_checked()
         try:
             self.prerequisite_view.toolbar.configuration.item_select('Edit Selected Cloud Provider')
         except MoveTargetOutOfBoundsException:

--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -266,7 +266,7 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(name=self.obj.name, 
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                    surf_pages=True).ensure_checked()
         try:
             self.prerequisite_view.toolbar.configuration.item_select('Edit Selected Cloud Provider')
@@ -290,7 +290,8 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   surf_pages=True).ensure_checked()
         try:
             self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
         except MoveTargetOutOfBoundsException:

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -744,7 +744,7 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
         if from_list_view:
             view = navigate_to(self, 'All')
             entity = view.entities.get_entity(name=self.name, surf_pages=True)
-            entity.check()
+            entity.ensure_checked()
 
         else:
             view = navigate_to(self, 'Details')

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -330,8 +330,8 @@ def test_power_on_or_off_multiple(provider, testing_instance, testing_instance2,
         view = navigate_to(testing_instance.parent, 'All')
         view.toolbar.view_selector.select('Grid View')
         view.paginator.set_items_per_page(1000)
-        view.entities.get_entity(name=testing_instance.name).check()
-        view.entities.get_entity(name=testing_instance2.name).check()
+        view.entities.get_entity(name=testing_instance.name).ensure_checked()
+        view.entities.get_entity(name=testing_instance2.name).ensure_checked()
         return view
 
     # Power 2 instances off

--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -971,7 +971,7 @@ def test_ssa_multiple_vms(ssa_multiple_vms, soft_assert, appliance, compare_linu
     view.toolbar.view_selector.select('List View')
     view.paginator.set_items_per_page(1000)
     for ssa_vm in ssa_multiple_vms:
-        view.entities.get_entity(name=ssa_vm.name, surf_pages=True).check()
+        view.entities.get_entity(name=ssa_vm.name, surf_pages=True).ensure_checked()
     # run SSA for all created vms
     view.toolbar.configuration.item_select('Perform SmartState Analysis', handle_alert=True)
     view.flash.assert_message('Analysis initiated for 3 VMs and Instances from the CFME Database')

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -135,7 +135,7 @@ def test_discover_host(request, provider, appliance, host_ips):
     for host in hosts_view.entities.entity_names:
         assert host in host_ips
 
-@pytest.mark.provider([RHEVMProvider], required_fields=['hosts'], selector=ONE)
+
 @pytest.mark.rhv2
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -90,7 +90,7 @@ def navigate_and_select_quads(provider):
         view: the provider nodes view, quadicons already selected"""
     hosts_view = navigate_to(provider, 'ProviderNodes')
     assert hosts_view.is_displayed
-    [h.check() for h in hosts_view.entities.get_all()]
+    [h.ensure_checked() for h in hosts_view.entities.get_all()]
 
     hosts_view.toolbar.configuration.item_select('Edit Selected items')
     edit_view = provider.create_view(HostsEditView)
@@ -135,7 +135,7 @@ def test_discover_host(request, provider, appliance, host_ips):
     for host in hosts_view.entities.entity_names:
         assert host in host_ips
 
-
+@pytest.mark.provider([RHEVMProvider], required_fields=['hosts'], selector=ONE)
 @pytest.mark.rhv2
 @pytest.mark.parametrize("creds", ["default", "remote_login", "web_services"],
                          ids=["default", "remote", "web"])


### PR DESCRIPTION
## Purpose or Intent

- __Updating tests and framework__ to use entity ensure_checked() instead of entity.check(). ensure_checked() is an enhancement to check() functionality that accounts for the checked state of an entity when selecting it.

### PRT Run

{{ pytest: --use-provider rhv42 --use-provider rhos13 --long-running cfme/tests/cloud_infra_common/test_policy_simulation.py::test_policy_simulation_ui cfme/tests/cloud/test_instance_power_control.py::test_power_on_or_off_multiple cfme/tests/cloud_infra_common/test_vm_instance_analysis.py::test_ssa_multiple_vms cfme/tests/infrastructure/test_host.py::test_multiple_host_good_creds }}