### PR TITLE
[1LP][RFR] fixed log collection from second server

### DIFF
--- a/cfme/configure/configuration/diagnostics_settings.py
+++ b/cfme/configure/configuration/diagnostics_settings.py
@@ -564,7 +564,7 @@ class DiagnosticsCollectLogsSecond(CFMENavigateStep):
         self.prerequisite_view.accordions.diagnostics.tree.click_path(
             self.appliance.server_region_string(),
             f"Zone: {self.appliance.server.zone.description} (current)",
-            f"Server: {secondary_server.name}, [{int(secondary_server.sid)}]")
+            f"Server: {secondary_server.name} [{int(secondary_server.sid)}]")
         self.prerequisite_view.collectlogs.select()
 
 


### PR DESCRIPTION
## Purpose or Intent
4 of the tests got broken `test_collect_multiple_servers[*-from_secondary]` with the error
```
E               widgetastic_patternfly.CandidateNotFound: message: Could not find the item CFME Region: Region 0 [0]/Zone: Default Zone (current)/Server: EVM, [34] in Boostrap tree diagnostics_tree, path: ('Zone: Default Zone (current)', 'Server: EVM, [34]'), cause: Was not found in Zone: Default Zone (current)

/var/ci/cfme_venv3/lib64/python3.7/site-packages/widgetastic_patternfly/__init__.py:1459: CandidateNotFound
CandidateNotFound
b"message: Could not find the item CFME Region: Region 0 [0]/Zone: Default Zone (current)/Server: EVM, [34] in Boostrap tree diagnostics_tree, path: ('Zone: Default Zone (current)', 'Server: EVM, [34]'), cause: Was not found in Zone: Default Zone (current)"
```

Tested locally in 5.10.13.0

### PRT Run
{{ pytest: -v cfme/tests/configure/test_log_depot_operation.py::test_collect_multiple_servers --long-running }}