### PR TITLE
[1LP][RFR] Automate: test_delete_generated_report

### DIFF
--- a/cfme/intelligence/optimization.py
+++ b/cfme/intelligence/optimization.py
@@ -82,13 +82,17 @@ class OptimizationSavedReportsCollection(BaseCollection):
 @attr.s
 class OptimizationReport(BaseEntity):
     menu_name = attr.ib()
-    runs = attr.ib(default=None)
 
     _collections = {
         "optimization_saved_reports": OptimizationSavedReportsCollection,
         "saved_reports": SavedReportsCollection,
         "reports": ReportsCollection,
     }
+
+    @property
+    def runs(self):
+        view = navigate_to(self.parent, "All")
+        return int(view.table.row(report_name=self.menu_name)["Report runs"].text)
 
     @property
     def last_run_at(self):
@@ -151,4 +155,4 @@ class SavedOptimizationReportDetails(CFMENavigateStep):
     prerequisite = NavigateToAttribute("parent.parent", "SavedAll")
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.table.row(last_run_at=self.obj.run_at).click()
+        self.prerequisite_view.table.row(last_run_at=self.obj.run_at, report=self.obj.name).click()

--- a/cfme/modeling/base.py
+++ b/cfme/modeling/base.py
@@ -4,6 +4,7 @@ import attr
 from cached_property import cached_property
 from navmazing import NavigationDestinationNotFound
 from widgetastic.exceptions import NoSuchElementException
+from widgetastic.exceptions import RowNotFound
 from widgetastic.utils import VersionPick
 from widgetastic_patternfly import CandidateNotFound
 
@@ -178,6 +179,7 @@ class BaseEntity(NavigatableMixin):
             NameError,
             NavigationDestinationNotFound,
             NoSuchElementException,
+            RowNotFound,
             TimedOutError,
         ):
             return False

--- a/cfme/tests/intelligence/test_optimization.py
+++ b/cfme/tests/intelligence/test_optimization.py
@@ -1,7 +1,10 @@
+from datetime import datetime
+
 import pytest
 from widgetastic.utils import attributize_string
 
 from cfme import test_requirements
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 
 pytestmark = [test_requirements.report, pytest.mark.tier(1), pytest.mark.ignore_stream("5.10")]
@@ -47,9 +50,8 @@ def test_generate_optimization_report(appliance, menu_name):
     assert saved_report.exists
 
 
-@pytest.mark.manual
-@pytest.mark.meta(coverage=[1769333])
-def test_delete_generated_report():
+@pytest.mark.meta(automates=[1769333])
+def test_delete_generated_report(appliance):
     """
     Bugzilla:
         1769333
@@ -69,4 +71,51 @@ def test_delete_generated_report():
             2.
             3. Report runs value for the optimization report must decrease by 1.
     """
-    pass
+    optimization_report = appliance.collections.optimization_reports.instantiate(
+        menu_name="Offline VMs with Snapshot"
+    )
+    opt_saved_report = optimization_report.queue()
+
+    # Note the value of runs for later comparison
+    old_run = optimization_report.runs
+
+    # There is an inconsistency between the time format for Optimization Report and Intel Report,
+    # to overcome that we pick the details from the SavedReport table so that it is easy to
+    # instantiate a SavedReport using ReportsCollection.
+    run_at_time = opt_saved_report.run_at.split()[1]
+
+    if BZ(1769333).blocks:
+        # convert run_at time from 12-hr to 24hr format
+        run_at_time = datetime.strftime(
+            datetime.strptime(
+                f"{opt_saved_report.run_at.split()[1]} {opt_saved_report.run_at.split()[2]}",
+                "%I:%M:%S %p",
+            ),
+            "%H:%M:%S",
+        )
+
+    view = navigate_to(optimization_report.collections.saved_reports, "All")
+    # This asserts the report exists for SavedReports accordion.
+    # If the report did not exist, RowNotFound error would be raised here.
+    row = next(
+        view.table.rows(
+            run_at__contains=run_at_time, name__contains=opt_saved_report.parent.parent.menu_name
+        )
+    )
+
+    # Assert the report exists for Reports accordion
+    saved_report = appliance.collections.reports.instantiate(
+        type="Operations",
+        subtype="Virtual Machines",
+        menu_name=opt_saved_report.parent.parent.menu_name,
+    ).saved_reports.instantiate(
+        run_datetime=row.run_at.text, queued_datetime=row.queued_at.text, candu=False
+    )
+
+    assert saved_report.exists
+    saved_report.delete()
+
+    # Assert the run value decreases after deleting the report
+    assert optimization_report.runs < old_run
+
+    assert not opt_saved_report.exists

--- a/cfme/tests/intelligence/test_optimization.py
+++ b/cfme/tests/intelligence/test_optimization.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytest
+from widgetastic.exceptions import RowNotFound
 from widgetastic.utils import attributize_string
 
 from cfme import test_requirements
@@ -95,13 +96,18 @@ def test_delete_generated_report(appliance):
         )
 
     view = navigate_to(optimization_report.collections.saved_reports, "All")
+
     # This asserts the report exists for SavedReports accordion.
-    # If the report did not exist, RowNotFound error would be raised here.
-    row = next(
-        view.table.rows(
-            run_at__contains=run_at_time, name__contains=opt_saved_report.parent.parent.menu_name
+    # If the report does not exist, RowNotFound error would be raised here.
+    try:
+        row = next(
+            view.table.rows(
+                run_at__contains=run_at_time,
+                name__contains=opt_saved_report.parent.parent.menu_name
+            )
         )
-    )
+    except RowNotFound:
+        pytest.fail("Saved Report does not exist.")
 
     # Assert the report exists for Reports accordion
     saved_report = appliance.collections.reports.instantiate(


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. `test_delete_generated_report`
- __Enhancements__
    1. Add `RowNotFound` exception to the list of exceptions for `exists` method in `BaseEntity`.
    2. Replace `runs` attribute of `OptimizationReport` to property.

### PRT Run
{{ pytest: cfme/tests/intelligence/test_optimization.py -k "test_delete_generated_report" -vvv }}