### PR TITLE
[1LP][RFR] Add required flags for test_cloud_timelines.py

### DIFF
--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -11,7 +11,7 @@ from cfme.utils.log import logger
 
 pytestmark = [
     pytest.mark.tier(3),
-    pytest.mark.provider([AzureProvider], scope='module'),
+    pytest.mark.provider([AzureProvider], scope='module', required_flags=['events']),
     pytest.mark.usefixtures('setup_provider_modscope'),
     test_requirements.events
 ]

--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -16,8 +16,8 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.tier(2),
-    # Only onr prov out of the 2 is taken, if not supplying --use-provider=complete
-    pytest.mark.provider([AzureProvider, EC2Provider]),
+    # Only one prov out of the 2 is taken, if not supplying --use-provider=complete
+    pytest.mark.provider([AzureProvider, EC2Provider], required_flags=['timelines', 'events']),
     pytest.mark.usefixtures('setup_provider'),
     test_requirements.timelines,
     test_requirements.events,

--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -13,7 +13,8 @@ from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
 
 
-all_prov = ProviderFilter(classes=[InfraProvider, CloudProvider], required_fields=['provisioning'])
+all_prov = ProviderFilter(classes=[InfraProvider, CloudProvider],
+                          required_fields=['provisioning', 'events'])
 excluded = ProviderFilter(classes=[KubeVirtProvider], inverted=True)
 pytestmark = [
     pytest.mark.usefixtures('uses_infra_providers', 'uses_cloud_providers'),


### PR DESCRIPTION
These tests were collecting against `azure_msdn` which has no templates on it. 