### PR TITLE
[1LP][RFR] Rewrite of test_infrastructure_hosts_crud for only single hosts

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -11,7 +11,6 @@ from widgetastic_patternfly import Dropdown
 
 from cfme.common import BaseLoggedInPage
 from cfme.common import TimelinesView
-from cfme.exceptions import displayed_not_implemented
 from cfme.utils.log import logger
 from cfme.utils.version import Version
 from cfme.utils.version import VersionPicker
@@ -302,8 +301,13 @@ class HostEditView(HostFormView):
     breadcrumb = BreadCrumb()
     save_button = Button("Save")
     reset_button = Button("Reset")
+    cancel_button = Button("Cancel")
 
-    is_displayed = displayed_not_implemented
+    @property
+    def is_displayed(self):
+        return (
+            self.logged_in_as_current_user and self.navigation.currently_selected == [
+                'Compute', 'Infrastructure', 'Hosts'] and self.title.text == 'Info/Settings')
 
 
 class HostsEditView(HostEditView):

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -92,14 +92,15 @@ class Host(
             super(Host.Credential, self).__init__(**kwargs)
             self.ipmi = kwargs.get('ipmi')
 
-    def update(self, updates, validate_credentials=False):
+    def update(self, updates, validate_credentials=False, from_details=False):
         """Updates a host in the UI. Better to use utils.update.update context manager than call
         this directly.
 
         Args:
            updates (dict): fields that are changing.
         """
-
+        if from_details:
+            view = navigate_to(self, "Details")
         view = navigate_to(self, "Edit")
         changed = view.fill({
             "name": updates.get("name"),

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -92,7 +92,7 @@ class Host(
             super(Host.Credential, self).__init__(**kwargs)
             self.ipmi = kwargs.get('ipmi')
 
-    def update(self, updates, validate_credentials=False, from_details=False):
+    def update(self, updates, validate_credentials=False, from_details=True):
         """Updates a host in the UI. Better to use utils.update.update context manager than call
         this directly.
 
@@ -100,10 +100,12 @@ class Host(
            updates (dict): fields that are changing.
         """
         if from_details:
-            view = navigate_to(self, "Details")
+            view = navigate_to(self, "Edit")
         else:
             view = navigate_to(self.parent, "All")
-        view = navigate_to(self, "Edit")
+            view.entities.get_entity(name=self.name, surf_pages=True).ensure_checked()
+            view.toolbar.configuration.item_select('Edit Selected items')
+            view = self.create_view(HostEditView)
         changed = view.fill({
             "name": updates.get("name"),
             "hostname": updates.get("hostname") or updates.get("ip_address"),

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -106,6 +106,7 @@ class Host(
             view.entities.get_entity(name=self.name, surf_pages=True).ensure_checked()
             view.toolbar.configuration.item_select('Edit Selected items')
             view = self.create_view(HostEditView)
+            assert view.is_displayed
         changed = view.fill({
             "name": updates.get("name"),
             "hostname": updates.get("hostname") or updates.get("ip_address"),

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -101,6 +101,8 @@ class Host(
         """
         if from_details:
             view = navigate_to(self, "Details")
+        else:
+            view = navigate_to(self.parent, "All")
         view = navigate_to(self, "Edit")
         changed = view.fill({
             "name": updates.get("name"),

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -2,6 +2,7 @@ import random
 import socket
 
 import pytest
+from datetime import datetime
 from wait_for import TimedOutError
 from widgetastic.exceptions import UnexpectedAlertPresentException
 
@@ -540,10 +541,9 @@ def test_add_ipmi_refresh(appliance, setup_provider):
     view = navigate_to(host, "Edit")
     assert view.ipmi_address.read() == ipmi_address
 
-from datetime import datetime
 
 @test_requirements.infra_hosts
-@pytest.mark.parametrize("num_hosts", [1,])
+@pytest.mark.parametrize("num_hosts", [1, ])
 def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider, num_hosts):
     """
     Polarion:
@@ -635,4 +635,3 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     host_view.flash.assert_success_message(f'Delete initiated for 1 Hosts / Nodes from the CFME '
                                            f'Database')
     # TODO add appliance host cases
-

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -551,8 +551,6 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
         casecomponent: Infra
         caseimportance: low
         initialEstimate: 1/6h
-    Bugzilla:
-        1634794
     """
     # edit host from provider hosts view
     my_slice = slice(0, num_hosts, None)

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -541,7 +541,7 @@ def test_add_ipmi_refresh(appliance, setup_provider):
 
 @test_requirements.infra_hosts
 @pytest.mark.parametrize("crud_action", ['edit_from_hosts', 'edit_from_details', 'remove'])
-def test_infrastructure_hosts_crud(appliance, setup_provider, provider, crud_action):
+def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
     """
     Polarion:
         assignee: prichard
@@ -549,14 +549,11 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, provider, crud_act
         caseimportance: low
         initialEstimate: 1/6h
     """
-    from cfme.utils.update import update
-
     host = appliance.collections.hosts.all()[0]
     if crud_action != 'remove':
         stamp = fauxfactory.gen_alphanumeric()
         new_custom_id = f'Edit host data. {stamp}'
 
-        # with update(host, from_details=lambda crud_action: crud_action=='edit_from_details'):
         with update(host, from_details=(crud_action == 'edit_from_details')):
             host.custom_ident = new_custom_id
 

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -553,10 +553,6 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
         initialEstimate: 1/6h
     Bugzilla:
         1634794
-
-    Just use multiple asserts.
-    Can't create, so start edit but nav away, update, cancel update, and delete. ?reset cases?
-    edit from details page? ****This is where we end up after an edit or cancel?
     """
     # edit host from provider hosts view
     my_slice = slice(0, num_hosts, None)
@@ -577,7 +573,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     custom_id = host_view.entities.summary("Properties").get_text_of("Custom Identifier")
     assert custom_id == edit_string
     # edit host from host detail view
-    hosts_view.toolbar.configuration.item_select('Edit This item',
+    hosts_view.toolbar.configuration.item_select('Edit this item',
                                                  handle_alert=False)
     edit_view = provider.create_view(HostEditView)
     stamp = datetime.now()
@@ -633,12 +629,10 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     # delete
     hosts_view = navigate_to(provider.collections.hosts, "All")
     for h in hosts_view.entities.get_all(slice=my_slice):
-        # note the host name so I can verify the deletion.
         h.ensure_checked()
     hosts_view.toolbar.configuration.item_select('Remove items from Inventory',
                                                  handle_alert=True)
-    host_view.flash.assert_success_message(f'Delete initiated for 1 Host / Node from the CFME '
+    host_view.flash.assert_success_message(f'Delete initiated for 1 Hosts / Nodes from the CFME '
                                            f'Database')
-    # TODO create and check displayed view.
-    # TODO verify host is deleted and not shown in view. and number of hosts has decremented.
     # TODO add appliance host cases
+

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -2,6 +2,7 @@ import random
 import socket
 from datetime import datetime
 
+import fauxfactory
 import pytest
 from wait_for import TimedOutError
 from widgetastic.exceptions import UnexpectedAlertPresentException
@@ -561,7 +562,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     hosts_view.toolbar.configuration.item_select('Edit Selected items',
                                                 handle_alert=False)
     edit_view = provider.create_view(HostEditView)
-    stamp = datetime.now()
+    stamp = fauxfactory.gen_alphanumeric()
     edit_string = f'Edit host data. {stamp}'
     edit_view.custom_ident.fill(edit_string)
     edit_view.save_button.click()

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -558,7 +558,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     Can't create, so start edit but nav away, update, cancel update, and delete. ?reset cases?
     edit from details page? ****This is where we end up after an edit or cancel?
     """
-    # edit host
+    # edit host from provider hosts view
     my_slice = slice(0, num_hosts, None)
     hosts_view = navigate_to(provider.collections.hosts, "All")
     for h in hosts_view.entities.get_all(slice=my_slice):
@@ -566,6 +566,19 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
         h.ensure_checked()
     hosts_view.toolbar.configuration.item_select('Edit Selected items',
                                                 handle_alert=False)
+    edit_view = provider.create_view(HostEditView)
+    stamp = datetime.now()
+    edit_string = f'Edit host data. {stamp}'
+    edit_view.custom_ident.fill(edit_string)
+    edit_view.save_button.click()
+    # now verify the change is displayed.
+    host_view = provider.create_view(HostDetailsView)
+    host_view.flash.assert_success_message(f'Host / Node "{hostname}" was saved')
+    custom_id = host_view.entities.summary("Properties").get_text_of("Custom Identifier")
+    assert custom_id == edit_string
+    # edit host from host detail view
+    hosts_view.toolbar.configuration.item_select('Edit This item',
+                                                 handle_alert=False)
     edit_view = provider.create_view(HostEditView)
     stamp = datetime.now()
     edit_string = f'Edit host data. {stamp}'
@@ -606,7 +619,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     reset_string = f'Edit host data. {stamp}'
     edit_view.custom_ident.fill(reset_string)
     edit_view.reset_button.click()
-    # TODO check warning flash banner "All changes have been reset"
+    edit_view.flash.assert_message(f'All changes have been reset')
     # update after reset and save
     stamp = datetime.now()
     reset_edit_string = f'Reset host data. {stamp}'
@@ -628,3 +641,4 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
                                            f'Database')
     # TODO create and check displayed view.
     # TODO verify host is deleted and not shown in view. and number of hosts has decremented.
+    # TODO add appliance host cases

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -1,17 +1,17 @@
 import random
 import socket
+from datetime import datetime
 
 import pytest
-from datetime import datetime
 from wait_for import TimedOutError
 from widgetastic.exceptions import UnexpectedAlertPresentException
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
+from cfme.common.host_views import HostDetailsView
+from cfme.common.host_views import HostEditView
 from cfme.common.host_views import HostsCompareView
 from cfme.common.host_views import HostsEditView
-from cfme.common.host_views import ProviderHostsCompareView
-from cfme.common.host_views import HostsEditView, HostEditView, HostsView, HostDetailsView
 from cfme.common.provider_views import InfraProviderDetailsView
 from cfme.common.provider_views import InfraProvidersView
 from cfme.common.provider_views import ProviderNodesView

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -1,11 +1,9 @@
 import random
 import socket
-from datetime import datetime
 
 import fauxfactory
 import pytest
 from wait_for import TimedOutError
-from widgetastic.exceptions import UnexpectedAlertPresentException
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
@@ -13,8 +11,8 @@ from cfme.common.host_views import HostDetailsView
 from cfme.common.host_views import HostEditView
 from cfme.common.host_views import HostsCompareView
 from cfme.common.host_views import HostsEditView
+from cfme.common.host_views import ProviderHostsCompareView
 from cfme.common.provider_views import InfraProviderDetailsView
-from cfme.common.provider_views import InfraProvidersView
 from cfme.common.provider_views import ProviderNodesView
 from cfme.fixtures.provider import setup_or_skip
 from cfme.infrastructure.provider import InfraProvider
@@ -575,7 +573,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     hosts_view.toolbar.configuration.item_select('Edit this item',
                                                  handle_alert=False)
     edit_view = provider.create_view(HostEditView)
-    stamp = datetime.now()
+    stamp = fauxfactory.gen_alphanumeric()
     edit_string = f'Edit host data. {stamp}'
     edit_view.custom_ident.fill(edit_string)
     edit_view.save_button.click()
@@ -592,7 +590,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     hosts_view.toolbar.configuration.item_select('Edit Selected items',
                                                  handle_alert=False)
     edit_view = provider.create_view(HostEditView)
-    stamp = datetime.now()
+    stamp = fauxfactory.gen_alphanumeric()
     cancel_string = f'Edit host data. {stamp}'
     edit_view.custom_ident.fill(cancel_string)
     edit_view.cancel_button.click()
@@ -610,13 +608,13 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     hosts_view.toolbar.configuration.item_select('Edit Selected items',
                                                  handle_alert=False)
     edit_view = provider.create_view(HostEditView)
-    stamp = datetime.now()
+    stamp = fauxfactory.gen_alphanumeric()
     reset_string = f'Edit host data. {stamp}'
     edit_view.custom_ident.fill(reset_string)
     edit_view.reset_button.click()
     edit_view.flash.assert_message(f'All changes have been reset')
     # update after reset and save
-    stamp = datetime.now()
+    stamp = fauxfactory.gen_alphanumeric()
     reset_edit_string = f'Reset host data. {stamp}'
     edit_view.custom_ident.fill(reset_edit_string)
     edit_view.save_button.click()


### PR DESCRIPTION
## Purpose or Intent

- __Updating tests__ for infra hosts CRUD to make coverage more intuitive and manageable.

### PRT Run

{{ pytest: --use-provider complete --long-running cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_crud }}