### PR TITLE
[1LP][RFR] New Test: Testing available tags on GitHub repo are displayed while refreshing domain

### DIFF
--- a/cfme/automate/explorer/domain.py
+++ b/cfme/automate/explorer/domain.py
@@ -35,6 +35,7 @@ class DomainRefreshView(AutomateExplorerView):
     title = Text("#explorer_title_text")
     branch_or_tag = BootstrapSelect(id="branch_or_tag_select")
     git_branches = BootstrapSelect(id="git_branches")
+    git_tags = BootstrapSelect(id="git_tags")
 
     save_button = Button("Save")
     cancel_button = Button("Cancel")

--- a/cfme/tests/automate/test_automate_manual.py
+++ b/cfme/tests/automate/test_automate_manual.py
@@ -109,39 +109,6 @@ def test_automate_check_quota_regression():
     pass
 
 
-@pytest.mark.tier(3)
-def test_automate_git_import_deleted_tag():
-    """
-
-    Polarion:
-        assignee: ghubale
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/12h
-        tags: automate
-        startsin: 5.7
-        testSteps:
-            1. Create a github-hosted repository containing a correctly formatted automate domain.
-               This repository should contain two or more tagged commits.
-            2. Import the git-hosted domain into automate. Note that the tags are visible to select
-               from in the import dialog
-            3. Delete the most recent tagged commit and tag from the source github repository
-            4. In automate explorer, click on the domain and click Configuration -> Refresh with a
-               new branch or tag
-            5. Observe the list of available tags to import from
-        expectedResults:
-            1.
-            2.
-            3.
-            4.
-            5. The deleted tag should no longer be visible in the list of tags to refresh from
-
-    Bugzilla:
-        1394194
-    """
-    pass
-
-
 @pytest.mark.tier(2)
 def test_button_can_trigger_events():
     """

--- a/cfme/tests/automate/test_git_import.py
+++ b/cfme/tests/automate/test_git_import.py
@@ -491,3 +491,37 @@ def test_automate_git_verify_ssl(appliance, setup_datastore, imported_domain):
     check_verify_ssl()
     imported_domain.rest_api_entity.action.refresh_from_source()
     check_verify_ssl()
+
+
+@pytest.mark.tier(3)
+@pytest.mark.meta(automates=[1394194])
+def test_automate_git_import_deleted_tag(appliance, imported_domain):
+    """
+    Note: This test case checks tags available on GitHub repository. But we can not delete or add
+    tags in GitHub repository using automation.
+
+    Bugzilla:
+        1394194
+
+    Polarion:
+        assignee: ghubale
+        casecomponent: Automate
+        caseimportance: medium
+        initialEstimate: 1/12h
+        tags: automate
+        startsin: 5.7
+        setup:
+            1. Create a github-hosted repository containing a correctly formatted automate domain.
+               This repository should contain tagged commits.
+            2. Import the git-hosted domain into automate.
+        testSteps:
+            1. In automate explorer, click on the domain and click Configuration -> Refresh with a
+               new branch or tag -> Select Branch/Tag - 'Tag'
+            2. Observe the list of available tags to import from
+        expectedResults:
+            1.
+            2. The available tags should be displayed
+    """
+    view = navigate_to(imported_domain, "Refresh")
+    view.branch_or_tag.fill("Tag")
+    assert view.git_tags.read() == "0.1"


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>


## Purpose or Intent
- Testing available tags on GitHub repo are displayed while refreshing domain
### PRT Run
{{ pytest: cfme/tests/automate/test_git_import.py -k 'test_automate_git_import_deleted_tag' --use-template-cache -qsvvv }}