### PR TITLE
[1LP][RFR] automate service fetch error after user delete

### DIFF
--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -148,11 +148,12 @@ def test_suspend_vm_service_details(context):
     pass
 
 
-@pytest.mark.meta(coverage=[1677744])
-@pytest.mark.manual
+@pytest.mark.meta(automates=[1677744])
+@pytest.mark.customer_scenario
 @pytest.mark.ignore_stream('5.10')
 @pytest.mark.tier(2)
-def test_no_error_while_fetching_the_service():
+def test_no_error_while_fetching_the_service(
+        request, appliance, user_self_service_role, generic_catalog_item):
     """
 
     Bugzilla:
@@ -170,7 +171,41 @@ def test_no_error_while_fetching_the_service():
             1.
             2. In SUI click on provisioned service
     """
-    pass
+    user, _ = user_self_service_role
+
+    # login with user having self service role
+    with user:
+        with appliance.context.use(ViaUI):
+            appliance.server.login(user)
+
+            # Order service from catalog item
+            serv_cat = ServiceCatalogs(
+                appliance,
+                catalog=generic_catalog_item.catalog,
+                name=generic_catalog_item.name,
+            )
+            provision_request = serv_cat.order()
+            provision_request.wait_for_request()
+
+            # Check service with user
+            service = MyService(appliance, generic_catalog_item.dialog.label)
+            assert service.exists
+
+    @request.addfinalizer
+    def _clear_service():
+        if service.exists:
+            service.delete()
+
+    # Delete user
+    # Note: before deleting user need to clean respected user requests
+    provision_request.remove_request(method="rest")
+    user.delete()
+    assert not user.exists
+
+    # Check service exist without user or not
+    for context in [ViaUI, ViaSSUI]:
+        with appliance.context.use(context):
+            assert service.exists
 
 
 @pytest.mark.meta(automates=[1628520])

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -150,10 +150,9 @@ def test_suspend_vm_service_details(context):
 
 @pytest.mark.meta(automates=[1677744])
 @pytest.mark.customer_scenario
-@pytest.mark.ignore_stream('5.10')
 @pytest.mark.tier(2)
-def test_no_error_while_fetching_the_service(
-        request, appliance, user_self_service_role, generic_catalog_item):
+def test_no_error_while_fetching_the_service(request, appliance, user_self_service_role,
+                                             generic_catalog_item):
     """
 
     Bugzilla:
@@ -161,7 +160,7 @@ def test_no_error_while_fetching_the_service(
 
     Polarion:
         assignee: nansari
-        startsin: 5.11
+        startsin: 5.10
         casecomponent: SelfServiceUI
         initialEstimate: 1/6h
         testSteps:


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/ssui/test_ssui_myservice.py::test_no_error_while_fetching_the_service --long-running -vv}}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
