### PR TITLE
[1LP][RFR] Automate dynamic dialog execution

### DIFF
--- a/cfme/services/service_catalogs/ui.py
+++ b/cfme/services/service_catalogs/ui.py
@@ -94,8 +94,11 @@ class OrderServiceCatalogView(OrderForm):
 
 
 @MiqImplementationContext.external_for(ServiceCatalogs.order, ViaUI)
-def order(self):
-    view = navigate_to(self, 'Order')
+def order(self, **kwargs):
+    # If dynamic dialog attached then it will take execution time as per respected method.
+    wait_for_view = kwargs.get("wait_for_view", 10)
+
+    view = navigate_to(self, 'Order', wait_for_view=wait_for_view)
     if self.stack_data:
         view.fill(self.stack_data)
     if self.dialog_values:

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -253,7 +253,7 @@ def test_retire_owned_service(request, appliance, context, user_self_service_rol
             )
 
 
-@pytest.mark.customer_stories
+@test_requirements.customer_stories
 @pytest.mark.customer_scenario
 @pytest.mark.meta(automates=[1695804])
 @pytest.mark.tier(2)

--- a/cfme/tests/ssui/test_ssui_myservice.py
+++ b/cfme/tests/ssui/test_ssui_myservice.py
@@ -1,4 +1,8 @@
 """Test Service Details page functionality."""
+from textwrap import dedent
+from timeit import timeit
+
+import fauxfactory
 import pytest
 
 from cfme import test_requirements
@@ -14,6 +18,8 @@ from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaSSUI
 from cfme.utils.appliance import ViaUI
 from cfme.utils.appliance.implementations.ssui import navigate_to as ssui_nav
+from cfme.utils.appliance.implementations.ui import navigate_to as ui_nav
+from cfme.utils.log_validator import LogValidator
 from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
 
@@ -247,11 +253,11 @@ def test_retire_owned_service(request, appliance, context, user_self_service_rol
             )
 
 
-@pytest.mark.meta(coverage=[1695804])
-@pytest.mark.manual
-@pytest.mark.ignore_stream('5.10')
+@pytest.mark.customer_stories
+@pytest.mark.customer_scenario
+@pytest.mark.meta(automates=[1695804])
 @pytest.mark.tier(2)
-def test_service_dialog_check_on_ssui():
+def test_service_dynamic_dialog_execution(appliance, request, custom_instance):
     """
     Bugzilla:
         1695804
@@ -261,21 +267,111 @@ def test_service_dialog_check_on_ssui():
         casecomponent: SelfServiceUI
         initialEstimate: 1/6h
         testSteps:
-            1. Import datastore and import dialog
-            2. Add catalog item with above dialog
-            3. Navigate to order page of service
+            1. Create custom instance and method
+            2. Create dynamic dialog with above method
+            3. Create Catalog and catalog item having dynamic dialog
             4. Order the service
-            5. Login into SSUI Portal
-            6. Go MyService and click on provisioned service
+            5. Access service with UI, SSUI, REST
         expectedResults:
             1.
             2.
             3.
             4.
-            5.
-            6. Automation code shouldn't load when opening a service
+            5. In all context, when opening a service automation code should not run
     """
-    pass
+
+    # Create custom instance with ruby method for dynamic dialog
+    code = dedent(
+        """
+        sleep 20 # wait 20 seconds
+        $evm.root['default_value'] = Time.now.to_s
+        exit MIQ_OK
+        """
+    )
+    instance = custom_instance(ruby_code=code)
+    assert instance.exists
+    matched_patterns = [f"System/Request/{instance.fields['meth1']['value']}", "MIQ_OK"]
+
+    # Create dynamic dialog and entry point as ruby method
+    service_dialog = appliance.collections.service_dialogs
+    dialog = fauxfactory.gen_alphanumeric(12, start="dialog_")
+    ele_name = fauxfactory.gen_alphanumeric(start="ele_")
+
+    element_data = {
+        "element_information": {
+            "ele_label": fauxfactory.gen_alphanumeric(15, start="ele_label_"),
+            "ele_name": ele_name,
+            "ele_desc": fauxfactory.gen_alphanumeric(15, start="ele_desc_"),
+            "dynamic_chkbox": True,
+            "choose_type": "Text Box",
+        },
+        "options": {"entry_point": instance.tree_path},
+    }
+    dialog = service_dialog.create(label=dialog, description="my dialog")
+    tab = dialog.tabs.create(
+        tab_label=fauxfactory.gen_alphanumeric(start="tab_"), tab_desc="my tab desc"
+    )
+    box = tab.boxes.create(
+        box_label=fauxfactory.gen_alphanumeric(start="box_"), box_desc="my box desc"
+    )
+    box.elements.create(element_data=[element_data])
+    request.addfinalizer(dialog.delete_if_exists)
+
+    # Create catalog and catalog item with dialog
+    catalog = appliance.collections.catalogs.create(
+        name=fauxfactory.gen_alphanumeric(start="cat_"),
+        description=fauxfactory.gen_alphanumeric(15, start="cat_desc_"),
+    )
+    assert catalog.exists
+    request.addfinalizer(catalog.delete_if_exists)
+
+    catalog_item = appliance.collections.catalog_items.create(
+        appliance.collections.catalog_items.GENERIC,
+        name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
+        description=fauxfactory.gen_alphanumeric(20, start="cat_item_desc_"),
+        display_in=True,
+        catalog=catalog,
+        dialog=dialog,
+    )
+    assert catalog_item.exists
+    request.addfinalizer(catalog_item.delete_if_exists)
+
+    # Order catalog item; check for method execution in log
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+
+    with LogValidator(
+        "/var/www/miq/vmdb/log/automation.log", matched_patterns=matched_patterns
+    ).waiting(timeout=60):
+        # The expected time to land on dialog page: 20+ sec (script has 20 sec sleep)
+        provision_request = service_catalogs.order(wait_for_view=30)
+
+    provision_request.wait_for_request()
+    service = MyService(appliance, catalog_item.name)
+
+    @request.addfinalizer
+    def _clean_request_service():
+        if provision_request.exists:
+            provision_request.remove_request(method="rest")
+        if service.exists:
+            service.delete()
+
+    # Check service access with UI and SSUI should not run automate method
+    for context in [ViaUI, ViaSSUI]:
+        with appliance.context.use(context):
+            # lets stay on Service All page before click on service
+            navigate_to = ui_nav if context is ViaUI else ssui_nav
+            navigate_to(service, "All")
+
+            with LogValidator(
+                "/var/www/miq/vmdb/log/automation.log", failure_patterns=matched_patterns
+            ).waiting(timeout=60):
+                assert timeit(lambda: navigate_to(service, "Details"), number=1) < 20
+
+    # The API call should not takes 20 seconds (sleep time). i.e it should not call automate method.
+    with LogValidator(
+        "/var/www/miq/vmdb/log/automation.log", failure_patterns=matched_patterns
+    ).waiting(timeout=60):
+        assert timeit(lambda: service.rest_api_entity, number=1) < 2
 
 
 @pytest.mark.meta(automates=[1743734])


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- Created customer story based on BZ-1695804
- **Here I don't want to use fixtures for setup :D. Just end-end test**
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/ssui/test_ssui_myservice.py::test_service_dynamic_dialog_execution --long-running}}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
