### PR TITLE
[1LP][RFR] Add periodic call and use it to prolong the appliances from Sprout

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -16,6 +16,7 @@ import pytest
 
 from cfme.test_framework.sprout.client import SproutClient
 from cfme.utils import conf
+from cfme.utils import periodic_call
 from cfme.utils.log import logger
 
 
@@ -38,7 +39,7 @@ def sprout_appliances(
         config: pytestconfig object to lookup sprout_user_key
         count: Number of appliances
         preconfigured: True if the appliance should be already configured, False otherwise
-        lease_time: Lease time in minutes (3 hours by default)
+        lease_time: Lease time in minutes (2 hours by default)
         stream: defaults to appliance stream
         provider_type: no default, sprout chooses, string type otherwise
         version: defaults to appliance version, string type otherwise
@@ -71,7 +72,9 @@ def sprout_appliances(
             logger.info("Appliance update finished on temp appliance...")
 
     try:
-        yield apps
+        with periodic_call(lease_time * 60 / 2.,
+                           sprout_client.prolong_pool, (request_id, lease_time)):
+            yield apps
     finally:
         sprout_client.destroy_pool(request_id)
 

--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -72,6 +72,7 @@ def sprout_appliances(
             logger.info("Appliance update finished on temp appliance...")
 
     try:
+        # Renew in half the lease time interval which is number of minutes.
         with periodic_call(lease_time * 60 / 2.,
                            sprout_client.prolong_pool, (request_id, lease_time)):
             yield apps

--- a/cfme/test_framework/sprout/client.py
+++ b/cfme/test_framework/sprout/client.py
@@ -141,3 +141,6 @@ class SproutClient(object):
 
     def destroy_pool(self, pool_id):
         self.call_method('destroy_pool', id=pool_id)
+
+    def prolong_pool(self, pool_id, minutes):
+        self.call_method('prolong_appliance_pool_lease', id=pool_id, minutes=minutes)

--- a/cfme/utils/__init__.py
+++ b/cfme/utils/__init__.py
@@ -2,6 +2,8 @@ import atexit
 import os
 import re
 import subprocess
+import threading
+from contextlib import contextmanager
 from functools import partial
 
 import diaper
@@ -387,3 +389,25 @@ class ParamClassName(object):
             return getattr(instance, self.instance_attr)
         else:
             return getattr(owner, self.class_attr)
+
+
+@contextmanager
+def periodic_call(period_seconds, call, args=None, kwargs=None):
+    timer = None
+    args = args or []
+    kwargs = kwargs or {}
+
+    def timer_event():
+        call(*args, **kwargs)
+        reschedule()
+
+    def reschedule():
+        nonlocal timer
+        timer = threading.Timer(period_seconds, timer_event)
+        timer.start()
+
+    reschedule()
+    try:
+        yield
+    finally:
+        timer.cancel()


### PR DESCRIPTION
## Purpose or Intent
Automatically prolong the sprout "pool" until fixture is destroyed.

This was sucessfully tested in https://github.com/ManageIQ/integration_tests/pull/9524
