### PR TITLE
[1LP][RFR] mgmt should refer to the vm object provider object

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -2676,7 +2676,7 @@ class Appliance(IPAppliance):
     # TODO Remove cached property, could be a lot of references
     @cached_property
     def mgmt(self):
-        return self.provider
+        return self.provider.get_vm(self.vm_name)
 
     def does_vm_exist(self):
         return self.provider.does_vm_exist(self.vm_name)


### PR DESCRIPTION
`mgmt` object should refer to the wrapanapi VM object, not the wrapanapi provider object. That is provided by `self.provider`.

Fixing a bug introduced in #9674