### PR TITLE
[1LP][RFR] Blocked azure provider refresh test case

### DIFF
--- a/cfme/tests/cloud_infra_common/test_relationships.py
+++ b/cfme/tests/cloud_infra_common/test_relationships.py
@@ -280,8 +280,15 @@ def test_tagvis_cloud_provider_children(prov_child_visibility, setup_provider, r
 @pytest.mark.rhv1
 @pytest.mark.provider([CloudProvider, InfraProvider])
 @pytest.mark.tier(1)
-@pytest.mark.meta(blockers=[
-    BZ(1756984, unblock=lambda provider: not provider.one_of(AzureProvider))])
+@pytest.mark.meta(
+    blockers=[
+        BZ(
+            1756984,
+            forced_streams=["5.11"],
+            unblock=lambda provider: not provider.one_of(AzureProvider),
+        )
+    ]
+)
 @pytest.mark.meta(automates=[1353285])
 def test_provider_refresh_relationship(provider, setup_provider):
     """Tests provider refresh


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>


## Purpose or Intent
- Blocked azure provider refresh test case as it shows error in evm logs. but no issue with fetching data in UI. 
- This issue was already reported for 5.10 but now this seems to be reproducible on 5.11 too. As commented here: https://bugzilla.redhat.com/show_bug.cgi?id=1756984#c9
- Hence blocking this test case

### PRT Run
{{ pytest: cfme/tests/cloud_infra_common/test_relationships.py -k 'test_provider_refresh_relationship' --use-template-cache -qsvv --long-running --use-provider=azure }}