### PR TITLE
[1LP][RFR] New Test: Adding multiple Remote Appliances in Global Appliance

### DIFF
--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -1082,7 +1082,11 @@ class Replication(NavigatableMixin):
         if replication_type == 'remote':
             return view.is_displayed
         else:
-            return self._global_replication_row(host).is_displayed
+            is_host_present = self._global_replication_row(host).is_displayed
+            host_row = view.subscription_table.row(host=host)
+            wait_for(lambda: host_row.status.text == "replicating",
+                     fail_func=view.browser.refresh)
+            return is_host_present
 
     def get_global_replication_backlog(self, host=None):
         """ Get global replication backlog value

--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -189,11 +189,11 @@ def temp_appliances_unconfig_funcscope_rhevm(appliance, pytestconfig):
 
 
 @pytest.fixture(scope="module")
-def temp_appliances_unconfig_modscope_rhevm(appliance, pytestconfig):
+def temp_appliances_unconfig_modscope_rhevm(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig,
-            count=2,
+            count=getattr(request, "param", 2),
             preconfigured=False,
             provider_type='rhevm'
     ) as appliances:

--- a/cfme/tests/test_replication.py
+++ b/cfme/tests/test_replication.py
@@ -5,6 +5,7 @@ from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.configure.configuration.region_settings import ReplicationGlobalView
 from cfme.fixtures.cli import provider_app_crud
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
 
 
@@ -201,9 +202,11 @@ def test_replication_appliance_set_type_global_ui():
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(2)
-def test_replication_appliance_add_multi_subscription():
+@pytest.mark.parametrize("temp_appliances_unconfig_modscope_rhevm", [3], indirect=True)
+def test_replication_appliance_add_multi_subscription(request, setup_multi_region_cluster,
+                                                      multi_region_cluster,
+                                                      temp_appliances_unconfig_modscope_rhevm):
     """
     add two or more subscriptions to global
 
@@ -220,7 +223,12 @@ def test_replication_appliance_add_multi_subscription():
             1.
             2. appliances subscribed.
     """
-    pass
+    region = multi_region_cluster.global_appliance.collections.regions.instantiate()
+    navigate_to(region.replication, "Global")
+    for host in multi_region_cluster.remote_appliances:
+        assert region.replication.get_replication_status(
+            host=host.hostname
+        ), f"{host.hostname} Remote Appliance is not found in Global Appliance's list"
 
 
 @pytest.mark.manual


### PR DESCRIPTION


## Purpose or Intent

- __Adding tests__ Test to add multiple remote appliances in global appliance




- {{pytest: cfme/tests/test_replication.py::test_replication_appliance_add_multi_subscription   --long-running -v}}
