### PR TITLE
[1LP][RFR] Fixed rbac tree issue on 5.11

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -4559,7 +4559,7 @@ class LineChart(Widget, ClickableMixin):
         return tooltip_data
 
 
-class ReactTextInput(TextInput):
+class ReactTextInput(Input):
 
     # The clear method from the WebElement class in the Selenium package was not clearing the react
     # text field. arguments[0] is the widget name


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

## Purpose or Intent
Fixed Error:
```
>                       self._repr_step(*self._process_step(steps_tried[-2])))})
E               widgetastic_patternfly.CandidateNotFound: message: Could not find the item Everything/Settings in Boostrap tree features_treebox, path: ('Settings', 'Configuration'), cause: Was not found in Everything

/var/ci/cfme_venv3/lib64/python3.7/site-packages/widgetastic_patternfly/__init__.py:1459: CandidateNotFound
CandidateNotFound
b"message: Could not find the item Everything/Settings in Boostrap tree features_treebox, path: ('Settings', 'Configuration'), cause: Was not found in Everything"
```
### PRT Run
{{ pytest: cfme/tests/configure/test_access_control.py -k "test_role_crud or test_tenant_unique_catalog" --use-template-cache -qsvvv }}
