### PR TITLE
[1LP][RFR] Automate: test_service_refresh_dialog_fields_default_values

### DIFF
--- a/cfme/automate/dialogs/service_dialogs.py
+++ b/cfme/automate/dialogs/service_dialogs.py
@@ -9,6 +9,7 @@ from cfme.automate.dialogs import AddDialogView
 from cfme.automate.dialogs import AutomateCustomizationView
 from cfme.automate.dialogs import EditDialogView
 from cfme.automate.dialogs.dialog_tab import TabCollection
+from cfme.exceptions import RestLookupError
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -88,6 +89,15 @@ class Dialog(BaseEntity, Fillable):
         view.flash.assert_no_error()
         view.flash.assert_success_message(
             'Dialog "{}": Delete successful'.format(self.label))
+
+    @property
+    def rest_api_entity(self):
+        try:
+            return self.appliance.rest_api.collections.service_dialogs.get(label=self.label)
+        except ValueError:
+            raise RestLookupError(
+                f"No service dialog rest entity found matching label {self.label}"
+            )
 
 
 @attr.s

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -88,45 +88,6 @@ def test_widget_generate_content_via_rest(context):
     pass
 
 
-@pytest.mark.meta(coverage=[1730813])
-@pytest.mark.tier(2)
-@test_requirements.rest
-@pytest.mark.customer_scenario
-def test_service_refresh_dialog_fields_default_values():
-    """
-    Bugzilla:
-        1730813
-        1731977
-
-    Polarion:
-        assignee: pvala
-        caseimportance: high
-        casecomponent: Rest
-        initialEstimate: 1/4h
-        setup:
-            1. Import dialog `RTP Testgear Client Provision` from the BZ attachments and create
-                a service_template and service catalog to attach it.
-        testSteps:
-            1. Start monitoring the evm log and look for fields `tag_1_region` and `tag_0_function`.
-            2. Perform action `refresh_dialog_fields` by sending a request
-                POST /api/service_catalogs/<:id>/sevice_templates/<:id>
-                    {
-                    "action": "refresh_dialog_fields",
-                    "resource": {
-                        "fields": [
-                            "tag_1_region",
-                            "tag_0_function"
-                            ]
-                        }
-                    }
-        expectedResults:
-            1.
-            2. Request must be successful and evm must have the default values
-                for the fields mentioned in testStep 1.
-    """
-    pass
-
-
 @pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1486765, 1740340])
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. Automate: `test_service_refresh_dialog_fields_default_values` and remove manual test.
- __Enhancement__
    1. Add `rest_api_entity` property to `ServiceDialogs`.

### PRT Run
{{ pytest: cfme/tests/services/test_rest_services.py -k "test_service_refresh_dialog_fields_default_values" --long-running -vvvv }}