### PR TITLE
[1LP][RFR] New Test:: Testing start EVM command

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -820,9 +820,8 @@ def test_appliance_console_evm_stop():
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(2)
-def test_appliance_console_evm_start():
+def test_appliance_console_evm_start(request, appliance):
     """
     test starting the evm server process
 
@@ -844,7 +843,16 @@ def test_appliance_console_evm_start():
             4. Confirm EVM service is being started.
             5. Confirm replication is working correctly
     """
-    pass
+    appliance.evmserverd.stop()
+    wait_for(lambda: appliance.is_web_ui_running(), delay=30, num_sec=10, fail_condition=True)
+
+    # Actual testcase starting from here
+    start_evm_command = ("ap", RETURN, "17", "Y", RETURN, RETURN, "21")
+    appliance.appliance_console.run_commands(start_evm_command, timeout=300)
+    wait_for(lambda: appliance.is_web_ui_running(), delay=30, num_sec=10)
+    logged_in_page = appliance.server.login()
+    request.addfinalizer(appliance.server.logout)
+    assert logged_in_page.is_displayed, "UI is not working after starting the EVM service."
 
 
 @pytest.mark.manual


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- Testing start evm command using remote console and verifying output using API and UI

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
- {{pytest: cfme/tests/cli/test_appliance_console.py::test_appliance_console_evm_start -vvvvv}}