### PR TITLE
[1LP][RFR] fixing error in artifactor shutdown appearing due to changes in selenium

### DIFF
--- a/cfme/fixtures/artifactor_plugin.py
+++ b/cfme/fixtures/artifactor_plugin.py
@@ -251,9 +251,9 @@ def pytest_runtest_teardown(item, nextitem):
     try:
         caps = app.browser.widgetastic.selenium.capabilities
         param_dict = {
-            'browserName': caps['browserName'],
-            'browserPlatform': caps['platform'],
-            'browserVersion': caps['version']
+            'browserName': caps.get('browserName', 'Unknown'),
+            'browserPlatform': caps.get('platformName', caps.get('platform', 'Unknown')),
+            'browserVersion': caps.get('browserVersion', caps.get('version', 'Unknown'))
         }
     except Exception:
         logger.exception("Couldn't grab browser env_vars")


### PR DESCRIPTION
capabilities don't have platform and version in currently used selenium. so, this code throws exception. 
It seems those fields were renamed into browserVersion and browserPlatform. Thus this PR fixes that issue.