### PR TITLE
[1LP][WIPTEST] Also use --include-manual when setting the coverage flag.

### DIFF
--- a/cfme/scripting/bz.py
+++ b/cfme/scripting/bz.py
@@ -52,6 +52,7 @@ def get_report(directory):
         "--use-template-cache",
         "--collect-only",
         "--dummy-appliance",
+        "--include-manual",
         "-q",
         "--generate-bz-report", directory
     ])

--- a/cfme/tests/configure/test_db_backup_schedule.py
+++ b/cfme/tests/configure/test_db_backup_schedule.py
@@ -135,7 +135,7 @@ def get_full_path_to_file(path_on_host, schedule_name):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.meta(automates=[1678223])
+@pytest.mark.meta(automates=[1678223, 1643106])
 def test_db_backup_schedule(request, db_backup_data, depot_machine_ip, appliance):
     """ Test scheduled one-type backup on given machines using smb/nfs
 
@@ -215,6 +215,10 @@ def test_db_backup_schedule(request, db_backup_data, depot_machine_ip, appliance
         # Find files no more than 5 minutes old, count them and remove newline
         file_check_cmd = "find {}/* -cmin -5 | wc -l | tr -d '\n' ".format(full_path)
 
+        # Note that this check is not sufficient. It seems the file may be
+        # present, but there is no check whether it is sane backup. For example
+        # it can be zero sized in some circumstances:
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1703278#c24
         wait_for(
             lambda: ssh_client.run_command(file_check_cmd, ensure_user=True).output == '1',
             delay=5,

--- a/cfme/tests/test_db_migrate_manual.py
+++ b/cfme/tests/test_db_migrate_manual.py
@@ -340,7 +340,7 @@ def test_rh_registration_proxy_crud():
 
 @pytest.mark.manual
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1721596])
+@pytest.mark.meta(coverage=[1721596, 1668800])
 def test_upgrade_multi_replication_inplace():
     """
     test_upgrade_multi_replication_inplace


### PR DESCRIPTION
The BZ may be covered by a manual test case. These cases were ignored
whe marked as manual test cases. We need to collect them as well to make
the coverage flag set.