### PR TITLE
[1LP][RFR] fix slave id representation in logs

### DIFF
--- a/cfme/fixtures/parallelizer/__init__.py
+++ b/cfme/fixtures/parallelizer/__init__.py
@@ -109,7 +109,8 @@ class SlaveDetail(object):
 
     appliance = attr.ib()
     worker_config = attr.ib()
-    id = attr.ib(default=attr.Factory(lambda: next(SlaveDetail.slaveid_generator)))
+    id = attr.ib(default=attr.Factory(lambda: next(SlaveDetail.slaveid_generator)),
+                 repr=lambda value: value.decode('utf-8'))
     forbid_restart = attr.ib(default=False, init=False)
     tests = attr.ib(default=attr.Factory(set), repr=False)
     process = attr.ib(default=None, repr=False)
@@ -205,7 +206,7 @@ class ParallelSession(object):
             if returncode:
                 slave.process = None
                 if returncode == -9:
-                    msg = f'{slave.id} killed due to error, respawning'
+                    msg = f'{slave.id.decode("utf-8")} killed due to error, respawning'
                 else:
                     msg = f'{slave.id} terminated unexpectedly with status {returncode}, respawning'
                 if slave.tests:

--- a/cfme/fixtures/parallelizer/__init__.py
+++ b/cfme/fixtures/parallelizer/__init__.py
@@ -206,7 +206,7 @@ class ParallelSession(object):
             if returncode:
                 slave.process = None
                 if returncode == -9:
-                    msg = f'{slave.id.decode("utf-8")} killed due to error, respawning'
+                    msg = f'{slave.id} killed due to error, respawning'
                 else:
                     msg = f'{slave.id} terminated unexpectedly with status {returncode}, respawning'
                 if slave.tests:
@@ -291,6 +291,7 @@ class ParallelSession(object):
 
     def _monitor_shutdown_t(self, slaveid, process):
         # a KeyError here means self.slaves got mangled, indicating a problem elsewhere
+        slaveid = slaveid.decode('utf-8') if isinstance(slaveid, bytes) else slaveid
         if process is None:
             self.log.warning('Slave was missing when trying to monitor shutdown')
 
@@ -361,7 +362,7 @@ class ParallelSession(object):
             test_perc = self.sent_tests * 100 / collect_len
             self.print_message(
                 f'sent {tests_len} tests '
-                f'to {slave.id} \n'
+                f'to {slave.id.decode("utf-8") if isinstance(slave.id, bytes) else slave.id} \n'
                 f'Total sent: {self.sent_tests} of {collect_len}, ({test_perc:.1f}%)'
             )
         return tests

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -8,7 +8,7 @@ appdirs==1.4.3
 asn1crypto==0.24.0
 aspy.yaml==1.3.0
 atomicwrites==1.3.0
-attrs==19.1.0
+attrs==19.3.0
 azure==4.0.0
 azure-applicationinsights==0.1.0
 azure-batch==4.1.3

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -10,7 +10,7 @@ anytree==2.6.0
 appdirs==1.4.3
 asn1crypto==0.24.0
 atomicwrites==1.3.0
-attrs==19.1.0
+attrs==19.3.0
 azure==4.0.0
 azure-applicationinsights==0.1.0
 azure-batch==4.1.3


### PR DESCRIPTION
slave id appears as bytes in logs everywhere. That's a bit annoying. 
This PR should make it appear as string in logs.

{ pytest: --long-running --use-template-cache --collect-only --dummy-appliance --num-dummies 10 }