### PR TITLE
[1LP][RFR] dismiss_alerts closes vmrc related alerts

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -280,8 +280,14 @@ class BaseVM(
 
         view = navigate_to(self, 'Details')
 
-        # Click console button given by type
-        view.toolbar.access.item_select(console, handle_alert=invokes_alert)
+        # dismiss_any_alerts() call closed subsequent alerts needed for vmrc
+        # below code is needed to fix such issue
+        try:
+            view.browser.IGNORE_SUBSEQUENT_ALERTS = True
+            # Click console button given by type
+            view.toolbar.access.item_select(console, handle_alert=invokes_alert)
+        finally:
+            view.browser.IGNORE_SUBSEQUENT_ALERTS = False
         self.vm_console
 
     def open_details(self, properties=None):

--- a/cfme/utils/appliance/implementations/common.py
+++ b/cfme/utils/appliance/implementations/common.py
@@ -9,6 +9,7 @@ from cfme.utils.wait import wait_for
 
 
 class HandleModalsMixin(object):
+    IGNORE_SUBSEQUENT_ALERTS = False
     @property
     def _modal_alert(self):
         return Modal(parent=self)
@@ -92,7 +93,8 @@ class HandleModalsMixin(object):
                 self.logger.info('  accepting')
                 popup.accept()
             # Should any problematic "double" alerts appear here, we don't care, just blow'em away.
-            self.dismiss_any_alerts()
+            if not self.IGNORE_SUBSEQUENT_ALERTS:
+                self.dismiss_any_alerts()
             return True
         except TimedOutError:
             # we waited (or didn't), and there was no alert


### PR DESCRIPTION
it should be disabled during vmrc tests. these changes will be tested by @kedark3 's PR #9703 .

