### PR TITLE
[RFR] remove tests as not supported by object

### DIFF
--- a/cfme/tests/automate/custom_button/test_service_objects.py
+++ b/cfme/tests/automate/custom_button/test_service_objects.py
@@ -703,40 +703,6 @@ def test_custom_button_dialog_service_obj(
             )
 
 
-@pytest.mark.manual
-@pytest.mark.ignore_stream("5.10")
-@pytest.mark.meta(coverage=[1550002])
-def test_custom_button_open_url_service_obj(objects, button_group):
-    """ Test Open url functionality of custom button.
-
-    Polarion:
-        assignee: ndhandre
-        initialEstimate: 1/2h
-        caseimportance: high
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.11
-        casecomponent: CustomButton
-        tags: custom_button
-        testSteps:
-            1. Create ruby method for url functionality
-            2. Create custom button group with the Object type
-            3. Create a custom button with open_url option and respective method
-            4. Navigate to object Detail page
-            5. Execute custom button
-        expectedResults:
-            1.
-            2.
-            3.
-            4.
-            5. New tab should open with respective url
-
-    Bugzilla:
-        1550002
-    """
-    pass
-
-
 @pytest.fixture(params=["Service", "Provider"], scope="module")
 def unassigned_btn_setup(request, appliance, provider, gen_rest_service):
     if request.param == "Service":


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
