### PR TITLE
[1LP][RFR] Automate test to verify key pair visibility in child tenants

### DIFF
--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -201,7 +201,7 @@ class KeyPair(BaseEntity, Taggable):
         if not fill_result:
             view.form.cancel_button.click()
             view = self.create_view(navigator.get_class(self, 'Details').VIEW)
-            view.flash.assert_success_message('Set Ownership was cancelled by the user')
+            view.flash.assert_no_error()
             return
 
         # Only if the form changed

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -185,7 +185,7 @@ class KeyPair(BaseEntity, Taggable):
         view.toolbar.configuration.item_select('Download private key')
         view.flash.assert_no_error()
 
-    def set_ownership(self, owner=None, group=None, click_cancel=False, click_reset=False):
+    def set_ownership(self, owner=None, group=None, cancel=False, reset=False):
         """Set instance ownership
 
         Args:
@@ -205,13 +205,13 @@ class KeyPair(BaseEntity, Taggable):
             return
 
         # Only if the form changed
-        if click_reset:
+        if reset:
             view.form.reset_button.click()
             view.flash.assert_message('All changes have been reset', 'warning')
             # Cancel after reset
             assert view.form.is_displayed
             view.form.cancel_button.click()
-        elif click_cancel:
+        elif cancel:
             view.form.cancel_button.click()
             view.flash.assert_success_message('Set Ownership was cancelled by the user')
         else:

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -185,7 +185,7 @@ class KeyPair(BaseEntity, Taggable):
         view.toolbar.configuration.item_select('Download private key')
         view.flash.assert_no_error()
 
-    def set_ownership(self, user=None, group=None, click_cancel=False, click_reset=False):
+    def set_ownership(self, owner=None, group=None, click_cancel=False, click_reset=False):
         """Set instance ownership
 
         Args:
@@ -196,8 +196,8 @@ class KeyPair(BaseEntity, Taggable):
         """
         view = navigate_to(self, 'SetOwnership', wait_for_view=0)
         fill_result = view.form.fill({
-            'user_name': user.name if user else None,
-            'group_name': group.description if group else group})
+            'user_name': owner if owner else None,
+            'group_name': group if group else None})
         if not fill_result:
             view.form.cancel_button.click()
             view = self.create_view(navigator.get_class(self, 'Details').VIEW)
@@ -218,8 +218,7 @@ class KeyPair(BaseEntity, Taggable):
             # save the form
             view.form.save_button.click()
             view = self.create_view(navigator.get_class(self, 'Details').VIEW)
-            view.flash.assert_success_message('Ownership saved for selected {}'
-                                              .format(self.name))
+            view.flash.assert_success_message('Ownership saved for selected Key Pair')
 
 
 @attr.s

--- a/cfme/cloud/keypairs.py
+++ b/cfme/cloud/keypairs.py
@@ -186,7 +186,7 @@ class KeyPair(BaseEntity, Taggable):
         view.flash.assert_no_error()
 
     def set_ownership(self, owner=None, group=None, cancel=False, reset=False):
-        """Set instance ownership
+        """Set keypair ownership
 
         Args:
             user (User): user object for ownership
@@ -196,8 +196,8 @@ class KeyPair(BaseEntity, Taggable):
         """
         view = navigate_to(self, 'SetOwnership', wait_for_view=0)
         fill_result = view.form.fill({
-            'user_name': owner if owner else None,
-            'group_name': group if group else None})
+            'user_name': owner.name if owner else None,
+            'group_name': group.description if group else None})
         if not fill_result:
             view.form.cancel_button.click()
             view = self.create_view(navigator.get_class(self, 'Details').VIEW)
@@ -213,12 +213,12 @@ class KeyPair(BaseEntity, Taggable):
             view.form.cancel_button.click()
         elif cancel:
             view.form.cancel_button.click()
-            view.flash.assert_success_message('Set Ownership was cancelled by the user')
+            view.flash.assert_no_error()
         else:
             # save the form
             view.form.save_button.click()
             view = self.create_view(navigator.get_class(self, 'Details').VIEW)
-            view.flash.assert_success_message('Ownership saved for selected Key Pair')
+            view.flash.assert_no_error()
 
 
 @attr.s

--- a/cfme/fixtures/multi_tenancy.py
+++ b/cfme/fixtures/multi_tenancy.py
@@ -10,7 +10,7 @@ from cfme.utils.update import update
 
 @pytest.fixture(scope='module')
 def child_tenant(appliance):
-    """Fixture to create a child tenant"""
+    """Fixture to create a child tenant with 'My Company' as its parent"""
     child_tenant = appliance.collections.tenants.create(
         name=fauxfactory.gen_alphanumeric(15, start="child_tenant_"),
         description='tenant description',

--- a/cfme/fixtures/multi_tenancy.py
+++ b/cfme/fixtures/multi_tenancy.py
@@ -54,7 +54,7 @@ def child_tenant_admin_user(appliance, request, child_tenant, tenant_role):
     tenant_admin_user = appliance.collections.users.create(
         name=fauxfactory.gen_alphanumeric(start='tenant_admin_user'),
         credential=credential,
-        email='xyz@redhat.com',
+        email=fauxfactory.gen_email(),
         groups=group,
         cost_center='Workload',
         value_assign='Database')

--- a/cfme/fixtures/multi_tenancy.py
+++ b/cfme/fixtures/multi_tenancy.py
@@ -1,0 +1,67 @@
+"""
+Fixtures for Multi Tenancy
+"""
+import fauxfactory
+import pytest
+
+from cfme.base.credential import Credential
+from cfme.utils.update import update
+
+
+def new_user(appliance, groups, name=None, credential=None):
+    name = name or fauxfactory.gen_alphanumeric(start="user_")
+    credential = credential or Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
+                    secret='redhat')
+
+    user = appliance.collections.users.create(
+        name=name,
+        credential=credential,
+        email='xyz@redhat.com',
+        groups=groups,
+        cost_center='Workload',
+        value_assign='Database')
+    return user
+
+
+@pytest.fixture(scope='module')
+def child_tenant(appliance):
+    child_tenant = appliance.collections.tenants.create(
+        name=fauxfactory.gen_alphanumeric(15, start="child_tenant_"),
+        description='tenant description',
+        parent=appliance.collections.tenants.get_root_tenant()
+    )
+    yield child_tenant
+    child_tenant.delete_if_exists()
+
+
+@pytest.fixture(scope='module')
+def tenant_role(appliance, request):
+    role = appliance.collections.roles.instantiate(name='EvmRole-tenant_administrator')
+    tenant_role = role.copy()
+
+    # Note: BZ 1278484 - tenant admin role has no permissions to create new roles
+    with update(tenant_role):
+        if appliance.version < '5.11':
+            tenant_role.product_features = [
+                (['Everything', 'Settings', 'Configuration', 'Settings'], True),
+                (['Everything', 'Compute', 'Clouds', 'Auth Key Pairs'], True)
+            ]
+        else:
+            tenant_role.product_features = [
+                (['Everything', 'Main Configuration', 'Settings'], True),
+                (['Everything', 'Compute', 'Clouds', 'Auth Key Pairs'], True)
+            ]
+    yield tenant_role
+    tenant_role.delete_if_exists()
+
+
+@pytest.fixture(scope='module')
+def new_tenant_admin(appliance, request, child_tenant, tenant_role):
+    group = appliance.collections.groups.create(
+        description=fauxfactory.gen_alphanumeric(15, start="tenant_grp_"), role=tenant_role.name,
+        tenant=f'My Company/{child_tenant.name}')
+
+    tenant_admin = new_user(appliance, group, name='tenant_admin_user')
+    yield tenant_admin
+    tenant_admin.delete_if_exists()
+    group.delete_if_exists()

--- a/cfme/fixtures/multi_tenancy.py
+++ b/cfme/fixtures/multi_tenancy.py
@@ -10,6 +10,7 @@ from cfme.utils.update import update
 
 @pytest.fixture(scope='module')
 def child_tenant(appliance):
+    """Fixture to create a child tenant"""
     child_tenant = appliance.collections.tenants.create(
         name=fauxfactory.gen_alphanumeric(15, start="child_tenant_"),
         description='tenant description',
@@ -21,6 +22,7 @@ def child_tenant(appliance):
 
 @pytest.fixture(scope='module')
 def tenant_role(appliance, request):
+    """Fixture to create a tenant_administrator role with additional product features"""
     role = appliance.collections.roles.instantiate(name='EvmRole-tenant_administrator')
     tenant_role = role.copy()
 
@@ -41,20 +43,21 @@ def tenant_role(appliance, request):
 
 
 @pytest.fixture(scope='module')
-def new_tenant_admin(appliance, request, child_tenant, tenant_role):
+def child_tenant_admin_user(appliance, request, child_tenant, tenant_role):
+    """Fixture to create a tenant admin user"""
     credential = Credential(principal=fauxfactory.gen_alphanumeric(start="uid"),
                     secret='redhat')
     group = appliance.collections.groups.create(
         description=fauxfactory.gen_alphanumeric(15, start="tenant_grp_"), role=tenant_role.name,
         tenant=f'My Company/{child_tenant.name}')
 
-    tenant_admin = appliance.collections.users.create(
+    tenant_admin_user = appliance.collections.users.create(
         name=fauxfactory.gen_alphanumeric(start='tenant_admin_user'),
         credential=credential,
         email='xyz@redhat.com',
         groups=group,
         cost_center='Workload',
         value_assign='Database')
-    yield tenant_admin
-    tenant_admin.delete_if_exists()
+    yield tenant_admin_user
+    tenant_admin_user.delete_if_exists()
     group.delete_if_exists()

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -190,9 +190,18 @@ def test_download_private_key(keypair):
 
 @pytest.mark.meta(automates=[1741635, 1747179])
 @test_requirements.multi_tenancy
-def test_tenantadmin_view_keypair(appliance, new_tenant_admin):
+def test_keypair_visibility_in_tenants(appliance, child_tenant_admin_user):
     """
-    Test to verify that child tenants can see key pairs of parent tenants.
+    Test to verify key pair visibility in tenants based on key pair ownership
+
+    Steps:
+        1. Copy the EvmRole_tenant_admin role to a new role (Since this role does not have the
+           Auth Key Pairs feature enabled)
+        2. In the role, enable the Auth Key Pairs feature
+        3. Add either new or existing group to the newly created tenant admin role
+           (Steps 1-3 are done through fixtures)
+        4. If the added group belongs to a child tenant, then the key pair is only visible to users
+           in that group/child tenant and also users from groups that belong to parent tenants.
 
     Polarion:
         assignee: nachandr
@@ -204,7 +213,8 @@ def test_tenantadmin_view_keypair(appliance, new_tenant_admin):
     view = navigate_to(appliance.collections.cloud_keypairs, 'All')
     key_pair = view.entities.get_first_entity().data['name']
     key_pair_obj = appliance.collections.cloud_keypairs.instantiate(key_pair)
-    key_pair_obj.set_ownership(group=new_tenant_admin.groups[0].description)
+    key_pair_obj.set_ownership(group=child_tenant_admin_user.groups[0])
+    view.flash.assert_success_message('Ownership saved for selected Key Pair')
 
-    with new_tenant_admin:
+    with child_tenant_admin_user:
         assert key_pair_obj.exists

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -28,8 +28,7 @@ def keypair(appliance, provider):
     yield key
 
 
-@pytest.mark.meta(blockers=[BZ(1718833, forced_streams=["5.10", "5.11"],
-                               unblock=lambda provider: provider.one_of(OpenStackProvider))])
+@pytest.mark.meta(automates=[BZ(1718833)])
 def test_keypair_crud(appliance, provider):
     """ This will test whether it will create new Keypair and then deletes it.
     Polarion:

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -13,7 +13,7 @@ from cfme.utils.blockers import BZ
 pytestmark = [
     pytest.mark.tier(3),
     test_requirements.cloud,
-    pytest.mark.usefixtures('setup_provider_modscope'),
+    pytest.mark.usefixtures('has_no_providers_modscope', 'setup_provider_modscope'),
     pytest.mark.provider([EC2Provider, OpenStackProvider], scope="module")
 ]
 
@@ -190,7 +190,7 @@ def test_download_private_key(keypair):
 
 @pytest.mark.meta(automates=[1741635, 1747179])
 @test_requirements.multi_tenancy
-def test_view_keypair(appliance, new_tenant_admin):
+def test_tenantadmin_view_keypair(appliance, new_tenant_admin):
     """
     Test to verify that child tenants can see key pairs of parent tenants.
 
@@ -204,7 +204,7 @@ def test_view_keypair(appliance, new_tenant_admin):
     view = navigate_to(appliance.collections.cloud_keypairs, 'All')
     key_pair = view.entities.get_first_entity().data['name']
     key_pair_obj = appliance.collections.cloud_keypairs.instantiate(key_pair)
-    key_pair_obj.set_ownership("", new_tenant_admin.groups[0].description)
+    key_pair_obj.set_ownership(group=new_tenant_admin.groups[0].description)
 
     with new_tenant_admin:
         assert key_pair_obj.exists

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -188,12 +188,11 @@ def test_download_private_key(keypair):
     keypair.download_private_key()
 
 
-@pytest.mark.meta(automates=[BZ(1741635)])
+@pytest.mark.meta(automates=[1741635, 1747179])
 @test_requirements.multi_tenancy
 def test_view_keypair(appliance, new_tenant_admin):
-
     """
-    Child tenants can see key pairs of parent tenants.
+    Test to verify that child tenants can see key pairs of parent tenants.
 
     Polarion:
         assignee: nachandr

--- a/cfme/tests/cloud/test_keypairs.py
+++ b/cfme/tests/cloud/test_keypairs.py
@@ -194,21 +194,21 @@ def test_keypair_visibility_in_tenants(appliance, child_tenant_admin_user):
     """
     Test to verify key pair visibility in tenants based on key pair ownership
 
-    Steps:
-        1. Copy the EvmRole_tenant_admin role to a new role (Since this role does not have the
-           Auth Key Pairs feature enabled)
-        2. In the role, enable the Auth Key Pairs feature
-        3. Add either new or existing group to the newly created tenant admin role
-           (Steps 1-3 are done through fixtures)
-        4. If the added group belongs to a child tenant, then the key pair is only visible to users
-           in that group/child tenant and also users from groups that belong to parent tenants.
-
     Polarion:
         assignee: nachandr
         casecomponent: Configuration
         caseimportance: high
         tags: cfme_tenancy
         initialEstimate: 1/4h
+        testSteps:
+            1. Copy the EvmRole_tenant_admin role to a new role (Since this role does not have the
+               Auth Key Pairs feature enabled).
+            2. Enable the Auth Key Pairs feature for the new role.
+            3. Add either new or existing group to the newly created tenant admin role.
+               (Steps 1-3 are done through fixtures)
+            4. If the added group belongs to a child tenant, then the key pair is only visible to
+               users in that group/child tenant and also users from groups that belong to parent
+               tenants.
     """
     view = navigate_to(appliance.collections.cloud_keypairs, 'All')
     key_pair = view.entities.get_first_entity().data['name']

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -124,11 +124,13 @@ def tenant_role(appliance, request):
     with update(tenant_role):
         if appliance.version < '5.11':
             tenant_role.product_features = [
-                (['Everything', 'Settings', 'Configuration', 'Settings'], True)
+                (['Everything', 'Settings', 'Configuration', 'Settings'], True),
+                (['Everything', 'Compute', 'Clouds', 'Auth Key Pairs'], True)
             ]
         else:
             tenant_role.product_features = [
-                (['Everything', 'Main Configuration', 'Settings'], True)
+                (['Everything', 'Main Configuration', 'Settings'], True),
+                (['Everything', 'Compute', 'Clouds', 'Auth Key Pairs'], True)
             ]
     yield tenant_role
     tenant_role.delete_if_exists()
@@ -2104,6 +2106,25 @@ def test_tenant_ldap_group_switch_between_tenants(appliance, setup_openldap_auth
 
     appliance.server.login_admin()
     assert user.exists, 'User record for "{}" should exist after login'.format(user.name)
+
+
+def test_view_key_pair(provider, appliance):
+    """
+    Child tenants can see MIQ AE namespaces of parent tenants.
+
+    Polarion:
+        assignee: nachandr
+        casecomponent: Configuration
+        caseimportance: high
+        tags: cfme_tenancy
+        initialEstimate: 1/4h
+    """
+    key_pair = provider.appliance.collections.cloud_keypairs.all()[0]
+    user = appliance.rest_api.collections.users.get(userid='admin')
+    data = {
+        "owner": {"href": user.href}
+    }
+    key_pair.set_ownership(**data)
 
 
 @pytest.mark.manual

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -1532,7 +1532,8 @@ def test_superadmin_tenant_admin_crud(appliance):
 
 @pytest.mark.tier(2)
 @test_requirements.multi_tenancy
-def test_tenantadmin_group_crud(new_tenant_admin, tenant_role, child_tenant, request, appliance):
+def test_tenantadmin_group_crud(child_tenant_admin_user, tenant_role, child_tenant, request,
+        appliance):
     """
     Perform CRUD operations on groups as Tenant administrator.
 
@@ -1547,9 +1548,9 @@ def test_tenantadmin_group_crud(new_tenant_admin, tenant_role, child_tenant, req
             1. Create new tenant admin user and assign user to group EvmGroup-tenant_administrator
             2. As Tenant administrator, create new group, update group and delete group.
     """
-    with new_tenant_admin:
+    with child_tenant_admin_user:
         navigate_to(appliance.server, 'LoggedIn')
-        assert appliance.server.current_full_name() == new_tenant_admin.name
+        assert appliance.server.current_full_name() == child_tenant_admin_user.name
 
         group_collection = appliance.collections.groups
         group = group_collection.create(
@@ -1599,7 +1600,8 @@ def test_tenant_unique_catalog(appliance, request, catalog_obj):
 
 @pytest.mark.ignore_stream("upstream")
 @test_requirements.multi_tenancy
-def test_tenantadmin_user_crud(new_tenant_admin, tenant_role, child_tenant, request, appliance):
+def test_tenantadmin_user_crud(child_tenant_admin_user, tenant_role, child_tenant, request,
+        appliance):
     """
     As a Tenant Admin, I want to be able to create users in my tenant.
     Polarion:
@@ -1623,11 +1625,11 @@ def test_tenantadmin_user_crud(new_tenant_admin, tenant_role, child_tenant, requ
             must be created by superadministrator. In 5.5.0.13 after giving additional permissions
             to tenant_admin,able to create new roles
     """
-    with new_tenant_admin:
+    with child_tenant_admin_user:
         navigate_to(appliance.server, 'LoggedIn')
-        assert appliance.server.current_full_name() == new_tenant_admin.name
+        assert appliance.server.current_full_name() == child_tenant_admin_user.name
 
-        user = new_user(appliance, new_tenant_admin.groups[0])
+        user = new_user(appliance, child_tenant_admin_user.groups[0])
         request.addfinalizer(user.delete_if_exists)
         assert user.exists
 

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -2108,23 +2108,6 @@ def test_tenant_ldap_group_switch_between_tenants(appliance, setup_openldap_auth
     assert user.exists, 'User record for "{}" should exist after login'.format(user.name)
 
 
-@pytest.mark.meta(automates=[BZ(1741635)])
-def test_view_key_pair(provider, appliance, keypairs):
-    """
-    Child tenants can key pairs of parent tenants.
-
-    Polarion:
-        assignee: nachandr
-        casecomponent: Configuration
-        caseimportance: high
-        tags: cfme_tenancy
-        initialEstimate: 1/4h
-    """
-    view = navigate_to(keypairs, 'All')
-    key_pair = view.entities.get_first_entity().data['name']
-    key_pair.set_ownership("Administrator", "EvmGroup-administrator")
-
-
 @pytest.mark.manual
 @pytest.mark.ignore_stream("upstream")
 @pytest.mark.tier(2)

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -2108,9 +2108,10 @@ def test_tenant_ldap_group_switch_between_tenants(appliance, setup_openldap_auth
     assert user.exists, 'User record for "{}" should exist after login'.format(user.name)
 
 
-def test_view_key_pair(provider, appliance):
+@pytest.mark.meta(automates=[BZ(1741635)])
+def test_view_key_pair(provider, appliance, keypairs):
     """
-    Child tenants can see MIQ AE namespaces of parent tenants.
+    Child tenants can key pairs of parent tenants.
 
     Polarion:
         assignee: nachandr
@@ -2119,12 +2120,9 @@ def test_view_key_pair(provider, appliance):
         tags: cfme_tenancy
         initialEstimate: 1/4h
     """
-    key_pair = provider.appliance.collections.cloud_keypairs.all()[0]
-    user = appliance.rest_api.collections.users.get(userid='admin')
-    data = {
-        "owner": {"href": user.href}
-    }
-    key_pair.set_ownership(**data)
+    view = navigate_to(keypairs, 'All')
+    key_pair = view.entities.get_first_entity().data['name']
+    key_pair.set_ownership("Administrator", "EvmGroup-administrator")
 
 
 @pytest.mark.manual

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -104,50 +104,6 @@ def setup_openldap_user_group(appliance, two_child_tenants, openldap_auth_provid
         group.delete_if_exists()
 
 
-@pytest.fixture(scope='module')
-def child_tenant(appliance):
-    child_tenant = appliance.collections.tenants.create(
-        name=fauxfactory.gen_alphanumeric(15, start="child_tenant_"),
-        description='tenant description',
-        parent=appliance.collections.tenants.get_root_tenant()
-    )
-    yield child_tenant
-    child_tenant.delete_if_exists()
-
-
-@pytest.fixture(scope='module')
-def tenant_role(appliance, request):
-    role = appliance.collections.roles.instantiate(name='EvmRole-tenant_administrator')
-    tenant_role = role.copy()
-
-    # Note: BZ 1278484 - tenant admin role has no permissions to create new roles
-    with update(tenant_role):
-        if appliance.version < '5.11':
-            tenant_role.product_features = [
-                (['Everything', 'Settings', 'Configuration', 'Settings'], True),
-                (['Everything', 'Compute', 'Clouds', 'Auth Key Pairs'], True)
-            ]
-        else:
-            tenant_role.product_features = [
-                (['Everything', 'Main Configuration', 'Settings'], True),
-                (['Everything', 'Compute', 'Clouds', 'Auth Key Pairs'], True)
-            ]
-    yield tenant_role
-    tenant_role.delete_if_exists()
-
-
-@pytest.fixture(scope='module')
-def new_tenant_admin(appliance, request, child_tenant, tenant_role):
-    group = appliance.collections.groups.create(
-        description=fauxfactory.gen_alphanumeric(15, start="tenant_grp_"), role=tenant_role.name,
-        tenant=f'My Company/{child_tenant.name}')
-
-    tenant_admin = new_user(appliance, group, name='tenant_admin_user')
-    yield tenant_admin
-    tenant_admin.delete_if_exists()
-    group.delete_if_exists()
-
-
 @pytest.fixture(scope='function')
 def check_item_visibility(tag):
     def _check_item_visibility(item, user_restricted):

--- a/conftest.py
+++ b/conftest.py
@@ -59,6 +59,7 @@ pytest_plugins = [
     "cfme.fixtures.maximized",
     "cfme.fixtures.model_collections",
     "cfme.fixtures.multi_region",
+    "cfme.fixtures.multi_tenancy",
     "cfme.fixtures.nelson",
     "cfme.fixtures.networks",
     "cfme.fixtures.nuage",


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
1.Automated test to verify key pair visibility in child tenants
2.Moved fixtures related to multi tenancy to a separate file
3.Added set_ownership method and SetOwnership view to cloud key pair page

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{ pytest: cfme/tests/cloud/test_keypairs.py::test_keypair_visibility_in_tenants cfme/tests/configure/test_access_control.py::test_tenantadmin_user_crud }}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->

PRT results:
510 - PASS
511- PASS