### PR TITLE
[1LP][RFR] New Test: Test message attribute while simulation

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -475,33 +475,6 @@ def test_overwrite_import_domain():
 
 
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1753523])
-def test_attribute_value_message():
-    """
-    Bugzilla:
-        1753523
-
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/8h
-        caseposneg: positive
-        casecomponent: Automate
-        testSteps:
-            1. Create domain, namespace, class and instance pointing to method
-            2. Navigate to automate > automation > simulation page
-            3. Fill values for attribute/value pairs of namespace, class, instance and add message
-               attribute with any value and click on submit.
-            4. See automation.log
-        expectedResults:
-            1.
-            2.
-            3.
-            4. Custom message attribute should be considered with instance in logs
-    """
-    pass
-
-
-@pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1743227])
 def test_queue_up_schedule_run_now():
     """

--- a/cfme/tests/automate/test_simulation.py
+++ b/cfme/tests/automate/test_simulation.py
@@ -187,3 +187,47 @@ def test_simulation_copy_button(appliance):
     assert view.copy.is_enabled
     view.target_type.select_by_visible_text("Provider")
     assert not view.copy.is_enabled
+
+
+@pytest.mark.meta(automates=[1753523], blockers=[BZ(1753523, forced_streams=['5.10'])])
+def test_attribute_value_message(custom_instance):
+    """
+    Bugzilla:
+        1753523
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        caseposneg: positive
+        casecomponent: Automate
+        setup:
+            1. Create domain, namespace, class and instance pointing to method
+        testSteps:
+            1. Navigate to automate > automation > simulation page
+            2. Fill values for attribute/value pairs of namespace, class, instance and add message
+               attribute with any value and click on submit.
+            3. See automation.log
+        expectedResults:
+            1.
+            2.
+            3. Custom message attribute should be considered with instance in logs
+    """
+    instance = custom_instance(ruby_code=None)
+    msg = fauxfactory.gen_alphanumeric()
+
+    # Executing automate method
+    with LogValidator(
+            "/var/www/miq/vmdb/log/automation.log",
+            matched_patterns=[f".*{instance.name}#{msg}.*"]).waiting(timeout=120):
+        simulate(
+            appliance=instance.appliance,
+            attributes_values={
+                "namespace": instance.klass.namespace.name,
+                "class": instance.klass.name,
+                "instance": instance.name,
+                "message": msg
+            },
+            message="create",
+            request="call_instance_with_message",
+            execute_methods=True,
+        )


### PR DESCRIPTION
## Purpose or Intent
- It should consider attribute message in logs with instance as per BZ fixed for custom button simulation: https://bugzilla.redhat.com/show_bug.cgi?id=1651099
### PRT Run
{{ pytest: cfme/tests/automate/test_simulation.py::test_attribute_value_message --use-template-cache -qsvvv}}