### PR TITLE
[1LP][RFR] Configuring remote app. and global App replication using UI

### DIFF
--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -1049,20 +1049,9 @@ class Replication(NavigatableMixin):
                 if replication_type == 'global':
                     if validate:
                         view.action_dropdown.item_select("Validate")
-                        view.flash.assert_success_message(
-                            "Subscription Credentials validated successfully"
-                        )
+                        view.flash.assert_no_error()
                     view.accept_button.click()
-                    view.save_button.click()
-                    view.flash.assert_success_message('Replication configuration save initiated.'
-                                              ' Check status of task "Save subscriptions for '
-                                              'global region" on My Tasks screen')
-                elif replication_type == 'remote':
-                    view.save_button.click()
-                    view.flash.assert_success_message('Replication configuration save initiated.'
-                                                      ' Check status of task "Configure the '
-                                                      'database to be a replication remote region"'
-                                                      ' on My Tasks screen')
+                view.save_button.click()
             except Exception:
                 logger.warning('Nothing was updated, please check the data')
 

--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -1038,7 +1038,7 @@ class Replication(NavigatableMixin):
                 'password': (
                     updates.get('password') if updates.get('password') else db_creds.password)
             })
-        else:
+        elif replication_type == 'remote':
             view = navigate_to(self, 'RemoteAdd')
             # TODO fill remote settings will be done after widget added
         if reset:
@@ -1046,13 +1046,23 @@ class Replication(NavigatableMixin):
             view.flash.assert_message('All changes have been reset')
         else:
             try:
-                if validate:
-                    view.action_dropdown.item_select("Validate")
-                    view.flash.assert_success_message(
-                        "Subscription Credentials validated successfully"
-                    )
-                view.accept_button.click()
-                view.save_button.click()
+                if replication_type == 'global':
+                    if validate:
+                        view.action_dropdown.item_select("Validate")
+                        view.flash.assert_success_message(
+                            "Subscription Credentials validated successfully"
+                        )
+                    view.accept_button.click()
+                    view.save_button.click()
+                    view.flash.assert_success_message('Replication configuration save initiated.'
+                                              ' Check status of task "Save subscriptions for '
+                                              'global region" on My Tasks screen')
+                elif replication_type == 'remote':
+                    view.save_button.click()
+                    view.flash.assert_success_message('Replication configuration save initiated.'
+                                                      ' Check status of task "Configure the '
+                                                      'database to be a replication remote region"'
+                                                      ' on My Tasks screen')
             except Exception:
                 logger.warning('Nothing was updated, please check the data')
 

--- a/cfme/tests/test_replication.py
+++ b/cfme/tests/test_replication.py
@@ -5,6 +5,7 @@ from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.configure.configuration.region_settings import ReplicationGlobalView
 from cfme.fixtures.cli import provider_app_crud
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
 
 
@@ -177,9 +178,8 @@ def test_replication_remote_to_global_by_ip_pglogical(setup_replication):
     assert provider.name in global_app.managed_provider_names, "Provider name not found"
 
 
-@pytest.mark.manual
 @pytest.mark.tier(1)
-def test_replication_appliance_set_type_global_ui():
+def test_replication_appliance_set_type_global_ui(configured_appliance, unconfigured_appliance):
     """
     Set appliance replication type to "Global" and add subscription in the
     UI
@@ -198,7 +198,38 @@ def test_replication_appliance_set_type_global_ui():
             1.
             2. No error, appliance subscribed.
     """
-    pass
+    remote_app, global_app = configured_appliance, unconfigured_appliance
+    app_params = dict(
+        region=99,
+        dbhostname='localhost',
+        username=credentials["database"]["username"],
+        password=credentials["database"]["password"],
+        dbname='vmdb_production',
+        dbdisk=global_app.unpartitioned_disks[0],
+        fetch_key=remote_app.hostname,
+        sshlogin=credentials["ssh"]["username"],
+        sshpass=credentials["ssh"]["password"],
+    )
+
+    global_app.appliance_console_cli.configure_appliance_internal_fetch_key(**app_params)
+    global_app.evmserverd.wait_for_running()
+    global_app.wait_for_web_ui()
+
+    # Making configured app to Remote Appliance using UI
+    remote_region = remote_app.collections.regions.instantiate()
+    navigate_to(remote_region.replication, "RemoteAdd")
+    remote_region.replication.set_replication(replication_type="remote")
+
+    # Adding Remote Appliance into Global appliance using UI
+    global_region = global_app.collections.regions.instantiate(number=99)
+    navigate_to(global_region.replication, "Global")
+    global_region.replication.set_replication(replication_type="global",
+                                       updates={"host": remote_app.hostname},
+                                       validate=True)
+
+    # Validating replication
+    assert global_region.replication.get_replication_status(host=remote_app.hostname),\
+        "Replication is not started."
 
 
 @pytest.mark.manual

--- a/cfme/tests/test_replication.py
+++ b/cfme/tests/test_replication.py
@@ -5,7 +5,6 @@ from cfme import test_requirements
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.configure.configuration.region_settings import ReplicationGlobalView
 from cfme.fixtures.cli import provider_app_crud
-from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.conf import credentials
 
 
@@ -217,19 +216,16 @@ def test_replication_appliance_set_type_global_ui(configured_appliance, unconfig
 
     # Making configured app to Remote Appliance using UI
     remote_region = remote_app.collections.regions.instantiate()
-    navigate_to(remote_region.replication, "RemoteAdd")
     remote_region.replication.set_replication(replication_type="remote")
 
     # Adding Remote Appliance into Global appliance using UI
     global_region = global_app.collections.regions.instantiate(number=99)
-    navigate_to(global_region.replication, "Global")
-    global_region.replication.set_replication(replication_type="global",
-                                       updates={"host": remote_app.hostname},
-                                       validate=True)
+    global_region.replication.set_replication(
+        replication_type="global", updates={"host": remote_app.hostname}, validate=True)
 
     # Validating replication
-    assert global_region.replication.get_replication_status(host=remote_app.hostname),\
-        "Replication is not started."
+    assert global_region.replication.get_replication_status(
+        host=remote_app.hostname), "Replication is not started."
 
 
 @pytest.mark.manual


### PR DESCRIPTION

## Purpose or Intent

- __Adding tests__ Adding new tc which is making remote appliance, global appliance and starting replication using UI
## Some examples are:
- {{pytest: cfme/tests/test_replication.py::test_replication_appliance_set_type_global_ui --long-running -v}}

