### PR TITLE
[1LP][RFR] Fix dashboard tests.

### DIFF
--- a/cfme/dashboard.py
+++ b/cfme/dashboard.py
@@ -14,6 +14,7 @@ from widgetastic.widget import Widget
 from widgetastic.xpath import quote
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Dropdown
+from widgetastic_patternfly import Tab
 
 from cfme.common import BaseLoggedInPage
 from cfme.modeling.base import BaseCollection
@@ -24,7 +25,6 @@ from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.timeutil import parsetime
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import Table
-from widgetastic_manageiq import WaitTab
 
 
 # TODO: Move this into widgetastic_patternfly
@@ -117,7 +117,7 @@ class DashboardView(BaseLoggedInPage):
             self.zoomed.close.click()
 
     @ParametrizedView.nested
-    class dashboards(WaitTab, ParametrizedView):    # noqa
+    class dashboards(Tab, ParametrizedView):    # noqa
         PARAMETERS = ('title', )
         ALL_LOCATOR = './/ul[contains(@class, "nav-tabs-pf")]/li/a'
         COLUMN_LOCATOR = '//div[@id="col{}"]//h2'

--- a/cfme/tests/intelligence/reports/test_widgets.py
+++ b/cfme/tests/intelligence/reports/test_widgets.py
@@ -52,7 +52,11 @@ def custom_widgets(appliance):
             filter="Configuration Management/Virtual Machines/Vendor and Guest OS",
             timer={"run": "Hourly", "hours": "Hour"},
             visibility="<To All Users>"),
-        collection.create(
+    ]
+
+    # RSS Removed in 5.11 (BZ 1728328)
+    if appliance.version < '5.11':
+        ws.append(collection.create(
             collection.RSS,
             fauxfactory.gen_alphanumeric(),
             description=fauxfactory.gen_alphanumeric(),
@@ -60,8 +64,7 @@ def custom_widgets(appliance):
             type="Internal",
             feed="Administrative Events",
             rows="8",
-            visibility="<To All Users>")
-    ]
+            visibility="<To All Users>"))
     yield ws
     map(lambda w: w.delete(), ws)
 

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -3657,22 +3657,20 @@ class DashboardWidgetsPicker(View):
 
     @property
     def all_dashboard_widgets(self):
-        widgets = list(self.dashboard_widgets)
-        if widgets:
-            return [self.browser.text(widget.div) for widget in widgets]
-        else:
-            return []
+        return [self.browser.text(widget.div) for widget in self.dashboard_widgets]
 
     def _values_to_remove(self, values):
-        return list(set(self.all_dashboard_widgets) - set(values))
+        return set(self.all_dashboard_widgets) - values
 
     def _values_to_add(self, values):
-        return list(set(values) - set(self.all_dashboard_widgets))
+        return values - set(self.all_dashboard_widgets)
 
     def fill(self, values):
         if isinstance(values, str):
             values = [values]
-        if set(values) == set(self.all_dashboard_widgets):
+        values = set(values)
+
+        if values == set(self.all_dashboard_widgets):
             return False
         else:
             values_to_remove = self._values_to_remove(values)


### PR DESCRIPTION
Recent changes to widgetastic broke the dashboard tests:
```
/var/ci/cfme_venv3/lib64/python3.7/site-packages/widgetastic/widget/base.py:1199: AttributeError
AttributeError
b'This is not an instance of widgets. You need to call this object and pass the required parameters of the view.'
```

There probably actually was a problem that ParametrizedView class was
used where just View should have been used.

When testing this PR, I also found out that the `cfme/tests/intelligence/reports/test_widgets.py::test_widgets_on_dashboard` fails on CFME 5.11 because it misses RSS which was removed in 5.11. I made creating of that conditional and this fixes the test.

{{pytest: cfme/tests/intelligence/test_dashboard.py cfme/tests/intelligence/reports/test_widgets.py -v}}
