### PR TITLE
[1LP][RFR] Audit qe-test-coverage for Customer BZs

### DIFF
--- a/cfme/tests/automate/test_service_dialog.py
+++ b/cfme/tests/automate/test_service_dialog.py
@@ -354,29 +354,6 @@ def test_mandatory_entry_point_with_dynamic_element(appliance):
 
 
 @pytest.mark.manual
-@test_requirements.general_ui
-@pytest.mark.tier(1)
-def test_copying_customization_dialog():
-    """
-    Bugzilla:
-        1342260
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        testSteps:
-            1. Automate -> Customization -> Check checkbox for at least one dialog
-            2. Select another dialog by clicking on it
-            3. Select in Toolbar Configuration -> Copy this dialog
-            4. Selected dialog should be copied and not the first checked dialog
-            in alphanumerical sort
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.service
 @pytest.mark.tier(1)
 def test_default_value_on_dropdown_inside_dialog():

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -910,9 +910,14 @@ def role_api(appliance, request, create_role):
 
 
 @pytest.mark.tier(2)
+@pytest.mark.customer_scenario
 @pytest.mark.meta(automates=[1727948, 1731157], blockers=[1731157])
-def test_create_picture_with_role(appliance, request, role_api):
+def test_create_picture_with_role(role_api):
     """
+    Bugzilla:
+        1727948
+        1731157
+
     Polarion:
         assignee: pvala
         caseimportance: high
@@ -928,10 +933,6 @@ def test_create_picture_with_role(appliance, request, role_api):
         expectedResults:
             1. Picture must be created without any error.
                 Check for `Use of Action create is forbidden` in response.
-
-    Bugzilla:
-        1727948
-        1731157
     """
     picture = role_api.collections.pictures.action.create(
         {

--- a/cfme/tests/configure/test_rest_access_control.py
+++ b/cfme/tests/configure/test_rest_access_control.py
@@ -911,7 +911,7 @@ def role_api(appliance, request, create_role):
 
 @pytest.mark.tier(2)
 @pytest.mark.customer_scenario
-@pytest.mark.meta(automates=[1727948, 1731157], blockers=[1731157])
+@pytest.mark.meta(automates=[1727948, 1731157])
 def test_create_picture_with_role(role_api):
     """
     Bugzilla:

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -343,6 +343,10 @@ def test_send_text_custom_report_with_long_condition(
     appliance, setup_provider, smtp_test, request, get_report
 ):
     """
+    Bugzilla:
+        1677839
+        1693727
+
     Polarion:
         assignee: pvala
         casecomponent: Reporting
@@ -356,9 +360,6 @@ def test_send_text_custom_report_with_long_condition(
             1. Queue the schedule and monitor evm log.
         expectedResults:
             1. There should be no error in the log and report must be sent successfully.
-
-    Bugzilla:
-        1677839
     """
     report = get_report("long_condition_report.yaml", "test_long_condition_report")
     data = {
@@ -543,6 +544,8 @@ def test_reports_service_unavailable(temp_appliance_preconfig, file_name, restor
     """
     Bugzilla:
         1725142
+        1737123
+
     Polarion:
         assignee: pvala
         casecomponent: Reporting

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -187,35 +187,3 @@ def test_reports_timelines_tab():
             1. Timelines tab must not be visible.
     """
     pass
-
-
-@test_requirements.report
-@pytest.mark.customer_scenario
-@pytest.mark.tier(1)
-@pytest.mark.meta(coverage=[1638533])
-@pytest.mark.parametrize("preserve_owner", [True, False])
-def test_import_report_preserve_owner(preserve_owner):
-    """
-    Bugzilla:
-        1638533
-        1693719
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        initialEstimate: 1/2h
-        setup:
-            1. Have a report with user and group values other than that of the admin
-                and note the user and group values.
-        testSteps:
-            1. While importing the report, mark `Preserve Owner` with the parametrization values.
-            2. Assert the user and group values are as expected.
-                i. If `preserve_owner` is True
-                ii. If `preserve_owner` is False
-        expectedResults:
-            1. Report imported successfully.
-            2.
-                i. Then expected values will be the original user and group
-                ii. Then expected values will be user and group of the currently logged in user
-    """
-    pass

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -6,7 +6,9 @@ from cfme.utils.appliance import ViaREST
 from cfme.utils.appliance import ViaUI
 
 
-@pytest.mark.manual
+pytestmark = [pytest.mark.manual]
+
+
 @test_requirements.report
 @pytest.mark.tier(1)
 def test_reports_generate_custom_conditional_filter_report():
@@ -34,11 +36,16 @@ def test_reports_generate_custom_conditional_filter_report():
     pass
 
 
-@pytest.mark.manual
 @test_requirements.report
 @pytest.mark.tier(1)
+@pytest.mark.customer_scenario
+@pytest.mark.meta(coverage=[1686281])
 def test_vm_volume_free_space_less_than_20_percent():
     """
+    Bugzilla:
+        1686281
+        1696420
+
     Polarion:
         assignee: pvala
         casecomponent: Reporting
@@ -52,14 +59,10 @@ def test_vm_volume_free_space_less_than_20_percent():
         expectedResults:
             1. It should report only those VMs which has volume free space less than
                 or equal to 20%.
-
-    Bugzilla:
-        1686281
     """
     pass
 
 
-@pytest.mark.manual
 @test_requirements.report
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("5.10")
@@ -86,7 +89,6 @@ def test_reports_timezone():
     pass
 
 
-@pytest.mark.manual
 @test_requirements.report
 @test_requirements.multi_region
 @pytest.mark.tier(2)
@@ -118,7 +120,6 @@ def test_reports_in_global_region(context, report):
 
 
 @test_requirements.report
-@pytest.mark.manual
 @pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1743579])
 def test_created_on_time_report_field():
@@ -143,7 +144,6 @@ def test_created_on_time_report_field():
 
 @pytest.mark.ignore_stream("5.10")
 @test_requirements.report
-@pytest.mark.manual
 @pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1714197])
 def test_optimization_reports():
@@ -168,7 +168,6 @@ def test_optimization_reports():
 
 @pytest.mark.ignore_stream("5.10")
 @test_requirements.report
-@pytest.mark.manual
 @pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1743651])
 def test_reports_timelines_tab():
@@ -186,5 +185,37 @@ def test_reports_timelines_tab():
             1. Copy a report based on timeline and check if the Timelines tab is visible.
         expectedResults:
             1. Timelines tab must not be visible.
+    """
+    pass
+
+
+@test_requirements.report
+@pytest.mark.customer_scenario
+@pytest.mark.tier(1)
+@pytest.mark.meta(coverage=[1638533])
+@pytest.mark.parametrize("preserve_owner", [True, False])
+def test_import_report_preserve_owner(preserve_owner):
+    """
+    Bugzilla:
+        1638533
+        1693719
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        initialEstimate: 1/2h
+        setup:
+            1. Have a report with user and group values other than that of the admin
+                and note the user and group values.
+        testSteps:
+            1. While importing the report, mark `Preserve Owner` with the parametrization values.
+            2. Assert the user and group values are as expected.
+                i. If `preserve_owner` is True
+                ii. If `preserve_owner` is False
+        expectedResults:
+            1. Report imported successfully.
+            2.
+                i. Then expected values will be the original user and group
+                ii. Then expected values will be user and group of the currently logged in user
     """
     pass

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -5,8 +5,9 @@ from cfme import test_requirements
 from cfme.utils.appliance.implementations.rest import ViaREST
 from cfme.utils.appliance.implementations.ui import ViaUI
 
+pytestmark = [pytest.mark.manual]
 
-@pytest.mark.manual
+
 @test_requirements.rest
 @pytest.mark.tier(3)
 def test_create_rhev_provider_with_metric():
@@ -29,11 +30,15 @@ def test_create_rhev_provider_with_metric():
 
 
 @test_requirements.rest
-@pytest.mark.manual()
+@pytest.mark.customer_scenario
 @pytest.mark.tier(1)
 @pytest.mark.meta(coverage=[1700378])
 def test_notification_url_parallel_requests():
     """
+    Bugzilla:
+        1700378
+        1714615
+
     Polarion:
         assignee: pvala
         caseimportance: medium
@@ -62,16 +67,13 @@ def test_notification_url_parallel_requests():
             3.
             4.
             5. Check if all the requests were processed and completed
-
-    Bugzilla:
-        1700378
     """
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.meta(coverage=[1761836])
 @pytest.mark.tier(3)
+@test_requirements.rest
 @pytest.mark.parametrize("context", [ViaUI, ViaREST])
 def test_widget_generate_content_via_rest(context):
     """
@@ -107,13 +109,15 @@ def test_widget_generate_content_via_rest(context):
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.meta(coverage=[1730813])
 @pytest.mark.tier(2)
+@test_requirements.rest
+@pytest.mark.customer_scenario
 def test_service_refresh_dialog_fields_default_values():
     """
     Bugzilla:
         1730813
+        1731977
 
     Polarion:
         assignee: pvala
@@ -144,12 +148,12 @@ def test_service_refresh_dialog_fields_default_values():
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1486765, 1740340])
 @pytest.mark.parametrize(
     "scheduler", ["2", "2019-08-14 17:41:06 UTC"], ids=["number_of_days", "exact_time"]
 )
+@test_requirements.rest
 def test_schedule_automation_request(scheduler):
     """
     Bugzilla:
@@ -188,9 +192,10 @@ def test_schedule_automation_request(scheduler):
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(1)
+@pytest.mark.customer_scenario
 @pytest.mark.meta(coverage=[1596142])
+@test_requirements.rest
 def test_update_roles_via_rest_name_change():
     """
     Bugzilla:
@@ -210,5 +215,83 @@ def test_update_roles_via_rest_name_change():
         expectedResults:
             1. Request was successful.
             2. Server name remains the same.
+    """
+    pass
+
+
+@pytest.mark.customer_scenario
+@pytest.mark.meta(coverage=[1661445])
+@pytest.mark.tier(1)
+@test_requirements.rest
+def test_authorization_header_sql_response():
+    """
+    Bugzilla:
+        1661445
+        1686021
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Rest
+        initialEstimate: 1/4h
+        testSteps:
+            1. GET /api/auth?requester_type=ui HEADERS: {"Authorization": "Basic testing"}
+                Perform this GET request with requests.get()
+        expectedResults:
+            1. There should be no sql statement in the response.
+                Expected Response:
+                {
+                "error": {
+                    "kind": "unauthorized",
+                    "message": ("PG::CharacterNotInRepertoire: ERROR:"
+                                "  invalid byte sequence for encoding \"UTF8\": 0xb5\n:"),
+                    "klass": "Api::AuthenticationError"
+                    }
+                }
+    """
+    # Check if it is possible to perform this testing with manageiq-api-client instead of requests.
+    pass
+
+
+@pytest.mark.customer_scenario
+@pytest.mark.meta(coverage=[1682739])
+@pytest.mark.tier(1)
+@test_requirements.rest
+def test_vm_compliance_attribute_rest():
+    """
+    Bugzilla:
+        1682739
+        1684196
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Rest
+        initialEstimate: 1/4h
+        setup:
+            1. Create a compliance policy.
+            2. Create a policy profile and assign the newly created compliance policy to it.
+            3. Provision a VM and assign the new policy profile to it.
+        testSteps:
+            1. Query the VM. GET /api/vms/:id?attributes=compliances
+        expectedResults:
+            1. Expected Response:
+                {
+                    "href": "https://<ip_address>/api/vms/8",
+                    "id": "8",
+                    "vendor": "vmware",
+                    "name": "v2v-rhel8-mini",
+                    ...
+                    "compliances": [
+                        {
+                            "id": "1",
+                            "resource_id": "8",
+                            "resource_type": "VmOrTemplate",
+                            "compliant": true,
+                            "timestamp": "2019-03-06T09:48:55Z",
+                            "updated_on": "2019-03-06T09:48:55Z",
+                            "event_type": "vm_compliance_check"
+                        }
+                  ],
+                    ...
+                }
     """
     pass

--- a/cfme/tests/webui/test_general_ui_manual.py
+++ b/cfme/tests/webui/test_general_ui_manual.py
@@ -3,8 +3,9 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.common.provider import BaseProvider
-from cfme.markers.env_markers.provider import ONE_PER_CATEGORY
+from cfme.cloud.provider import CloudProvider
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 
 pytestmark = [
     pytest.mark.ignore_stream("upstream"),
@@ -81,11 +82,11 @@ def test_infrastructure_provider_left_panel_titles():
     pass
 
 
-@pytest.mark.manual
+@pytest.mark.manual("manualonly")
 @pytest.mark.tier(1)
 @pytest.mark.meta(coverage=[1651194, 1503213])
 @test_requirements.general_ui
-@pytest.mark.provider([BaseProvider], selector=ONE_PER_CATEGORY)
+@pytest.mark.provider([InfraProvider, CloudProvider], selector=ONE)
 def test_pdf_summary_provider(provider):
     """
     Polarion:


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. `test_authorization_header_sql_response`
    2. `test_vm_compliance_attribute_rest`
- __Updating tests__  - Update missing Bugzilla coverage and missing markers.
    1. `test_create_picture_with_role`
    2. `test_reports_service_unavailable`
    3. `test_notification_url_parallel_requests`
    4. `test_service_refresh_dialog_fields_default_values`
- __Removing tests__ 
    1. `test_copying_customization_dialog`
