### PR TITLE
[1LP][RFR] fix scope for tests where provider has module scope whereas setup_provider has function scope

### DIFF
--- a/cfme/tests/candu/test_gap_collection.py
+++ b/cfme/tests/candu/test_gap_collection.py
@@ -13,7 +13,7 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     pytest.mark.tier(3),
     test_requirements.c_and_u,
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([VMwareProvider],
     scope='module',
     required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')]),

--- a/cfme/tests/cloud/test_cloud_events.py
+++ b/cfme/tests/cloud/test_cloud_events.py
@@ -12,7 +12,7 @@ from cfme.utils.log import logger
 pytestmark = [
     pytest.mark.tier(3),
     pytest.mark.provider([AzureProvider], scope='module'),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     test_requirements.events
 ]
 

--- a/cfme/tests/cloud/test_delete_cloud_object.py
+++ b/cfme/tests/cloud/test_delete_cloud_object.py
@@ -8,7 +8,7 @@ from cfme.utils.wait import TimedOutError
 pytestmark = [
     pytest.mark.tier(2),
     test_requirements.cloud,
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([CloudProvider], required_fields=['remove_test'], scope="module")
 ]
 

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -12,7 +12,7 @@ from cfme.utils.blockers import BZ
 
 pytestmark = [
     test_requirements.cloud,
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([EC2Provider, OpenStackProvider], scope="module")
 ]
 

--- a/cfme/tests/cloud/test_quota_tagging.py
+++ b/cfme/tests/cloud/test_quota_tagging.py
@@ -13,7 +13,7 @@ from cfme.utils.update import update
 
 pytestmark = [
     test_requirements.quota,
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([OpenStackProvider],
                          required_fields=[['provisioning', 'image']], scope="module")
 ]

--- a/cfme/tests/cloud/test_tenant_quota.py
+++ b/cfme/tests/cloud/test_tenant_quota.py
@@ -11,7 +11,7 @@ from cfme.utils.generators import random_vm_name
 
 pytestmark = [
     test_requirements.quota,
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([OpenStackProvider], required_fields=[['provisioning', 'image']],
                          scope="module")]
 

--- a/cfme/tests/configure/test_logs.py
+++ b/cfme/tests/configure/test_logs.py
@@ -15,7 +15,7 @@ pytestmark = [
     pytest.mark.provider(
         [AzureProvider, EC2Provider, RHEVMProvider, SCVMMProvider], scope="module"
     ),
-    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.usefixtures("setup_provider_modscope"),
 ]
 
 

--- a/cfme/tests/configure/test_schedule_operations.py
+++ b/cfme/tests/configure/test_schedule_operations.py
@@ -14,7 +14,7 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.provider([VMwareProvider], required_fields=['hosts'], selector=ONE, scope='module'),
-    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.usefixtures("setup_provider_modscope"),
     test_requirements.scheduled_ops
 ]
 

--- a/cfme/tests/infrastructure/test_project_quota.py
+++ b/cfme/tests/infrastructure/test_project_quota.py
@@ -13,7 +13,7 @@ from cfme.utils.generators import random_vm_name
 pytestmark = [
     test_requirements.quota,
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.long_running,
     pytest.mark.provider([VMwareProvider, RHEVMProvider], scope="module",
                          required_fields=[["provisioning", "template"]], selector=ONE_PER_TYPE)

--- a/cfme/tests/infrastructure/test_provisioning_rest.py
+++ b/cfme/tests/infrastructure/test_provisioning_rest.py
@@ -16,7 +16,7 @@ pytestmark = [
     test_requirements.rest,
     pytest.mark.tier(2),
     pytest.mark.meta(server_roles='+automate'),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([VMwareProvider, RHEVMProvider], scope='module')
 ]
 

--- a/cfme/tests/infrastructure/test_quota_tagging.py
+++ b/cfme/tests/infrastructure/test_quota_tagging.py
@@ -17,7 +17,7 @@ from cfme.utils.update import update
 
 pytestmark = [
     test_requirements.quota,
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([RHEVMProvider, VMwareProvider], scope="module", selector=ONE_PER_TYPE)
 ]
 

--- a/cfme/tests/infrastructure/test_vmware_provider.py
+++ b/cfme/tests/infrastructure/test_vmware_provider.py
@@ -24,7 +24,7 @@ filter_fields = [['provisioning', 'template'],
 pytestmark = [
     test_requirements.vmware,
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.usefixtures('setup_provider', 'uses_infra_providers'),
+    pytest.mark.usefixtures('setup_provider_modscope', 'uses_infra_providers'),
     pytest.mark.provider([VMwareProvider], required_fields=filter_fields, scope="module")
 ]
 

--- a/cfme/tests/infrastructure/test_webmks_console.py
+++ b/cfme/tests/infrastructure/test_webmks_console.py
@@ -15,7 +15,7 @@ from cfme.utils.providers import ProviderFilter
 
 
 pytestmark = [
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider(gen_func=providers,
                          filters=[ProviderFilter(classes=[InfraProvider],
                                                  required_flags=['webmks_console'])],

--- a/cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py
+++ b/cfme/tests/intelligence/chargeback/test_chargeback_long_term_rates.py
@@ -26,7 +26,7 @@ pytestmark = [
     pytest.mark.provider([RHEVMProvider], selector=ONE,
                        scope='module',
                        required_fields=[(['cap_and_util', 'test_chargeback'], True)]),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     test_requirements.chargeback,
 ]
 

--- a/cfme/tests/intelligence/chargeback/test_resource_allocation.py
+++ b/cfme/tests/intelligence/chargeback/test_resource_allocation.py
@@ -47,7 +47,7 @@ pytestmark = [
     pytest.mark.long_running,
     pytest.mark.provider([CloudProvider, InfraProvider], scope='module', selector=ONE_PER_TYPE,
                          required_fields=[(['cap_and_util', 'test_chargeback'], True)]),
-    pytest.mark.usefixtures('has_no_providers_modscope', 'setup_provider'),
+    pytest.mark.usefixtures('has_no_providers_modscope', 'setup_provider_modscope'),
     test_requirements.chargeback,
 ]
 

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -10,7 +10,7 @@ from cfme.utils.providers import get_crud_by_name
 
 pytestmark = [
     pytest.mark.tier(3),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider(classes=[InfraProvider], scope='module'),
     test_requirements.report,
 ]

--- a/cfme/tests/intelligence/reports/test_generate_report.py
+++ b/cfme/tests/intelligence/reports/test_generate_report.py
@@ -13,7 +13,7 @@ from cfme.markers.env_markers.provider import ONE
 pytestmark = [
     pytest.mark.tier(3),
     test_requirements.report,
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([InfraProvider], scope='module', selector=ONE),
 ]
 

--- a/cfme/tests/intelligence/reports/test_views.py
+++ b/cfme/tests/intelligence/reports/test_views.py
@@ -9,7 +9,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 pytestmark = [
     pytest.mark.tier(3),
     test_requirements.report,
-    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.usefixtures("setup_provider_modscope"),
     pytest.mark.provider([BaseProvider], selector=ONE, scope="module"),
 ]
 

--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -11,7 +11,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
     test_requirements.sdn,
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([AzureProvider, EC2Provider, GCEProvider], scope='module'),
     pytest.mark.ignore_stream("5.11", "upstream")  # BZ 1672949 (RFE)
 ]

--- a/cfme/tests/networks/test_tag_tagvis.py
+++ b/cfme/tests/networks/test_tag_tagvis.py
@@ -13,7 +13,7 @@ from cfme.networks.views import SubnetView
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider([AzureProvider], selector=ONE_PER_CATEGORY, scope='module'),
     test_requirements.tag
 ]

--- a/cfme/tests/services/test_add_remove_vm_to_service.py
+++ b/cfme/tests/services/test_add_remove_vm_to_service.py
@@ -10,7 +10,7 @@ from cfme.markers.env_markers.provider import ONE_PER_TYPE
 
 pytestmark = [
     test_requirements.service,
-    pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
+    pytest.mark.usefixtures('setup_provider_module', 'catalog_item', 'uses_infra_providers'),
     pytest.mark.long_running,
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.tier(3),

--- a/cfme/tests/services/test_operations.py
+++ b/cfme/tests/services/test_operations.py
@@ -16,7 +16,7 @@ pytestmark = [
     pytest.mark.meta(server_roles="-automate"),  # To prevent the provisioning itself.
     test_requirements.service,
     pytest.mark.provider(classes=[InfraProvider], scope="module", selector=ONE),
-    pytest.mark.usefixtures('setup_provider')
+    pytest.mark.usefixtures('setup_provider_modscope')
 ]
 
 

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -14,7 +14,7 @@ from cfme.utils.wait import wait_for_decorator
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
+    pytest.mark.usefixtures('setup_provider_modscope', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,
     pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE,

--- a/cfme/tests/services/test_service_customer_bz.py
+++ b/cfme/tests/services/test_service_customer_bz.py
@@ -15,7 +15,7 @@ from cfme.utils.wait import TimedOutError
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.usefixtures('setup_provider', 'uses_infra_providers'),
+    pytest.mark.usefixtures('setup_provider_modscope', 'uses_infra_providers'),
     test_requirements.customer_stories,
     test_requirements.service,
     pytest.mark.long_running,

--- a/cfme/tests/services/test_service_manual_approval.py
+++ b/cfme/tests/services/test_service_manual_approval.py
@@ -18,7 +18,7 @@ from cfme.utils.update import update
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
-    pytest.mark.usefixtures('setup_provider', 'catalog_item', 'uses_infra_providers'),
+    pytest.mark.usefixtures('setup_provider_modscope', 'catalog_item', 'uses_infra_providers'),
     test_requirements.service,
     pytest.mark.long_running,
     pytest.mark.provider([InfraProvider], selector=ONE_PER_TYPE,

--- a/cfme/tests/services/test_service_rbac.py
+++ b/cfme/tests/services/test_service_rbac.py
@@ -6,7 +6,7 @@ from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.services.service_catalogs import ServiceCatalogs
 
 pytestmark = [
-    pytest.mark.usefixtures('uses_infra_providers', 'setup_provider'),
+    pytest.mark.usefixtures('uses_infra_providers', 'setup_provider_modscope'),
     pytest.mark.provider([VMwareProvider], selector=ONE_PER_TYPE, scope="module")
 ]
 

--- a/cfme/tests/storage/test_manager.py
+++ b/cfme/tests/storage/test_manager.py
@@ -10,7 +10,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 pytestmark = [
     pytest.mark.tier(3),
     test_requirements.storage,
-    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.usefixtures("setup_provider_modscope"),
     pytest.mark.provider([EC2Provider, OpenStackProvider], scope="module"),
     pytest.mark.uncollectif(lambda manager, provider:
                             provider.one_of(EC2Provider) and "object_managers" in manager,

--- a/cfme/tests/storage/test_object_store_container.py
+++ b/cfme/tests/storage/test_object_store_container.py
@@ -7,7 +7,7 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.tier(3),
-    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.usefixtures("setup_provider_modscope"),
     pytest.mark.provider([OpenStackProvider], scope="module"),
 ]
 

--- a/cfme/tests/storage/test_object_store_object.py
+++ b/cfme/tests/storage/test_object_store_object.py
@@ -9,7 +9,7 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.tier(3),
-    pytest.mark.usefixtures("setup_provider"),
+    pytest.mark.usefixtures("setup_provider_modscope"),
     pytest.mark.provider([OpenStackProvider], scope="module"),
 ]
 

--- a/cfme/tests/storage/test_volume.py
+++ b/cfme/tests/storage/test_volume.py
@@ -18,7 +18,7 @@ pytestmark = [
     pytest.mark.tier(3),
     test_requirements.storage,
     pytest.mark.ignore_stream("upstream"),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider(
         [OpenStackProvider, EC2Provider],
         scope='module',

--- a/cfme/tests/storage/test_volume_backup.py
+++ b/cfme/tests/storage/test_volume_backup.py
@@ -8,7 +8,7 @@ from cfme.utils.log import logger
 
 pytestmark = [
     pytest.mark.ignore_stream("upstream"),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider(
         [OpenStackProvider],
         scope='module',

--- a/cfme/tests/storage/test_volume_snapshot.py
+++ b/cfme/tests/storage/test_volume_snapshot.py
@@ -14,7 +14,7 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     test_requirements.storage,
     pytest.mark.ignore_stream("upstream"),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider_modscope'),
     pytest.mark.provider(
         [EC2Provider, OpenStackProvider],
         scope='module',


### PR DESCRIPTION
there are many test suits where setup/teardown for provider happens for every test. This PR fixes such issue. 
