### PR TITLE
[1LP][RFR] Make appliance_log_collector able to fetch logs from additional appliances.

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -87,25 +87,28 @@ def temp_appliance_preconfig(temp_appliance_preconfig_modscope):
 
 
 @pytest.fixture(scope="module")
-def temp_appliance_preconfig_modscope(appliance, pytestconfig):
+def temp_appliance_preconfig_modscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=True) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="class")
-def temp_appliance_preconfig_clsscope(appliance, pytestconfig):
+def temp_appliance_preconfig_clsscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=True) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
-def temp_appliance_preconfig_funcscope(appliance, pytestconfig):
+def temp_appliance_preconfig_funcscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=True) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
-def temp_appliance_preconfig_funcscope_upgrade(appliance, pytestconfig):
+def temp_appliance_preconfig_funcscope_upgrade(request, appliance, pytestconfig):
     split_version = (str(appliance.version).split("."))
     with sprout_appliances(
             appliance,
@@ -116,16 +119,18 @@ def temp_appliance_preconfig_funcscope_upgrade(appliance, pytestconfig):
             )  # n-1 stream for upgrade
     ) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="module")
-def temp_appliance_preconfig_long(appliance, pytestconfig):
+def temp_appliance_preconfig_long(request, appliance, pytestconfig):
     """ temp appliance with 24h lease for auth tests """
     with sprout_appliances(
             appliance, config=pytestconfig, preconfigured=True, lease_time=1440,
             provider_type='rhevm'
     ) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 # Single appliance, unconfigured
@@ -135,25 +140,28 @@ def temp_appliance_unconfig(temp_appliance_unconfig_modscope):
 
 
 @pytest.fixture(scope="module")
-def temp_appliance_unconfig_modscope(appliance, pytestconfig):
+def temp_appliance_unconfig_modscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=False) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="class")
-def temp_appliance_unconfig_clsscope(appliance, pytestconfig):
+def temp_appliance_unconfig_clsscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=False) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
-def temp_appliance_unconfig_funcscope(appliance, pytestconfig):
+def temp_appliance_unconfig_funcscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=False) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
-def temp_appliance_unconfig_funcscope_rhevm(appliance, pytestconfig):
+def temp_appliance_unconfig_funcscope_rhevm(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig,
@@ -161,6 +169,7 @@ def temp_appliance_unconfig_funcscope_rhevm(appliance, pytestconfig):
             provider_type='rhevm'
     ) as appliances:
         yield appliances[0]
+        call_collect_logs_hook(request.config, appliances)
 
 
 # Pair of appliances, unconfigured
@@ -170,7 +179,7 @@ def temp_appliances_unconfig(temp_appliances_unconfig_modscope):
 
 
 @pytest.fixture(scope="module")
-def temp_appliances_unconfig_modscope(appliance, pytestconfig):
+def temp_appliances_unconfig_modscope(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig,
@@ -178,10 +187,11 @@ def temp_appliances_unconfig_modscope(appliance, pytestconfig):
             preconfigured=False
     ) as appliances:
         yield appliances
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
-def temp_appliances_unconfig_funcscope_rhevm(appliance, pytestconfig):
+def temp_appliances_unconfig_funcscope_rhevm(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig,
@@ -190,6 +200,7 @@ def temp_appliances_unconfig_funcscope_rhevm(appliance, pytestconfig):
             provider_type='rhevm'
     ) as appliances:
         yield appliances
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="module")
@@ -202,10 +213,11 @@ def temp_appliances_unconfig_modscope_rhevm(request, appliance, pytestconfig):
             provider_type='rhevm'
     ) as appliances:
         yield appliances
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
-def temp_appliances_preconfig_funcscope(appliance, pytestconfig):
+def temp_appliances_preconfig_funcscope(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig,
@@ -213,10 +225,11 @@ def temp_appliances_preconfig_funcscope(appliance, pytestconfig):
             preconfigured=True
     ) as appliances:
         yield appliances
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="class")
-def temp_appliances_unconfig_clsscope(appliance, pytestconfig):
+def temp_appliances_unconfig_clsscope(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig,
@@ -224,10 +237,11 @@ def temp_appliances_unconfig_clsscope(appliance, pytestconfig):
             preconfigured=False
     ) as appliances:
         yield appliances
+        call_collect_logs_hook(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
-def temp_appliances_unconfig_funcscope(appliance, pytestconfig):
+def temp_appliances_unconfig_funcscope(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig,
@@ -289,3 +303,8 @@ def temp_appliance_extended_db(temp_appliance_preconfig):
     app.db.extend_partition()
     app.evmserverd.start()
     return app
+
+
+def call_collect_logs_hook(config, appliances):
+    # TODO only call when hook registered and available.
+    config.pluginmanager.hook.pytest_collect_logs(config=config, appliances=appliances)

--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -90,21 +90,21 @@ def temp_appliance_preconfig(temp_appliance_preconfig_modscope):
 def temp_appliance_preconfig_modscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=True) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="class")
 def temp_appliance_preconfig_clsscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=True) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
 def temp_appliance_preconfig_funcscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=True) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
@@ -119,7 +119,7 @@ def temp_appliance_preconfig_funcscope_upgrade(request, appliance, pytestconfig)
             )  # n-1 stream for upgrade
     ) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="module")
@@ -130,7 +130,7 @@ def temp_appliance_preconfig_long(request, appliance, pytestconfig):
             provider_type='rhevm'
     ) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 # Single appliance, unconfigured
@@ -143,21 +143,21 @@ def temp_appliance_unconfig(temp_appliance_unconfig_modscope):
 def temp_appliance_unconfig_modscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=False) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="class")
 def temp_appliance_unconfig_clsscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=False) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
 def temp_appliance_unconfig_funcscope(request, appliance, pytestconfig):
     with sprout_appliances(appliance, config=pytestconfig, preconfigured=False) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
@@ -169,7 +169,7 @@ def temp_appliance_unconfig_funcscope_rhevm(request, appliance, pytestconfig):
             provider_type='rhevm'
     ) as appliances:
         yield appliances[0]
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 # Pair of appliances, unconfigured
@@ -187,7 +187,7 @@ def temp_appliances_unconfig_modscope(request, appliance, pytestconfig):
             preconfigured=False
     ) as appliances:
         yield appliances
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
@@ -200,7 +200,7 @@ def temp_appliances_unconfig_funcscope_rhevm(request, appliance, pytestconfig):
             provider_type='rhevm'
     ) as appliances:
         yield appliances
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="module")
@@ -213,7 +213,7 @@ def temp_appliances_unconfig_modscope_rhevm(request, appliance, pytestconfig):
             provider_type='rhevm'
     ) as appliances:
         yield appliances
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
@@ -225,7 +225,7 @@ def temp_appliances_preconfig_funcscope(request, appliance, pytestconfig):
             preconfigured=True
     ) as appliances:
         yield appliances
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="class")
@@ -237,7 +237,7 @@ def temp_appliances_unconfig_clsscope(request, appliance, pytestconfig):
             preconfigured=False
     ) as appliances:
         yield appliances
-        call_collect_logs_hook(request.config, appliances)
+        _collect_logs(request.config, appliances)
 
 
 @pytest.fixture(scope="function")
@@ -305,6 +305,9 @@ def temp_appliance_extended_db(temp_appliance_preconfig):
     return app
 
 
-def call_collect_logs_hook(config, appliances):
-    # TODO only call when hook registered and available.
+def _collect_logs(config, appliances):
+    """ Wraps calling the pytest_collect_logs hook
+    This method is there currently just for saving the typing as the call is
+    made on many places.
+    """
     config.pluginmanager.hook.pytest_collect_logs(config=config, appliances=appliances)

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -189,7 +189,7 @@ def get_puddle_cfme_version(repo_file_path):
 
 
 @contextmanager
-def get_apps(appliance, old_version, count, preconfigured, pytest_config):
+def get_apps(requests, appliance, old_version, count, preconfigured, pytest_config):
     """Requests appliance from sprout based on old_versions, edits partitions and adds
         repo file for update"""
     series = appliance.version.series()
@@ -227,6 +227,7 @@ def get_apps(appliance, old_version, count, preconfigured, pytest_config):
         logger.exception(msg)
         pytest.skip(msg)
     finally:
+        call_collect_logs_hook(pytest_config, apps)
         for app in apps:
             app.ssh_client.close()
         if pool_id:
@@ -236,7 +237,7 @@ def get_apps(appliance, old_version, count, preconfigured, pytest_config):
 @pytest.fixture
 def appliance_preupdate(appliance, old_version, request):
     """Requests single appliance from sprout."""
-    with get_apps(appliance, old_version, count=1, preconfigured=True,
+    with get_apps(request, appliance, old_version, count=1, preconfigured=True,
                   pytest_config=request.config) as apps:
         yield apps[0]
 
@@ -244,7 +245,7 @@ def appliance_preupdate(appliance, old_version, request):
 @pytest.fixture
 def multiple_preupdate_appliances(appliance, old_version, request):
     """Requests multiple appliances from sprout."""
-    with get_apps(appliance, old_version, count=2, preconfigured=False,
+    with get_apps(request, appliance, old_version, count=2, preconfigured=False,
                   pytest_config=request.config) as apps:
         yield apps
 
@@ -252,7 +253,7 @@ def multiple_preupdate_appliances(appliance, old_version, request):
 @pytest.fixture
 def ha_multiple_preupdate_appliances(appliance, old_version, request):
     """Requests multiple appliances from sprout."""
-    with get_apps(appliance, old_version, count=3, preconfigured=False,
+    with get_apps(request, appliance, old_version, count=3, preconfigured=False,
                   pytest_config=request.config) as apps:
         yield apps
 

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -12,7 +12,7 @@ from lxml import etree
 import cfme.utils.auth as authutil
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.configure.configuration.region_settings import RedHatUpdates
-from cfme.fixtures.appliance import call_collect_logs_hook
+from cfme.fixtures.appliance import _collect_logs
 from cfme.fixtures.appliance import sprout_appliances
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.test_framework.sprout.client import AuthException
@@ -41,7 +41,7 @@ def unconfigured_appliance(request, appliance, pytestconfig):
             provider_type='rhevm',
     ) as apps:
         yield apps[0]
-        call_collect_logs_hook(request.config, apps)
+        _collect_logs(request.config, apps)
 
 
 @pytest.fixture()
@@ -54,7 +54,7 @@ def unconfigured_appliance_secondary(request, appliance, pytestconfig):
             provider_type='rhevm',
     ) as apps:
         yield apps[0]
-        call_collect_logs_hook(request.config, apps)
+        _collect_logs(request.config, apps)
 
 
 @pytest.fixture()
@@ -67,7 +67,7 @@ def unconfigured_appliances(request, appliance, pytestconfig):
             provider_type='rhevm',
     ) as apps:
         yield apps
-        call_collect_logs_hook(request.config, apps)
+        _collect_logs(request.config, apps)
 
 
 @pytest.fixture()
@@ -80,7 +80,7 @@ def configured_appliance(request, appliance, pytestconfig):
             provider_type='rhevm',
     ) as apps:
         yield apps[0]
-        call_collect_logs_hook(request.config, apps)
+        _collect_logs(request.config, apps)
 
 
 @pytest.fixture(scope="function")
@@ -227,7 +227,7 @@ def get_apps(requests, appliance, old_version, count, preconfigured, pytest_conf
         logger.exception(msg)
         pytest.skip(msg)
     finally:
-        call_collect_logs_hook(pytest_config, apps)
+        _collect_logs(pytest_config, apps)
         for app in apps:
             app.ssh_client.close()
         if pool_id:

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -12,6 +12,7 @@ from lxml import etree
 import cfme.utils.auth as authutil
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.configure.configuration.region_settings import RedHatUpdates
+from cfme.fixtures.appliance import call_collect_logs_hook
 from cfme.fixtures.appliance import sprout_appliances
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.test_framework.sprout.client import AuthException
@@ -31,7 +32,7 @@ TimedCommand = namedtuple("TimedCommand", ["command", "timeout"])
 
 
 @pytest.fixture()
-def unconfigured_appliance(appliance, pytestconfig):
+def unconfigured_appliance(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             preconfigured=False,
@@ -40,10 +41,11 @@ def unconfigured_appliance(appliance, pytestconfig):
             provider_type='rhevm',
     ) as apps:
         yield apps[0]
+        call_collect_logs_hook(request.config, apps)
 
 
 @pytest.fixture()
-def unconfigured_appliance_secondary(appliance, pytestconfig):
+def unconfigured_appliance_secondary(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             preconfigured=False,
@@ -52,10 +54,11 @@ def unconfigured_appliance_secondary(appliance, pytestconfig):
             provider_type='rhevm',
     ) as apps:
         yield apps[0]
+        call_collect_logs_hook(request.config, apps)
 
 
 @pytest.fixture()
-def unconfigured_appliances(appliance, pytestconfig):
+def unconfigured_appliances(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             preconfigured=False,
@@ -64,10 +67,11 @@ def unconfigured_appliances(appliance, pytestconfig):
             provider_type='rhevm',
     ) as apps:
         yield apps
+        call_collect_logs_hook(request.config, apps)
 
 
 @pytest.fixture()
-def configured_appliance(appliance, pytestconfig):
+def configured_appliance(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             preconfigured=True,
@@ -76,6 +80,7 @@ def configured_appliance(appliance, pytestconfig):
             provider_type='rhevm',
     ) as apps:
         yield apps[0]
+        call_collect_logs_hook(request.config, apps)
 
 
 @pytest.fixture(scope="function")

--- a/cfme/test_framework/appliance_log_collector.py
+++ b/cfme/test_framework/appliance_log_collector.py
@@ -9,6 +9,7 @@ Options in env.yaml will define what files to collect, will default to the set b
             - /var/www/miq/vmdb/log/evm.log
             - /var/www/miq/vmdb/log/production.log
             - /var/www/miq/vmdb/log/automation.log
+            - /var/www/miq/vmdb/log/appliance_console.log
 
 Log files will be tarred and written to log_path
 """
@@ -21,7 +22,8 @@ from cfme.utils.path import log_path
 
 DEFAULT_FILES = ['/var/www/miq/vmdb/log/evm.log',
                  '/var/www/miq/vmdb/log/production.log',
-                 '/var/www/miq/vmdb/log/automation.log']
+                 '/var/www/miq/vmdb/log/automation.log',
+                 '/var/www/miq/vmdb/log/appliance_console.log']
 
 DEFAULT_LOCAL = log_path
 

--- a/cfme/test_framework/appliance_log_collector.py
+++ b/cfme/test_framework/appliance_log_collector.py
@@ -32,50 +32,75 @@ def pytest_addoption(parser):
                            'shutdown.  Configured via log_collector in env.yaml'))
 
 
+def pytest_addhooks(pluginmanager):
+    """ This example assumes the hooks are grouped in the 'hooks' module. """
+    pluginmanager.add_hookspecs(CollectLogsHookSpecs)
+
+
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
 def pytest_unconfigure(config):
     yield  # since hookwrapper, let hookimpl run
-    if config.getoption('--collect-logs'):
-        logger.info('Starting log collection on appliances')
-        log_files = DEFAULT_FILES
-        local_dir = DEFAULT_LOCAL
-        try:
-            log_files = env.log_collector.log_files
-        except (AttributeError, KeyError):
-            logger.info('No log_collector.log_files in env, use default files: %s', log_files)
-            pass
-        try:
-            local_dir = log_path.join(env.log_collector.local_dir)
-        except (AttributeError, KeyError):
-            logger.info('No log_collector.local_dir in env, use default local_dir: %s', local_dir)
-            pass
+    from cfme.test_framework.appliance import PLUGIN_KEY
+    holder = config.pluginmanager.get_plugin(PLUGIN_KEY)
+    if holder is None:
+        # No appliances to fetch logs from
+        logger.warning('No logs to collect, appliance holder is empty')
+        return
 
-        # Handle local dir existing
-        local_dir.ensure(dir=True)
-        from cfme.test_framework.appliance import PLUGIN_KEY
-        holder = config.pluginmanager.get_plugin(PLUGIN_KEY)
-        if holder is None:
-            # No appliances to fetch logs from
-            logger.warning('No logs collected, appliance holder is empty')
-            return
+    collect_logs = config.pluginmanager.hook.pytest_collect_logs
+    collect_logs(config=config, appliances=holder.appliances)
 
-        written_files = []
-        for app in holder.appliances:
-            with app.ssh_client as ssh_client:
-                tar_file = 'log-collector-{}.tar.gz'.format(
-                    app.hostname)
-                logger.debug('Creating tar file on app %s:%s with log files %s',
-                             app, tar_file, ' '.join(log_files))
-                # wrap the files in ls, redirecting stderr, to ignore files that don't exist
-                tar_result = ssh_client.run_command(
-                    'tar -czvf {tar} $(ls {files} 2>/dev/null)'
-                    .format(tar=tar_file, files=' '.join(log_files)))
-                try:
-                    assert tar_result.success
-                except AssertionError:
-                    logger.exception('Tar command non-zero RC when collecting logs on %s: %s',
-                                     app, tar_result.output)
-                    continue
-                ssh_client.get_file(tar_file, local_dir.strpath)
-            written_files.append(tar_file)
-        logger.info('Wrote the following files to local log path: %s', written_files)
+
+@pytest.hookimpl
+def pytest_collect_logs(config, appliances):
+    if not config.getoption('--collect-logs'):
+        return
+
+    for app in appliances:
+        try:
+            collect_logs(app)
+        except Exception as exc:
+            logger.error(f"Failed to collect logs: {exc}")
+
+
+def collect_logs(app):
+    log_files = DEFAULT_FILES
+    local_dir = DEFAULT_LOCAL
+    try:
+        log_files = env.log_collector.log_files
+    except (AttributeError, KeyError):
+        logger.info('No log_collector.log_files in env, use default files: %s', log_files)
+        pass
+    try:
+        local_dir = log_path.join(env.log_collector.local_dir)
+    except (AttributeError, KeyError):
+        logger.info('No log_collector.local_dir in env, use default local_dir: %s', local_dir)
+        pass
+
+    # Handle local dir existing
+    local_dir.ensure(dir=True)
+
+    with app.ssh_client as ssh_client:
+        logger.info(f'Starting log collection on appliance {app.hostname}')
+        tar_file = 'log-collector-{}.tar.gz'.format(
+            app.hostname)
+        logger.debug('Creating tar file on app %s:%s with log files %s',
+                    app, tar_file, ' '.join(log_files))
+        # wrap the files in ls, redirecting stderr, to ignore files that don't exist
+        tar_result = ssh_client.run_command(
+            'tar -czvf {tar} $(ls {files} 2>/dev/null)'
+            .format(tar=tar_file, files=' '.join(log_files)))
+        try:
+            assert tar_result.success
+        except AssertionError:
+            raise RuntimeError(
+                f'Tar command non-zero RC when collecting logs on {app}: {tar_result.output}')
+        ssh_client.get_file(tar_file, local_dir.strpath)
+        logger.info('Wrote the following file to %s: %s', local_dir.strpath, tar_file)
+
+
+class CollectLogsHookSpecs:
+    @pytest.hookspec
+    def pytest_collect_logs(config, appliances):
+        logger.warning('Executing the hookspec')
+        pass

--- a/cfme/test_framework/appliance_log_collector.py
+++ b/cfme/test_framework/appliance_log_collector.py
@@ -14,6 +14,7 @@ Options in env.yaml will define what files to collect, will default to the set b
 Log files will be tarred and written to log_path
 """
 import os.path
+import shutil
 import subprocess
 
 import pytest
@@ -101,6 +102,7 @@ def collect_logs(app):
         logger.debug('Creating tar file for appliance %s', app)
         subprocess.run(['tar', '-C', local_dir, '-czvf', tarball_path, tarred_dir_name],
                        stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+        shutil.rmtree(tar_dir_path)
         logger.info('Wrote the following file %s', tarball_path)
 
 


### PR DESCRIPTION
Register a pytest_collect_logs hook that when called, the logs will get
collected when --collect-log is specified.

The PR test is in invalid status, but I believe this is not related to the PR changes. It failed to connect to trackerbot.

The tests executed as part of PRT are irrelevant they just show that we get the logs collected. For this it is actually good that the 5.11 test failed. We can see collection happens even in that case.

{{pytest:  cfme/tests/cli/test_appliance_console_db_restore.py::test_appliance_console_restore_db_samba -v --use-provider 'complete' --collect-logs }}
