### PR TITLE
[1LP][RFR] New Test: Testing domain import with broken yml

### DIFF
--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -166,7 +166,6 @@ def test_automate_requests_tab_exposed():
             4. Did not allow user to see Requests under Automate.
             5. Enabled all the Service => Request role features.
             6. This allows user to see the Automate => Requests.
-
         expectedResults:
             1.
             2.
@@ -183,6 +182,7 @@ def test_automate_requests_tab_exposed():
 
 
 @pytest.mark.tier(3)
+@pytest.mark.manual('manualonly')
 def test_automate_git_credentials_changed():
     """
     Polarion:
@@ -248,30 +248,8 @@ def test_vm_naming_number_padding():
     pass
 
 
-@pytest.mark.tier(1)
-def test_git_refresh_with_renamed_yaml():
-    """
-    Polarion:
-        assignee: ghubale
-        initialEstimate: 1/8h
-        startsin: 5.10
-        casecomponent: Automate
-        testSteps:
-            1. Have a git backed Automate Domain
-            2. Delete (or rename) a .rb/.yaml pair, commit, push to repo
-            3. Refresh Domain in CF ui
-        expectedResults:
-            1.
-            2.
-            3. Domain should refresh successfully and renamed method appears
-
-    Bugzilla:
-        1716443
-    """
-    pass
-
-
 @pytest.mark.tier(2)
+@pytest.mark.manual('manualonly')
 def test_git_refresh_with_rapid_updates():
     """
     Polarion:
@@ -376,6 +354,7 @@ def test_queue_up_schedule_run_now():
 
 
 @pytest.mark.tier(2)
+@pytest.mark.manual('manualonly')
 @pytest.mark.meta(coverage=[1741259])
 def test_copy_automate_method_without_edit():
     """

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -525,3 +525,26 @@ def test_automate_git_import_deleted_tag(appliance, imported_domain):
     view = navigate_to(imported_domain, "Refresh")
     view.branch_or_tag.fill("Tag")
     assert view.git_tags.read() == "0.1"
+
+
+@pytest.mark.tier(1)
+def test_git_refresh_with_renamed_yaml():
+    """
+    Bugzilla:
+        1716443
+
+    Polarion:
+        assignee: ghubale
+        initialEstimate: 1/8h
+        startsin: 5.10
+        casecomponent: Automate
+        testSteps:
+            1. Have a git backed Automate Domain
+            2. Delete (or rename) a .rb/.yaml pair, commit, push to repo
+            3. Refresh Domain in CF ui
+        expectedResults:
+            1.
+            2.
+            3. Domain should refresh successfully and renamed method appears
+    """
+    pass

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -17,7 +17,7 @@ pytestmark = [
     pytest.mark.meta(server_roles="+git_owner"),
 ]
 
-GIT_REPO_URL = "https://github.com/RedHatQE/ManageIQ-automate-git.git"
+GIT_REPO_URL = cfme_data.automate_links.datastore_repositories.manageiq_automate
 
 
 @pytest.fixture
@@ -78,17 +78,16 @@ def test_automate_git_domain_displayed_in_service(appliance):
         initialEstimate: 1/20h
         tags: automate
     """
-    url = cfme_data.ansible_links.playbook_repositories.automate_domain
     repo = appliance.collections.automate_import_exports.instantiate(
-        import_type="git", url=url, verify_ssl=True
+        import_type="git", url=GIT_REPO_URL, verify_ssl=True
     )
-    imported_domain = repo.import_domain_from(branch="origin/master")
+    imported_domain = repo.import_domain_from(branch="origin/domain-display")
     collection = appliance.collections.catalog_items
     cat_item = collection.instantiate(collection.GENERIC, "test")
     view = navigate_to(cat_item, "Add")
     path = (
         "Datastore",
-        "{0} ({1}) ({0}) (Locked)".format(imported_domain.name, "origin/master"),
+        "{0} ({1}) ({0}) (Locked)".format(imported_domain.name, "origin/domain-display"),
         "Service",
         "Generic",
         "StateMachines",
@@ -123,13 +122,12 @@ def test_automate_git_import_multiple_domains(request, appliance):
             2.
             3. Import of multiple domains from a single git repo is not allowed
     """
-    url = "https://github.com/ganeshhubale/ManageIQ-automate-git"
     repo = appliance.collections.automate_import_exports.instantiate(
-        import_type="git", url=url, verify_ssl=True
+        import_type="git", url=GIT_REPO_URL, verify_ssl=True
     )
     with pytest.raises(AssertionError,
                        match="Selected branch or tag contains more than one domain"):
-        domain = repo.import_domain_from(branch="origin/master")
+        domain = repo.import_domain_from(branch="origin/multi-domains")
         request.addfinalizer(domain.delete_if_exists)
         assert not domain.exists
 
@@ -137,38 +135,32 @@ def test_automate_git_import_multiple_domains(request, appliance):
 @pytest.mark.meta(automates=[BZ(1714493)])
 @pytest.mark.tier(2)
 @pytest.mark.parametrize(
-    ("url", "param_type", "param_value", "verify_ssl"),
+    ("param_type", "param_value", "verify_ssl"),
     [
         (
-            'https://github.com/ramrexx/CloudForms_Essentials.git',
             'branch',
-            'origin/cf4.1',
+            'origin/testbranch',
             True
         ),
         (
-            'https://github.com/RedHatQE/ManageIQ-automate-git.git',
             'tag',
             '0.1',
             False
         ),
         (
-            "https://github.com/RedHatQE/ManageIQ-automate-git.git",
             "branch",
             "origin/master",
             False,
         ),
         (
-            "https://github.com/ganeshhubale/ManageIQ-automate-git.git",
             "branch",
-            "origin/test",
+            "origin/without-top-level",
             False,
         ),
     ],
     ids=["with_branch", "with_tag", "with_top_level_domain", "without_top_level_domain"],
 )
-def test_domain_import_git(
-    request, appliance, url, param_type, param_value, verify_ssl
-):
+def test_domain_import_git(request, appliance, param_type, param_value, verify_ssl):
     """This test case Verifies that a domain can be imported from git and Importing domain from git
        should work with or without the top level domain directory.
 
@@ -195,7 +187,7 @@ def test_domain_import_git(
         1389823
     """
     repo = appliance.collections.automate_import_exports.instantiate(
-        import_type="git", url=url, verify_ssl=verify_ssl
+        import_type="git", url=GIT_REPO_URL, verify_ssl=verify_ssl
     )
     domain = repo.import_domain_from(**{param_type: param_value})
     request.addfinalizer(domain.delete)
@@ -340,7 +332,7 @@ def test_automate_git_import_case_insensitive(request, appliance):
     """
     appliance.ssh_client.run_rake_command(
         "evm:automate:import PREVIEW=false "
-        "GIT_URL=https://github.com/RedHatQE/ManageIQ-automate-git REF=TestBranch"
+        f"GIT_URL={GIT_REPO_URL}"
     )
     domain = appliance.collections.domains.instantiate(name="testdomain")
     request.addfinalizer(domain.delete_if_exists)
@@ -553,9 +545,9 @@ def test_git_refresh_with_renamed_yaml(appliance):
             1. Domain should not get imported
     """
     repo = appliance.collections.automate_import_exports.instantiate(
-        import_type="git", url="https://github.com/ganeshhubale/ManageIQ-automate-git.git"
+        import_type="git", url=GIT_REPO_URL
     )
     with pytest.raises(AssertionError, match=(
             "Error: import failed: Selected branch or tag does not contain a valid domain"
     )):
-        repo.import_domain_from(branch="origin/brok-yml")
+        repo.import_domain_from(branch="origin/broken-yaml")

--- a/conf/cfme_data.yaml.template
+++ b/conf/cfme_data.yaml.template
@@ -677,3 +677,6 @@ vm_console:
         city: Durham
         organization: CFME
         organizational_unit: QE
+automate_links:
+    datastore_repositories:
+        manageiq_automate: https://github.com/RedHatQE/ManageIQ-automate-git.git


### PR DESCRIPTION
## Purpose or Intent
- **Note:** In this test case, we are checking that datastore with broken __domain__.yml should not
    get imported. But this BZ says, automate namespace, class, instance, method under domain should
    be refreshed even if you broke the __domain__.yml once it imported(This could be only tested
    manually)
- Made this test case (```test_copy_automate_method_without_edit```) - **manualonly**
### PRT Run
{{ pytest: cfme/tests/automate/test_git_import.py -k "test_git_refresh_with_renamed_yaml or test_automate_git_import_multiple_domains  or test_domain_import_git or test_automate_git_domain_displayed_in_service" --use-template-cache -qsvvv }}