### PR TITLE
[WIPTEST]Automate: test_widget_generate_content_via_rest

### DIFF
--- a/cfme/intelligence/reports/widgets/__init__.py
+++ b/cfme/intelligence/reports/widgets/__init__.py
@@ -9,6 +9,7 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
+from cfme.exceptions import RestLookupError
 from cfme.intelligence.reports import CloudIntelReportsView
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
@@ -99,6 +100,15 @@ class BaseDashboardReportWidget(BaseEntity, Updateable, Pretty):
             view = self.create_view(AllDashboardWidgetsView)
         assert view.is_displayed
         view.flash.assert_no_error()
+
+    @property
+    def rest_api_entity(self):
+        try:
+            return self.appliance.rest_api.collections.widgets.get(description=self.description)
+        except ValueError:
+            raise RestLookupError(
+                f"No widget rest entity found matching description {self.description}"
+            )
 
 
 @attr.s

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -2,8 +2,6 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.utils.appliance.implementations.rest import ViaREST
-from cfme.utils.appliance.implementations.ui import ViaUI
 
 pytestmark = [pytest.mark.manual]
 
@@ -46,44 +44,6 @@ def test_notification_url_parallel_requests():
             3.
             4.
             5. Check if all the requests were processed and completed
-    """
-    pass
-
-
-@pytest.mark.meta(coverage=[1761836])
-@pytest.mark.tier(3)
-@test_requirements.rest
-@pytest.mark.parametrize("context", [ViaUI, ViaREST])
-def test_widget_generate_content_via_rest(context):
-    """
-    Bugzilla:
-       1761836
-       1623607
-       1753682
-
-    Polarion:
-        assignee: pvala
-        caseimportance: medium
-        casecomponent: Rest
-        initialEstimate: 1/4h
-        testSteps:
-            1. Depending on the implementation -
-                i. GET /api/widgtes/:id and note the `last_generated_content_on`.
-                ii. Navigate to Dashboard and note the `last_generated_content_on` for the widget.
-            2. POST /api/widgets/:id
-                {
-                    "action": "generate_content"
-                }
-            3. Wait until the task completes.
-            4. Depending on the implementation
-                i. GET /api/widgets/:id and compare the value of `last_generated_content_on`
-                    with the value noted in step 1.
-                ii.  Navigate to the dashboard and check if the value was updated for the widget.
-        expectedResults:
-            1.
-            2.
-            3.
-            4. Both values must be different, value must be updated.
     """
     pass
 


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__ 
    1. `test_widget_generate_content_via_rest`
- __Extending tests__
    1. Modifying fixture `custom_widgets` to take arguments.
- __Enhancement__
    1. Add `rest_api_entity` property for `BaseDashboardReportWidget` entity.


### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_widgets.py -k "test_widget_generate_content_via_rest or test_widgets_on_dashboard" -vvvv }}