### PR TITLE
[1LP][RFR] Adding BZ blocker for Azure candu tests for 510

### DIFF
--- a/cfme/tests/candu/test_utilization_metrics.py
+++ b/cfme/tests/candu/test_utilization_metrics.py
@@ -124,6 +124,10 @@ def query_metric_db(appliance, provider, metric, vm_name=None, host_name=None):
 
 @pytest.mark.rhv2
 @pytest.mark.meta(automates=[1671580, 1722937])
+@pytest.mark.meta(
+    blockers=[BZ(1744845, forced_streams=['5.10'],
+        unblock=lambda provider: not provider.one_of(AzureProvider))]
+)
 # Tests to check that specific metrics are being collected
 def test_raw_metric_vm_cpu(metrics_collection, appliance, provider):
     """
@@ -181,6 +185,10 @@ def test_raw_metric_vm_memory(metrics_collection, appliance, provider):
 
 @pytest.mark.rhv2
 @pytest.mark.meta(automates=[1671580, 1722937])
+@pytest.mark.meta(
+    blockers=[BZ(1744845, forced_streams=['5.10'],
+        unblock=lambda provider: not provider.one_of(AzureProvider))]
+)
 def test_raw_metric_vm_network(metrics_collection, appliance, provider):
     """
     Polarion:
@@ -203,6 +211,10 @@ def test_raw_metric_vm_network(metrics_collection, appliance, provider):
     [VMwareProvider, RHEVMProvider, OpenStackProvider, AzureProvider, GCEProvider],
     required_fields=[(['cap_and_util', 'capandu_vm'], 'cu-24x7')],
     scope='module',
+)
+@pytest.mark.meta(
+    blockers=[BZ(1744845, forced_streams=['5.10'],
+        unblock=lambda provider: not provider.one_of(AzureProvider))]
 )
 @pytest.mark.meta(automates=[1671580, 1722937])
 def test_raw_metric_vm_disk(metrics_collection, appliance, provider):


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{pytest: cfme/tests/candu/test_utilization_metrics.py --use-provider azure}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
