### PR TITLE
[RFR] Updates for gob tests that have had BZ's fixed

### DIFF
--- a/cfme/generic_objects/definition/button_groups.py
+++ b/cfme/generic_objects/definition/button_groups.py
@@ -18,10 +18,16 @@ from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.update import Updateable
+from cfme.utils.version import Version
+from cfme.utils.version import VersionPicker
 
 
 @attr.s
 class GenericObjectButton(BaseEntity, Updateable):
+    REMOVE_TEXT = VersionPicker({
+        "5.11": 'Remove this Custom Button from Inventory',
+        Version.lowest(): 'Remove this Button from Inventory'}
+    )
 
     name = attr.ib()
     description = attr.ib()
@@ -49,7 +55,7 @@ class GenericObjectButton(BaseEntity, Updateable):
             Args: cancel(bool): By default button will be deleted, pass True to cancel deletion
         """
         view = navigate_to(self, 'Details')
-        view.configuration.item_select('Remove this Button from Inventory', handle_alert=not cancel)
+        view.configuration.item_select(self.REMOVE_TEXT, handle_alert=not cancel)
         view = self.create_view(GenericObjectDefinitionAllView)
         assert view.is_displayed
         view.flash.assert_no_error()
@@ -203,6 +209,10 @@ class ButtonEdit(CFMENavigateStep):
 
 @attr.s
 class GenericObjectButtonGroup(BaseEntity, Updateable):
+    REMOVE_TEXT = VersionPicker({
+        "5.11": 'Remove this Custom Button Group from Inventory',
+        Version.lowest(): 'Remove this Button Group from Inventory'}
+    )
 
     name = attr.ib()
     description = attr.ib()
@@ -218,12 +228,12 @@ class GenericObjectButtonGroup(BaseEntity, Updateable):
         """
         view = navigate_to(self, 'Details')
 
-        if not view.configuration.item_enabled('Remove this Button Group from Inventory'):
+        if not view.configuration.item_enabled(self.REMOVE_TEXT):
             raise OptionNotAvailable(
                 "Remove this Button Group is not enabled, there are buttons assigned to this group")
         else:
             view.configuration.item_select(
-                'Remove this Button Group from Inventory', handle_alert=not cancel
+                self.REMOVE_TEXT, handle_alert=not cancel
             )
         view = self.create_view(GenericObjectDefinitionAllView, wait=10)
         view.flash.assert_no_error()

--- a/cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py
+++ b/cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py
@@ -126,9 +126,14 @@ def test_custom_group_on_generic_class_crud(appliance, generic_definition):
 
         # delete group
         group.delete()
-        # TODO(ndhandre): For now, we can not guess exact flash message.
-        #  Change flash as per BZ-1744478.
-        view.flash.assert_success_message('Button Group:"undefined" was successfully deleted')
+        if not (BZ(1744478).blocks or BZ(1773666).blocks):
+            view.flash.assert_success_message(
+                f'CustomButtonSet: "{group.name}" was successfully deleted'
+            )
+        else:
+            view.flash.assert_success_message(
+                'Button Group:"undefined" was successfully deleted'
+            )
         assert not group.exists
 
 
@@ -189,7 +194,12 @@ def test_custom_button_on_generic_class_crud(appliance, button_group, is_undefin
         button.delete()
         # TODO(ndhandre): For now, we can not guess exact flash message.
         #  Change flash as per BZ-1744478.
-        view.flash.assert_success_message('Button:"undefined" was successfully deleted')
+        if not (BZ(1744478).blocks or BZ(1773666).blocks):
+            view.flash.assert_success_message(
+                f'CustomButton: "{button.name}" was successfully deleted'
+            )
+        else:
+            view.flash.assert_success_message('Button:"undefined" was successfully deleted')
         assert not button.exists
 
 
@@ -314,12 +324,11 @@ def test_generic_object_button_delete_flash(button_without_group):
             3. Assert that the button name is in the flash message
     """
     view = navigate_to(button_without_group, "Details")
-    view.configuration.item_select('Remove this Button from Inventory', handle_alert=True)
+    view.configuration.item_select('Remove this Custom Button from Inventory', handle_alert=True)
     view = button_without_group.create_view(GenericObjectDefinitionAllView)
     assert view.is_displayed
-    # TODO: update flash if it turns out to be different after BZ's are fixed
     view.flash.assert_success_message(
-        f'Button:"{button_without_group.name}" was successfully deleted'
+        f'CustomButton: "{button_without_group.name}" was successfully deleted'
     )
 
 


### PR DESCRIPTION
Updating generic object button tests as some BZs have been fixed that change the flash messages. 

{{ pytest: --long-running cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py }}
