### PR TITLE
[WIPTEST] Add new testcase test_incomplete_edit_multi_infrastructure_hosts

### DIFF
--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -7,8 +7,8 @@ from widgetastic.exceptions import UnexpectedAlertPresentException
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
-from cfme.common.host_views import HostsCompareView
 from cfme.common.host_views import HostDetailsView
+from cfme.common.host_views import HostsCompareView
 from cfme.common.host_views import HostsEditView
 from cfme.common.provider_views import InfraProviderDetailsView
 from cfme.common.provider_views import InfraProvidersView

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -560,3 +560,33 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
     except UnexpectedAlertPresentException:
         pytest.fail("Abandon changes alert displayed, but no changes made.")
     # TODO add additional crud functionality.
+
+
+@test_requirements.infra_hosts
+@pytest.mark.parametrize("num_hosts", [2,])
+@pytest.mark.meta(blockers=[BZ(1634794, forced_streams=["5.10"])], automates=[1634794])
+def test_incomplete_edit_multi_infrastructure_hosts(appliance, setup_provider_min_hosts,
+                                                     provider, num_hosts):
+    """
+    Polarion:
+        assignee: prichard
+        casecomponent: Infra
+        caseimportance: low
+        initialEstimate: 1/6h
+    Bugzilla:
+        1634794
+    """
+    # select 2 hosts, click edit button, but nav away before any changes made
+    my_slice = slice(0, num_hosts, None)
+    hosts_view = navigate_to(provider.collections.hosts, "All")
+    for h in hosts_view.entities.get_all(slice=my_slice):
+        h.ensure_checked()
+    hosts_view.toolbar.configuration.item_select('Edit Selected items',
+                                                handle_alert=False)
+    try:
+        hosts_view.navigation.select('Compute', 'Infrastructure', 'Providers', handle_alert=False)
+        final_view = provider.create_view(InfraProvidersView)
+        assert final_view.is_displayed
+    except UnexpectedAlertPresentException:
+        pytest.fail("Abandon changes alert displayed, but no changes made.")
+    # TODO multi edit and cancel (This works).

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -597,7 +597,6 @@ def test_incomplete_edit_multi_infrastructure_hosts(appliance, setup_provider_mi
         h.ensure_checked()
     hosts_view.toolbar.configuration.item_select('Edit Selected items',
                                                 handle_alert=False)
-                                                
     edit_view = provider.create_view(HostsEditView)
     edit_string = f'usertest.'
     edit_view.endpoints.default.username.fill(edit_string)
@@ -605,6 +604,5 @@ def test_incomplete_edit_multi_infrastructure_hosts(appliance, setup_provider_mi
     # now verify the change is displayed.
     host_view = provider.create_view(HostDetailsView)
     if provider.type == 'rhevm':
-        host_view.flash.assert_success_message(f'Edit of credentials for selected Hosts / Nodes was '
-                                           f'cancelled by the user')
-
+        host_view.flash.assert_success_message(f'Edit of credentials for selected Hosts / Nodes '
+                                               f'was cancelled by the user')

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -563,10 +563,10 @@ def test_infrastructure_hosts_crud(appliance, setup_provider_min_hosts, provider
 
 
 @test_requirements.infra_hosts
-@pytest.mark.parametrize("num_hosts", [2,])
+@pytest.mark.parametrize("num_hosts", [2, ])
 @pytest.mark.meta(blockers=[BZ(1634794, forced_streams=["5.10"])], automates=[1634794])
 def test_incomplete_edit_multi_infrastructure_hosts(appliance, setup_provider_min_hosts,
-                                                     provider, num_hosts):
+                                                    provider, num_hosts):
     """
     Polarion:
         assignee: prichard


### PR DESCRIPTION
## Purpose or Intent

- __Adding and moving tests__ for Infra Hosts to cover incomplete multiple host edits.  There have been BZs in this area.

### PRT Run

{{ pytest: --use-provider complete --long-running cfme/tests/infrastructure/test_host.py::test_incomplete_edit_multi_infrastructure_hosts }}