### PR TITLE
[1LP][RFR] Fix subscription tests

### DIFF
--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -6,6 +6,7 @@ from navmazing import NavigateToSibling
 from widgetastic.exceptions import RowNotFound
 from widgetastic.exceptions import UnexpectedAlertPresentException
 from widgetastic.widget import Checkbox
+from widgetastic.widget import Select
 from widgetastic.widget import Text
 from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import BootstrapSwitch
@@ -553,10 +554,8 @@ class RedHatUpdatesEditView(RegionView):
     proxy_url = Input(id='proxy_address')
     proxy_username = Input(id='proxy_userid')
     proxy_password = Input(id='proxy_password')
-    proxy_password_verify = Input(id='proxy_password2')
     username = Input(id='customer_userid')
     password = Input(id='customer_password')
-    password_verify = Input(id='customer_password2')
 
     repo_default_name = Button(id='repo_default_name')
     rhn_default_url = Button(id='rhn_default_button')
@@ -565,6 +564,7 @@ class RedHatUpdatesEditView(RegionView):
     reset_button = Button('Reset')
     save_button = Button('Save')
     cancel_button = Button('Cancel')
+    organization = Select(id='customer_org')
 
     @property
     def is_displayed(self):
@@ -583,15 +583,12 @@ class RedHatUpdates(Navigatable, Pretty):
         url: Service server URL address.
         username: Username to use for registration.
         password: Password to use for registration.
-        password_verify: 2nd entry of password for verification. Same as 'password' if None.
         repo_name: Repository/channel to enable.
         organization: Organization (sat6 only).
         use_proxy: `True` if proxy should be used, `False` otherwise (default `False`).
         proxy_url: Address of the proxy server.
         proxy_username: Username for the proxy server.
         proxy_password: Password for the proxy server.
-        proxy_password_verify: 2nd entry of proxy server password for verification.
-            Same as 'proxy_password' if None.
         set_default_rhsm_address: Click the Default button connected to
             the RHSM (only) address if `True`
         set_default_repository: Click the Default button connected to the repo/channel if `True`
@@ -608,23 +605,20 @@ class RedHatUpdates(Navigatable, Pretty):
         'sat6': 'Red Hat Satellite 6'
     }
 
-    def __init__(self, service, url, username, password, password_verify=None, repo_name=None,
+    def __init__(self, service, url, username, password, repo_name=None,
                  organization=None, use_proxy=False, proxy_url=None, proxy_username=None,
-                 proxy_password=None, proxy_password_verify=None,
-                 set_default_rhsm_address=False,
+                 proxy_password=None, set_default_rhsm_address=False,
                  set_default_repository=False, appliance=None):
         self.service = service
         self.url = url
         self.username = username
         self.password = password
-        self.password_verify = password_verify
         self.repo_name = repo_name
         self.organization = organization
         self.use_proxy = use_proxy
         self.proxy_url = proxy_url
         self.proxy_username = proxy_username
         self.proxy_password = proxy_password
-        self.proxy_password_verify = proxy_password_verify
         self.set_default_rhsm_address = set_default_rhsm_address
         self.set_default_repository = set_default_repository
         Navigatable.__init__(self, appliance=appliance)
@@ -642,22 +636,17 @@ class RedHatUpdates(Navigatable, Pretty):
             self.service)
         service_value = self.service_types[self.service]
 
-        password_verify = self.password_verify or self.password
-        proxy_password_verify = self.proxy_password_verify or self.proxy_password
-
         view = navigate_to(self, 'Edit')
         details = {
             'register_to': service_value,
             'url': self.url,
             'username': self.username,
             'password': self.password,
-            'password_verify': password_verify,
             'repo_name': self.repo_name,
             'use_proxy': self.use_proxy,
             'proxy_url': self.proxy_url,
             'proxy_username': self.proxy_username,
             'proxy_password': self.proxy_password,
-            'proxy_password_verify': proxy_password_verify
         }
 
         view.fill(details)
@@ -670,6 +659,9 @@ class RedHatUpdates(Navigatable, Pretty):
 
         if validate:
             view.validate_button.click()
+
+        if self.organization:
+            view.fill({'organization': self.organization})
 
         if cancel:
             view.cancel_button.click()

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from cfme import test_requirements
@@ -136,6 +134,7 @@ def test_rh_creds_validation(reg_method, reg_data, proxy_url, proxy_creds):
 
 @pytest.mark.rhel_testing
 @pytest.mark.ignore_stream("upstream")
+@pytest.mark.meta(automates=[1532201])
 def test_rh_registration(
         temp_appliance_preconfig_funcscope, request, reg_method, reg_data, proxy_url, proxy_creds):
     """ Tests whether an appliance can be registered against RHSM and SAT6
@@ -145,6 +144,9 @@ def test_rh_registration(
         caseimportance: high
         casecomponent: Configuration
         initialEstimate: 1/12h
+
+    Bugzilla:
+        1532201
     """
     repo = reg_data.get('enable_repo')
     if not repo:
@@ -181,10 +183,8 @@ def test_rh_registration(
 
         used_repo_or_channel = red_hat_updates.get_repository_names()
 
-        # FIXME workaround BZ 1532201 (An exception to the rule as it waits for backend config)
-        time.sleep(15)
-        request.addfinalizer(appliance.unregister)
         red_hat_updates.register_appliances()  # Register all
+        request.addfinalizer(appliance.unregister)
 
         wait_for(
             func=red_hat_updates.is_registering,

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -136,7 +136,8 @@ def test_rh_creds_validation(reg_method, reg_data, proxy_url, proxy_creds):
 
 @pytest.mark.rhel_testing
 @pytest.mark.ignore_stream("upstream")
-def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, proxy_creds):
+def test_rh_registration(
+        temp_appliance_preconfig_funcscope, request, reg_method, reg_data, proxy_url, proxy_creds):
     """ Tests whether an appliance can be registered against RHSM and SAT6
 
     Polarion:
@@ -160,42 +161,45 @@ def test_rh_registration(appliance, request, reg_method, reg_data, proxy_url, pr
         proxy_url = None
         proxy_username = None
         proxy_password = None
-    red_hat_updates = RedHatUpdates(
-        service=reg_method,
-        url=reg_data['url'],
-        username=conf.credentials[reg_method]['username'],
-        password=conf.credentials[reg_method]['password'],
-        repo_name=repo,
-        organization=reg_data.get('organization'),
-        use_proxy=use_proxy,
-        proxy_url=proxy_url,
-        proxy_username=proxy_username,
-        proxy_password=proxy_password,
-        set_default_repository=set_default_repo
-    )
-    red_hat_updates.update_registration(validate=False if reg_method != 'sat6' else True)
 
-    used_repo_or_channel = red_hat_updates.get_repository_names()
+    with temp_appliance_preconfig_funcscope as appliance:
+        red_hat_updates = RedHatUpdates(
+            service=reg_method,
+            url=reg_data['url'],
+            username=conf.credentials[reg_method]['username'],
+            password=conf.credentials[reg_method]['password'],
+            repo_name=repo,
+            organization=reg_data.get('organization'),
+            use_proxy=use_proxy,
+            proxy_url=proxy_url,
+            proxy_username=proxy_username,
+            proxy_password=proxy_password,
+            set_default_repository=set_default_repo
+        )
 
-    # FIXME workaround BZ 1532201 (An exception to the rule as it waits for backend config)
-    time.sleep(15)
-    request.addfinalizer(appliance.unregister)
-    red_hat_updates.register_appliances()  # Register all
+        red_hat_updates.update_registration(validate=False if reg_method != 'sat6' else True)
 
-    wait_for(
-        func=red_hat_updates.is_registering,
-        func_args=[appliance.server.name],
-        delay=10,
-        num_sec=240,
-        fail_func=red_hat_updates.refresh
-    )
+        used_repo_or_channel = red_hat_updates.get_repository_names()
 
-    wait_for(
-        func=appliance.is_registration_complete,
-        func_args=[used_repo_or_channel],
-        delay=20,
-        num_sec=400
-    )
+        # FIXME workaround BZ 1532201 (An exception to the rule as it waits for backend config)
+        time.sleep(15)
+        request.addfinalizer(appliance.unregister)
+        red_hat_updates.register_appliances()  # Register all
+
+        wait_for(
+            func=red_hat_updates.is_registering,
+            func_args=[appliance.server.name],
+            delay=10,
+            num_sec=240,
+            fail_func=red_hat_updates.refresh
+        )
+
+        wait_for(
+            func=appliance.is_registration_complete,
+            func_args=[used_repo_or_channel],
+            delay=20,
+            num_sec=400
+        )
 
 
 @pytest.mark.rhel_testing

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -242,12 +242,7 @@ class IPAppliance(object):
     def is_registration_complete(self, used_repo_or_channel):
         """ Checks if an appliance has the correct repos enabled with RHSM or SAT6 """
         result = self.ssh_client.run_command('yum repolist enabled')
-        # Check that the specified (or default) repo (can be multiple, separated by a space)
-        # is enabled and that there are packages available
-        for repo in used_repo_or_channel.split(' '):
-            if (repo not in result.output) or (not re.search(r'repolist: [^0]', result.output)):
-                return False
-        return True
+        return all(repo in result.output for repo in used_repo_or_channel.split(' '))
 
     @property
     def default_zone(self):


### PR DESCRIPTION
## Purpose or Intent
Fix tests of appliance subscriptions
## Needs:
https://CFME_GITLAB/cfme-qe/cfme-qe-yamls/merge_requests/876

## Expected tests results:
On CFME 5.11:
```
    cfme/tests/configure/test_register_appliance.py::test_rh_creds_validation[rhsm-proxy_off] PASSED
    cfme/tests/configure/test_register_appliance.py::test_rh_creds_validation[sat6-proxy_off] PASSED
    cfme/tests/configure/test_register_appliance.py::test_rh_registration[rhsm-proxy_off] PASSED
    cfme/tests/configure/test_register_appliance.py::test_rh_registration[sat6-proxy_off] FAILED
    cfme/tests/configure/test_register_appliance.py::test_rhsm_registration_check_repo_names PASSED
    cfme/tests/configure/test_register_appliance.py::test_rh_updates FAILED
```    
On CFME 5.10
```
    cfme/tests/configure/test_register_appliance.py::test_rh_creds_validation[rhsm-proxy_off] PASSED
    cfme/tests/configure/test_register_appliance.py::test_rh_creds_validation[sat6-proxy_off] PASSED
    cfme/tests/configure/test_register_appliance.py::test_rh_registration[rhsm-proxy_off] PASSED
    cfme/tests/configure/test_register_appliance.py::test_rh_registration[sat6-proxy_off] PASSED
    cfme/tests/configure/test_register_appliance.py::test_rhsm_registration_check_repo_names PASSED
    cfme/tests/configure/test_register_appliance.py::test_rh_updates FAILED
```

The sat6 test fails because the CFME 5.11 is not in our satellite yet
The test_rh_updates fails because of the test is broken and this PR is not focussed on fixing it.