### PR TITLE
rename the temp_appliance_preconfig_long to temp_appliance_preconfig_…

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -119,10 +119,10 @@ def temp_appliance_preconfig_funcscope_upgrade(appliance, pytestconfig):
 
 
 @pytest.fixture(scope="module")
-def temp_appliance_preconfig_long(appliance, pytestconfig):
+def temp_appliance_preconfig_modscope_rhevm(appliance, pytestconfig):
     """ temp appliance with 24h lease for auth tests """
     with sprout_appliances(
-            appliance, config=pytestconfig, preconfigured=True, lease_time=1440,
+            appliance, config=pytestconfig, preconfigured=True,
             provider_type='rhevm'
     ) as appliances:
         yield appliances[0]

--- a/cfme/tests/integration/test_aws_iam_auth_and_roles.py
+++ b/cfme/tests/integration/test_aws_iam_auth_and_roles.py
@@ -42,7 +42,7 @@ def pytest_generate_tests(metafunc):
                          reason="Test not valid for dev server")
 @pytest.mark.meta(automates=[BZ(1530683)])
 @test_requirements.auth
-def test_group_roles(temp_appliance_preconfig_long, setup_aws_auth_provider, group_name,
+def test_group_roles(temp_appliance_preconfig_modscope_rhevm, setup_aws_auth_provider, group_name,
                      role_access, context, soft_assert):
     """Basic default AWS_IAM group role auth + RBAC test
 
@@ -68,16 +68,17 @@ def test_group_roles(temp_appliance_preconfig_long, setup_aws_auth_provider, gro
     except KeyError:
         pytest.fail('No match in credentials file for group "{}"'.format(iam_group_name))
 
-    with temp_appliance_preconfig_long.context.use(context):
+    with temp_appliance_preconfig_modscope_rhevm.context.use(context):
         # fullname overrides user.name attribute, but doesn't impact login with username credential
-        user = temp_appliance_preconfig_long.collections.users.simple_user(
+        user = temp_appliance_preconfig_modscope_rhevm.collections.users.simple_user(
             username, password, fullname=fullname
         )
         with user:
-            view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
-            assert temp_appliance_preconfig_long.server.current_full_name() == user.name
+            view = navigate_to(temp_appliance_preconfig_modscope_rhevm.server, 'LoggedIn')
+            assert temp_appliance_preconfig_modscope_rhevm.server.current_full_name() == user.name
             assert group_name.lower() in [
-                name.lower() for name in temp_appliance_preconfig_long.server.group_names()
+                name.lower() for name
+                in temp_appliance_preconfig_modscope_rhevm.server.group_names()
             ]
             nav_visible = view.navigation.nav_item_tree()
 
@@ -91,5 +92,5 @@ def test_group_roles(temp_appliance_preconfig_long, setup_aws_auth_provider, gro
                 soft_assert(diff == {}, '{g} RBAC mismatch (expected first) for {a}: {d}'
                                         .format(g=group_name, a=area, d=diff))
 
-        temp_appliance_preconfig_long.server.login_admin()
+        temp_appliance_preconfig_modscope_rhevm.server.login_admin()
         assert user.exists

--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -21,8 +21,8 @@ from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import wait_for
 
 pytestmark = [
-    pytest.mark.uncollectif(lambda temp_appliance_preconfig_long:
-                            temp_appliance_preconfig_long.is_pod,
+    pytest.mark.uncollectif(lambda temp_appliance_preconfig_modscope_rhevm:
+                            temp_appliance_preconfig_modscope_rhevm.is_pod,
                             reason='Tests not valid for podified'),
     pytest.mark.meta(blockers=[
         GH('ManageIQ/integration_tests:6465',
@@ -104,28 +104,28 @@ def pytest_generate_tests(metafunc):
 
 
 @pytest.fixture(scope='function')
-def user_obj(temp_appliance_preconfig_long, auth_user, user_type):
+def user_obj(temp_appliance_preconfig_modscope_rhevm, auth_user, user_type):
     """return a simple user object, see if it exists and delete it on teardown"""
     # Replace spaces with dashes in UPN type usernames for login compatibility
     username = auth_user.username.replace(' ', '-') if user_type == 'upn' else auth_user.username
-    user = temp_appliance_preconfig_long.collections.users.simple_user(
+    user = temp_appliance_preconfig_modscope_rhevm.collections.users.simple_user(
         username,
         credentials[auth_user.password].password,
         fullname=auth_user.fullname or auth_user.username)  # fullname could be empty
     yield user
 
-    temp_appliance_preconfig_long.browser.widgetastic.refresh()
-    temp_appliance_preconfig_long.server.login_admin()
+    temp_appliance_preconfig_modscope_rhevm.browser.widgetastic.refresh()
+    temp_appliance_preconfig_modscope_rhevm.server.login_admin()
     if user.exists:
         user.delete()
 
 
 @pytest.fixture
-def log_monitor(user_obj, temp_appliance_preconfig_long):
+def log_monitor(user_obj, temp_appliance_preconfig_modscope_rhevm):
     """Search evm.log for any plaintext password"""
     result = LogValidator(
         "/var/www/miq/vmdb/log/evm.log", failure_patterns=[f"{user_obj.credential.secret}"],
-        hostname=temp_appliance_preconfig_long.hostname
+        hostname=temp_appliance_preconfig_modscope_rhevm.hostname
     )
     result.start_monitoring()
     yield result
@@ -140,7 +140,7 @@ def log_monitor(user_obj, temp_appliance_preconfig_long):
                                 'or the auth user does not have an evm built-in group')
 # this test only runs against users that have an evm built-in group
 def test_login_evm_group(
-        temp_appliance_preconfig_long, auth_user, user_obj, soft_assert, log_monitor
+        temp_appliance_preconfig_modscope_rhevm, auth_user, user_obj, soft_assert, log_monitor
 ):
     """This test checks whether a user can login while assigned a default EVM group
         Prerequisities:
@@ -158,7 +158,7 @@ def test_login_evm_group(
     evm_group_names = [group for group in auth_user.groups if 'evmgroup' in group.lower()]
     with user_obj:
         logger.info('Logging in as user %s, member of groups %s', user_obj, evm_group_names)
-        view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
+        view = navigate_to(temp_appliance_preconfig_modscope_rhevm.server, 'LoggedIn')
         assert view.is_displayed, 'user {} failed login'.format(user_obj)
         soft_assert(user_obj.name == view.current_fullname,
                     'user {} is not in view fullname'.format(user_obj))
@@ -167,24 +167,24 @@ def test_login_evm_group(
                         'user {} evm group {} not in view group_names'.format(user_obj, name))
 
     # split loop to reduce number of logins
-    temp_appliance_preconfig_long.server.login_admin()
+    temp_appliance_preconfig_modscope_rhevm.server.login_admin()
     assert user_obj.exists, 'user record should have been created for "{}"'.format(user_obj)
 
     # assert no pwd in logs
     assert log_monitor.validate()
 
 
-def retrieve_group(temp_appliance_preconfig_long, auth_mode, username, groupname, auth_provider,
-        tenant=None):
+def retrieve_group(temp_appliance_preconfig_modscope_rhevm,
+                   auth_mode, username, groupname, auth_provider, tenant=None):
     """Retrieve group from ext/ldap auth provider through UI
 
     Args:
-        temp_appliance_preconfig_long: temp_appliance_preconfig_long object
+        temp_appliance_preconfig_modscope_rhevm: temp_appliance_preconfig_modscope_rhevm object
         auth_mode: key from cfme.configure.configuration.server_settings.AUTH_MODES, parametrization
         user_data: user_data AttrDict from yaml, with username, groupname, password fields
 
     """
-    group = temp_appliance_preconfig_long.collections.groups.instantiate(
+    group = temp_appliance_preconfig_modscope_rhevm.collections.groups.instantiate(
         description=groupname,
         role='EvmRole-user',
         tenant=tenant,
@@ -211,7 +211,7 @@ def retrieve_group(temp_appliance_preconfig_long, auth_mode, username, groupname
                          reason='Amazon auth mode with default groups tested elsewhere,'
                                 'or the auth user does not have an evm built-in group')
 def test_login_retrieve_group(
-        temp_appliance_preconfig_long, request, log_monitor,
+        temp_appliance_preconfig_modscope_rhevm, request, log_monitor,
         auth_mode, auth_provider, soft_assert, auth_user, user_obj
 ):
     """This test checks whether different cfme auth modes are working correctly.
@@ -231,14 +231,16 @@ def test_login_retrieve_group(
     # get a list of (user_obj, groupname) tuples, creating the user object inline
     # filtering on those that do NOT evmgroup in groupname
     non_evm_group = [g for g in auth_user.groups or [] if 'evmgroup' not in g.lower()][0]
-    # retrieving in test call and not fixture, getting the group from auth provider is part of test
+    # retrieving in test call and not fixture, getting the group from auth
+    # provider is part of test
     group = retrieve_group(
-        temp_appliance_preconfig_long, auth_mode, auth_user.username, non_evm_group, auth_provider,
+        temp_appliance_preconfig_modscope_rhevm, auth_mode, auth_user.username,
+        non_evm_group, auth_provider,
         tenant="My Company"  # tenant is required for group
     )
 
     with user_obj:
-        view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
+        view = navigate_to(temp_appliance_preconfig_modscope_rhevm.server, 'LoggedIn')
         soft_assert(view.current_fullname == user_obj.name,
                     'user full name "{}" did not match UI display name "{}"'
                     .format(user_obj.name, view.current_fullname))
@@ -246,7 +248,8 @@ def test_login_retrieve_group(
                     u'user group "{}" not displayed in UI groups list "{}"'
                     .format(group.description, view.group_names))
 
-    temp_appliance_preconfig_long.server.login_admin()  # context should get us back to admin
+    # context should get us back to admin
+    temp_appliance_preconfig_modscope_rhevm.server.login_admin()
     assert user_obj.exists, 'User record for "{}" should exist after login'.format(user_obj)
 
     # assert no pwd in logs
@@ -274,10 +277,10 @@ def format_user_principal(username, user_type, auth_provider):
 
 
 @pytest.fixture(scope='function')
-def local_group(temp_appliance_preconfig_long):
+def local_group(temp_appliance_preconfig_modscope_rhevm):
     """Helper method to check for existance of a group and delete if need be"""
     group_name = gen_alphanumeric(length=15, start="test-group-")
-    group = temp_appliance_preconfig_long.collections.groups.create(
+    group = temp_appliance_preconfig_modscope_rhevm.collections.groups.create(
         description=group_name, role='EvmRole-desktop'
     )
     assert group.exists
@@ -288,9 +291,10 @@ def local_group(temp_appliance_preconfig_long):
 
 
 @pytest.fixture(scope='function')
-def local_user(temp_appliance_preconfig_long, auth_user, user_type, auth_provider, local_group):
+def local_user(temp_appliance_preconfig_modscope_rhevm,
+               auth_user, user_type, auth_provider, local_group):
     # list of created users, instantiating the Credential and formatting the user name in loop
-    user = temp_appliance_preconfig_long.collections.users.create(
+    user = temp_appliance_preconfig_modscope_rhevm.collections.users.create(
         name=auth_user.fullname or auth_user.username,  # fullname could be empty
         credential=Credential(
             principal=format_user_principal(auth_user.username, user_type, auth_provider),
@@ -304,9 +308,9 @@ def local_user(temp_appliance_preconfig_long, auth_user, user_type, auth_provide
 
 
 @pytest.fixture
-def do_not_fetch_remote_groups(temp_appliance_preconfig_long):
+def do_not_fetch_remote_groups(temp_appliance_preconfig_modscope_rhevm):
     # modify auth settings to not get groups
-    temp_appliance_preconfig_long.server.authentication.auth_settings = {
+    temp_appliance_preconfig_modscope_rhevm.server.authentication.auth_settings = {
         'auth_settings': {'get_groups': False}
     }
     # this setting takes a bit to register, so wait 30 s
@@ -318,7 +322,8 @@ def do_not_fetch_remote_groups(temp_appliance_preconfig_long):
 @pytest.mark.tier(1)
 @pytest.mark.uncollectif(lambda auth_mode: auth_mode == 'amazon',
                          reason='Amazon auth_data needed for local group testing')
-def test_login_local_group(temp_appliance_preconfig_long, local_user, local_group, soft_assert,
+def test_login_local_group(temp_appliance_preconfig_modscope_rhevm,
+                           local_user, local_group, soft_assert,
                            do_not_fetch_remote_groups):
     """
     Test remote authentication with a locally created group.
@@ -331,7 +336,7 @@ def test_login_local_group(temp_appliance_preconfig_long, local_user, local_grou
         casecomponent: Auth
     """
     with local_user:
-        view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
+        view = navigate_to(temp_appliance_preconfig_modscope_rhevm.server, 'LoggedIn')
         soft_assert(view.current_fullname == local_user.name,
                     'user full name "{}" did not match UI display name "{}"'
                     .format(local_user.name, view.current_fullname))
@@ -349,7 +354,7 @@ def test_login_local_group(temp_appliance_preconfig_long, local_user, local_grou
                          'user does not have multiple groups')
 @pytest.mark.meta(blockers=[BZ(1759291)], automates=[1759291])
 def test_user_group_switching(
-        temp_appliance_preconfig_long, auth_user, auth_mode, auth_provider,
+        temp_appliance_preconfig_modscope_rhevm, auth_user, auth_mode, auth_provider,
         soft_assert, request, user_obj, log_monitor
 ):
     """Test switching groups on a single user, between retreived group and built-in group
@@ -368,7 +373,7 @@ def test_user_group_switching(
         if 'evmgroup' not in group.lower():
             # create group in CFME via retrieve_group which looks it up on auth_provider
             logger.info(u'Retrieving a user group that is non evm built-in: {}'.format(group))
-            retrieved_groups.append(retrieve_group(temp_appliance_preconfig_long,
+            retrieved_groups.append(retrieve_group(temp_appliance_preconfig_modscope_rhevm,
                                                    auth_mode,
                                                    auth_user.username,
                                                    group,
@@ -378,7 +383,7 @@ def test_user_group_switching(
                     .format(auth_user.groups))
 
     with user_obj:
-        view = navigate_to(temp_appliance_preconfig_long.server, 'LoggedIn')
+        view = navigate_to(temp_appliance_preconfig_modscope_rhevm.server, 'LoggedIn')
         # Check there are multiple groups displayed
         assert len(view.group_names) > 1, 'Only a single group is displayed for the user'
         display_other_groups = [g for g in view.group_names if g != view.current_groupname]
@@ -405,7 +410,7 @@ def test_user_group_switching(
                         u'After switching to group {}, its not displayed as active'
                         .format(other_group))
 
-    temp_appliance_preconfig_long.server.login_admin()
+    temp_appliance_preconfig_modscope_rhevm.server.login_admin()
     assert user_obj.exists, 'User record for "{}" should exist after login'.format(auth_user)
 
     # assert no pwd in log

--- a/cfme/tests/integration/test_ldap_auth_and_roles.py
+++ b/cfme/tests/integration/test_ldap_auth_and_roles.py
@@ -12,7 +12,7 @@ pytest_generate_tests = generate(gen_func=auth_groups, auth_mode='ldap')
 @pytest.mark.uncollect(reason='Needs to be fixed after menu removed')
 @test_requirements.auth
 @pytest.mark.tier(2)
-def test_group_roles(request, temp_appliance_preconfig_long, group_name, group_data):
+def test_group_roles(request, temp_appliance_preconfig_modscope_rhevm, group_name, group_data):
     """Basic default LDAP group role RBAC test
 
     Validates expected menu and submenu names are present for default
@@ -26,7 +26,7 @@ def test_group_roles(request, temp_appliance_preconfig_long, group_name, group_d
         initialEstimate: 1/4h
         tags: rbac
     """
-    appliance = temp_appliance_preconfig_long
+    appliance = temp_appliance_preconfig_modscope_rhevm
     request.addfinalizer(appliance.server.login_admin)
 
     # This should be removed but currently these roles are subject to a bug


### PR DESCRIPTION
…modscope_rhevm

The fixture used to be ordering from sprout with long lease time which
is now not necessary because the PR

  Add periodic call and use it to prolong the appliances from Sprout #9753

was merged.

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
