### PR TITLE
[1LP][RFR] Automate: test_provider_documentation

### DIFF
--- a/cfme/infrastructure/config_management/__init__.py
+++ b/cfme/infrastructure/config_management/__init__.py
@@ -136,11 +136,13 @@ class ConfigManagementCollectionView(BaseLoggedInPage):
     @property
     def in_config(self):
         """Determine if we're in the config section"""
-        object_type = getattr(self.context['object'], 'type', None)
+        object_type = getattr(self.context['object'], 'type_name', None)
         if object_type == 'ansible_tower':
             nav_chain = ['Automation', 'Ansible Tower', 'Explorer']
-        else:
+        elif object_type == "satellite":
             nav_chain = ['Configuration', 'Management']
+        else:
+            nav_chain = []
         return (
             self.logged_in_as_current_user and
             self.navigation.currently_selected == nav_chain
@@ -153,11 +155,13 @@ class ConfigManagementView(BaseLoggedInPage):
     @property
     def in_config(self):
         """Determine if we're in the config section"""
-        object_type = getattr(self.context['object'], 'type', None)
+        object_type = getattr(self.context['object'], 'type_name', None)
         if object_type == 'ansible_tower':
             nav_chain = ['Automation', 'Ansible Tower', 'Explorer']
-        else:
+        elif object_type == "satellite":
             nav_chain = ['Configuration', 'Management']
+        else:
+            nav_chain = []
         return (
             self.logged_in_as_current_user and
             self.navigation.currently_selected == nav_chain

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -585,7 +585,7 @@ def test_infrastructure_provider_left_panel_titles(
 @pytest.mark.ignore_stream("5.10")
 @pytest.mark.parametrize("provider", PROVIDERS)
 @pytest.mark.meta(automates=[1741030, 1783208])
-def test_provider_documentation(has_no_providers, provider, request):
+def test_provider_documentation(temp_appliance_preconfig, provider, request):
     """
     Bugzilla:
         1741030

--- a/cfme/tests/webui/test_general_ui_manual.py
+++ b/cfme/tests/webui/test_general_ui_manual.py
@@ -89,31 +89,6 @@ def test_pdf_summary_provider(provider):
 
 
 @pytest.mark.tier(1)
-@pytest.mark.ignore_stream("5.10")
-@pytest.mark.meta(coverage=[1741030])
-def test_provider_documentation():
-    """
-    Bugzilla:
-        1741030
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Infra
-        caseimportance: low
-        initialEstimate: 1/18h
-        startsin: 5.11
-        setup:
-            1. Take a fresh appliance with no provider
-        testSteps:
-            1. Log into the appliance and check where the link provided
-                in `Learn more about this in the documentation.` points to.
-        expectedResults:
-            1. Link must point to downstream documentation and not upstream.
-    """
-    pass
-
-
-@pytest.mark.tier(1)
 @pytest.mark.meta(coverage=[1733120])
 def test_compare_vm_from_datastore_relationships():
     """


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. `test_provider_documentation` and remove it's manual test.
- __Enhancement__ 
    1. Enhance `ConfigManagementCollectionView` and `ConfigManagementView` views `is_displayed` to work for navigation through `AnsibleTowerProvider` and `SatelliteProvider` class.
    2. Add `data/ui/provider_docs.yaml`

### PRT Run

{{ pytest: cfme/tests/webui/test_general_ui.py -k "test_provider_documentation" -vvv }}