### PR TITLE
[1LP][RFR] Network adapter support in VM reconfiguration for vsphere

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -66,6 +66,7 @@ from widgetastic_manageiq import SnapshotMemorySwitch
 from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
 from widgetastic_manageiq.vm_reconfigure import DisksTable
+from widgetastic_manageiq.vm_reconfigure import NetworkAdaptersTable
 
 
 def has_child(tree, text, parent_item=None):
@@ -410,6 +411,12 @@ class InfraVmReconfigureView(BaseLoggedInPage):
             9: Button(),
         }
     )
+
+    network_adapters_table = NetworkAdaptersTable(
+        '//div/table[./../h3[normalize-space(text())="Network Adapters"]]',
+        column_widgets={"vLan": BootstrapSelect(id="vLan"), "Actions": Button(), 4: Button()},
+    )
+
     cd_dvd_table = WTable('//div/table[./../h3[normalize-space(text())="CD/DVD Drives"]]',
         column_widgets={
             "Host File": BootstrapSelect(id="isoName"),
@@ -538,6 +545,12 @@ class VMHardware(object):
         return self.mem_size * 1024 if self.mem_size_unit == 'GB' else self.mem_size
 
 
+class NetwrokAdapter(namedtuple("NetwrokAdapter", ["name", "vlan"])):
+    # just compare name not vlan
+    def __eq__(self, other):
+        return self.name == other.name
+
+
 class VMConfiguration(Pretty):
     """Represents VM's full configuration - hardware, disks and so forth
 
@@ -554,12 +567,16 @@ class VMConfiguration(Pretty):
         self.hw = VMHardware()
         self.disks = []
         self.vm = vm
+        self.nw_adapters = []
         self._load()
 
     def __eq__(self, other):
         return (
-            (self.hw == other.hw) and (self.num_disks == other.num_disks) and
-            all(disk in other.disks for disk in self.disks))
+            (self.hw == other.hw)
+            and (self.num_disks == other.num_disks)
+            and all(disk in other.disks for disk in self.disks)
+            and (self.num_nw_adapters == other.num_nw_adapters)
+        )
 
     def _load(self):
         """Loads the configuration from the VM object's appliance (through DB)
@@ -570,15 +587,31 @@ class VMConfiguration(Pretty):
         ems = appl_db['ext_management_systems']
         vms = appl_db['vms']
         hws = appl_db['hardwares']
+        guest_devices = appl_db["guest_devices"]
+
         hw_data = appl_db.session.query(ems, vms, hws).filter(
             ems.name == self.vm.provider.name).filter(
             vms.ems_id == ems.id).filter(
             vms.name == self.vm.name).filter(
             hws.vm_or_template_id == vms.id
         ).first().hardwares
+
         self.hw = VMHardware(
             hw_data.cpu_cores_per_socket, hw_data.cpu_sockets, hw_data.memory_mb, 'MB')
         hw_id = hw_data.id
+
+        # Network adapter
+        from cfme.infrastructure.provider.virtualcenter import VMwareProvider
+        if self.vm.provider.one_of(VMwareProvider):
+            guest_device_nw_filter = appl_db.session.query(ems, vms, hws, guest_devices).filter(
+                ems.name == self.vm.provider.name).filter(vms.ems_id == ems.id).filter(
+                vms.name == self.vm.name).filter(hws.vm_or_template_id == vms.id).filter(
+                guest_devices.hardware_id == hws.id).all()
+
+            self.nw_adapters = [
+                NetwrokAdapter(devices.guest_devices.device_name, None)
+                for devices in guest_device_nw_filter
+            ]
 
         # Disks
         disks = appl_db['disks']
@@ -586,6 +619,7 @@ class VMConfiguration(Pretty):
             disks.hardware_id == hw_id).filter(
             disks.device_type == 'disk'
         ).all()
+
         for disk_data in disks_data:
             # In DB stored in bytes, but UI default is GB
             size_gb = disk_data.size / (1024 ** 3)
@@ -606,6 +640,7 @@ class VMConfiguration(Pretty):
         # We can just make shallow copy here because disks can be only added or deleted, not edited
         config.disks = self.disks[:]
         config.vm = self.vm
+        config.nw_adapters = self.nw_adapters[:]
         return config
 
     def add_disk(self, size, size_unit='GB', type='thin', mode='persistent'):
@@ -657,6 +692,17 @@ class VMConfiguration(Pretty):
     def num_disks(self):
         return len(self.disks)
 
+    def add_nw_adapter(self, name, vlan):
+        self.nw_adapters.append(NetwrokAdapter(name=name, vlan=vlan))
+
+    def remove_nw_adapter(self, name):
+        nw_adapter = next(nw for nw in self.nw_adapters if nw.name == name)
+        self.nw_adapters.remove(nw_adapter)
+
+    @property
+    def num_nw_adapters(self):
+        return len(self.nw_adapters)
+
     def get_changes_to_fill(self, other_configuration):
         """ Returns changes to be applied to this config to reach the other config
 
@@ -665,15 +711,19 @@ class VMConfiguration(Pretty):
         """
         changes = {}
         changes['disks'] = []
+        changes['nw_adapters'] = []
+
         for key in ['cores_per_socket', 'sockets']:
             if getattr(self.hw, key) != getattr(other_configuration.hw, key):
                 changes[key] = str(getattr(other_configuration.hw, key))
                 changes['cpu'] = True
+
         if (self.hw.mem_size != other_configuration.hw.mem_size or
                 self.hw.mem_size_unit != other_configuration.hw.mem_size_unit):
             changes['memory'] = True
             changes['mem_size'] = other_configuration.hw.mem_size
             changes['mem_size_unit'] = other_configuration.hw.mem_size_unit
+
         for disk in self.disks + other_configuration.disks:
             if disk in self.disks and disk not in other_configuration.disks:
                 changes['disks'].append({'action': 'delete', 'disk': disk, 'delete_backing': None})
@@ -686,6 +736,14 @@ class VMConfiguration(Pretty):
                     change = {"action": "resize", "disk": new_disk}
                     if change not in changes["disks"]:
                         changes["disks"].append(change)
+
+        # Network adapter changes
+        for adapter in self.nw_adapters + other_configuration.nw_adapters:
+            if adapter in self.nw_adapters and adapter not in other_configuration.nw_adapters:
+                changes['nw_adapters'].append({'action': 'delete', 'nw_adapter': adapter})
+            elif adapter not in self.nw_adapters and adapter in other_configuration.nw_adapters:
+                changes['nw_adapters'].append({'action': 'add', 'nw_adapter': adapter})
+
         return changes
 
 
@@ -1049,6 +1107,7 @@ class InfraVm(VM):
             changes.get("mem_size", "0"), changes.get("mem_size_unit", "MB")) if changes.get(
             "memory", False) else None
         disk_message = None
+        nw_adapter_message = None
 
         for disk_change in changes['disks']:
             action, disk = disk_change['action'], disk_change['disk']
@@ -1092,7 +1151,29 @@ class InfraVm(VM):
                 disk_message = "Resize Disks"
             else:
                 raise ValueError("Unknown disk change action; must be one of: add, delete")
-        message = ", ".join([_f for _f in [ram_message, cpu_message, disk_message] if _f])
+
+        for nw_adapters_change in changes['nw_adapters']:
+            action, nw_adapter = nw_adapters_change['action'], nw_adapters_change['nw_adapter']
+
+            if action == "add":
+                row = vm_recfg.network_adapters_table.click_add_nw_adapter()
+                row.vlan.fill(nw_adapter.vlan)
+                row.actions.widget.click()
+                nw_adapter_message = "Add Network Adapters"
+            elif action == "delete":
+                row = vm_recfg.network_adapters_table.row(name=nw_adapter.name)
+                # https://github.com/RedHatQE/widgetastic.core/issues/95
+                # second action button, delete, is column 4 on colspan
+                row[4].widget.click()
+                nw_adapter_message = "Remove Network Adapters"
+            else:
+                raise ValueError(
+                    "Unknown newtwork adapter change action; must be one of: add, delete"
+                )
+
+        message = ", ".join(
+            [_f for _f in [ram_message, cpu_message, disk_message, nw_adapter_message] if _f]
+        )
 
         if cancel:
             vm_recfg.cancel_button.click()

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -545,7 +545,7 @@ class VMHardware(object):
         return self.mem_size * 1024 if self.mem_size_unit == 'GB' else self.mem_size
 
 
-class NetwrokAdapter(namedtuple("NetwrokAdapter", ["name", "vlan"])):
+class NetworkAdapter(namedtuple("NetworkAdapter", ["name", "vlan"])):
     # just compare name not vlan
     def __eq__(self, other):
         return self.name == other.name
@@ -572,10 +572,10 @@ class VMConfiguration(Pretty):
 
     def __eq__(self, other):
         return (
-            (self.hw == other.hw)
-            and (self.num_disks == other.num_disks)
+            self.hw == other.hw
+            and self.num_disks == other.num_disks
             and all(disk in other.disks for disk in self.disks)
-            and (self.num_nw_adapters == other.num_nw_adapters)
+            and self.num_nw_adapters == other.num_nw_adapters
         )
 
     def _load(self):
@@ -609,7 +609,7 @@ class VMConfiguration(Pretty):
                 guest_devices.hardware_id == hws.id).all()
 
             self.nw_adapters = [
-                NetwrokAdapter(devices.guest_devices.device_name, None)
+                NetworkAdapter(devices.guest_devices.device_name, None)
                 for devices in guest_device_nw_filter
             ]
 
@@ -693,7 +693,7 @@ class VMConfiguration(Pretty):
         return len(self.disks)
 
     def add_nw_adapter(self, name, vlan):
-        self.nw_adapters.append(NetwrokAdapter(name=name, vlan=vlan))
+        self.nw_adapters.append(NetworkAdapter(name=name, vlan=vlan))
 
     def remove_nw_adapter(self, name):
         nw_adapter = next(nw for nw in self.nw_adapters if nw.name == name)

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -390,8 +390,8 @@ def test_vm_reconfig_add_remove_network_adapters(request, adapters_type, full_vm
 
     # Create new configuration with new network adapter
     new_config = orig_config.copy()
-    new_config.add_nw_adapter(
-        f"Network adapter {orig_config.num_nw_adapters + 1}", vlan=adapters_type
+    new_config.add_network_adapter(
+        f"Network adapter {orig_config.num_network_adapters + 1}", vlan=adapters_type
     )
     add_adapter_request = full_vm.reconfigure(new_config)
     add_adapter_request.wait_for_request(method="ui")
@@ -399,7 +399,7 @@ def test_vm_reconfig_add_remove_network_adapters(request, adapters_type, full_vm
 
     # Verify network adapter added or not
     wait_for(
-        lambda: full_vm.configuration.num_nw_adapters == new_config.num_nw_adapters,
+        lambda: full_vm.configuration.num_network_adapters == new_config.num_network_adapters,
         timeout=120,
         delay=10,
         fail_func=full_vm.refresh_relationships,
@@ -413,7 +413,7 @@ def test_vm_reconfig_add_remove_network_adapters(request, adapters_type, full_vm
 
     # Verify network adapter removed or not
     wait_for(
-        lambda: full_vm.configuration.num_nw_adapters == orig_config.num_nw_adapters,
+        lambda: full_vm.configuration.num_network_adapters == orig_config.num_network_adapters,
         timeout=120,
         delay=10,
         fail_func=full_vm.refresh_relationships,

--- a/cfme/tests/infrastructure/test_vm_reconfigure.py
+++ b/cfme/tests/infrastructure/test_vm_reconfigure.py
@@ -363,12 +363,14 @@ def test_vm_reconfig_resize_disk_snapshot(request, disk_type, disk_mode, full_vm
     assert not row[9].widget.is_displayed
 
 
-@pytest.mark.manual
 @pytest.mark.tier(1)
 @pytest.mark.provider([VMwareProvider])
 @pytest.mark.parametrize(
-    'adapters_type', ['DPortGroup', 'VmNetwork', 'MgmtNetwork', 'VmKernel'])
-def test_vm_reconfig_add_remove_network_adapters(adapters_type):
+    "adapters_type",
+    ["DPortGroup", "VM Network", "Management Network", "VMkernel"],
+    ids=["DPortGroup", "VmNetwork", "MgmtNetwork", "VmKernel"],
+)
+def test_vm_reconfig_add_remove_network_adapters(request, adapters_type, full_vm):
     """
     Polarion:
         assignee: nansari
@@ -384,7 +386,39 @@ def test_vm_reconfig_add_remove_network_adapters(adapters_type):
             4. Check the changes in VM reconfiguration page
             5. Remove the Adapters
     """
-    pass
+    orig_config = full_vm.configuration.copy()
+
+    # Create new configuration with new network adapter
+    new_config = orig_config.copy()
+    new_config.add_nw_adapter(
+        f"Network adapter {orig_config.num_nw_adapters + 1}", vlan=adapters_type
+    )
+    add_adapter_request = full_vm.reconfigure(new_config)
+    add_adapter_request.wait_for_request(method="ui")
+    request.addfinalizer(add_adapter_request.remove_request)
+
+    # Verify network adapter added or not
+    wait_for(
+        lambda: full_vm.configuration.num_nw_adapters == new_config.num_nw_adapters,
+        timeout=120,
+        delay=10,
+        fail_func=full_vm.refresh_relationships,
+        message="confirm that network adapter was added",
+    )
+
+    # Remove network adapter
+    remove_adapter_request = full_vm.reconfigure(orig_config)
+    remove_adapter_request.wait_for_request(method="ui")
+    request.addfinalizer(remove_adapter_request.remove_request)
+
+    # Verify network adapter removed or not
+    wait_for(
+        lambda: full_vm.configuration.num_nw_adapters == orig_config.num_nw_adapters,
+        timeout=120,
+        delay=10,
+        fail_func=full_vm.refresh_relationships,
+        message="confirm that network adapter was added",
+    )
 
 
 @pytest.mark.manual

--- a/widgetastic_manageiq/vm_reconfigure.py
+++ b/widgetastic_manageiq/vm_reconfigure.py
@@ -38,13 +38,13 @@ class NetworkAdaptersTable(VanillaTable):
     add_nw_btn = DisksButton("contains", "Add Network", classes=[Button.PRIMARY])
     cancel_add_nw_btn = DisksButton("contains", "Cancel Add", classes=[Button.DEFAULT])
 
-    def click_add_nw_adapter(self):
+    def click_add_network_adapter(self):
         """Clicks the 'Add Network' button attached to the table and
         returns the new editable row
         """
         self.add_nw_btn.click()
         return self[-1]
 
-    def click_cancel_add_nw_adapter(self):
+    def click_cancel_add_network_adapter(self):
         """Clicks the 'Cancel Add' button to cancel adding a new row"""
         self.cancel_add_nw_btn.click()

--- a/widgetastic_manageiq/vm_reconfigure.py
+++ b/widgetastic_manageiq/vm_reconfigure.py
@@ -23,28 +23,28 @@ class DisksTable(VanillaTable):
     cancel_add_btn = DisksButton("contains", "Cancel Add", classes=[Button.DEFAULT])
 
     def click_add_disk(self):
-        """Clicks the Add Disk button attached to the table and returns the new editable row"""
+        """Clicks the 'Add Disk' button attached to the table and returns the new editable row"""
         self.add_disk_btn.click()
         return self[0]
 
     def click_cancel_add(self):
-        """Clicks the Cancel Add button to cancel adding a new row"""
+        """Clicks the 'Cancel Add' button to cancel adding a new row"""
         self.cancel_add_btn.click()
 
 
 class NetworkAdaptersTable(VanillaTable):
-    """Table to add and remove Disks (in VM Reconfigure form)"""
+    """Table to add and remove Network Adapters (in VM Reconfigure form)"""
 
     add_nw_btn = DisksButton("contains", "Add Network", classes=[Button.PRIMARY])
     cancel_add_nw_btn = DisksButton("contains", "Cancel Add", classes=[Button.DEFAULT])
 
     def click_add_nw_adapter(self):
-        """Clicks the Add Network Adapter button attached to the table and
+        """Clicks the 'Add Network' button attached to the table and
         returns the new editable row
         """
         self.add_nw_btn.click()
         return self[-1]
 
     def click_cancel_add_nw_adapter(self):
-        """Clicks the Cancel Add button to cancel adding a new row"""
+        """Clicks the 'Cancel Add' button to cancel adding a new row"""
         self.cancel_add_nw_btn.click()

--- a/widgetastic_manageiq/vm_reconfigure.py
+++ b/widgetastic_manageiq/vm_reconfigure.py
@@ -30,3 +30,21 @@ class DisksTable(VanillaTable):
     def click_cancel_add(self):
         """Clicks the Cancel Add button to cancel adding a new row"""
         self.cancel_add_btn.click()
+
+
+class NetworkAdaptersTable(VanillaTable):
+    """Table to add and remove Disks (in VM Reconfigure form)"""
+
+    add_nw_btn = DisksButton("contains", "Add Network", classes=[Button.PRIMARY])
+    cancel_add_nw_btn = DisksButton("contains", "Cancel Add", classes=[Button.DEFAULT])
+
+    def click_add_nw_adapter(self):
+        """Clicks the Add Network Adapter button attached to the table and
+        returns the new editable row
+        """
+        self.add_nw_btn.click()
+        return self[-1]
+
+    def click_cancel_add_nw_adapter(self):
+        """Clicks the Cancel Add button to cancel adding a new row"""
+        self.cancel_add_nw_btn.click()


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- Add network adapter reconfig facility in model page
- Automate network related test
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/infrastructure/test_vm_reconfigure.py -k 'test_vm_reconfig_add_remove_network_adapters' --long-running -v}}

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
-
-->
