### PR TITLE
[1LP][RFR] Fix ftp failures due to year change

### DIFF
--- a/cfme/utils/ftp.py
+++ b/cfme/utils/ftp.py
@@ -334,9 +334,13 @@ class FTPClient(object):
             fields = re.split(r"\s+", line, maxsplit=8)
             # This is because how informations in LIST are presented
             # Nov 11 12:34 filename (from the end)
-            date = strptime(str(datetime.now().year) + " " + fields[-4] + " " + fields[-3] + " " +
-                            fields[-2],
-                            "%Y %b %d %H:%M")
+            try:
+                date = strptime(
+                    f"{datetime.now().year} {fields[-4]} {fields[-3]} {fields[-2]}",
+                    "%Y %b %d %H:%M",
+                )
+            except ValueError:
+                date = strptime(f"{datetime.now().year} {fields[-4]} {fields[-3]}", "%Y %b %d")
             # convert time.struct_time into datetime
             date = datetime.fromtimestamp(mktime(date))
             result.append((is_dir, fields[-1], date))

--- a/cfme/utils/ftp.py
+++ b/cfme/utils/ftp.py
@@ -332,15 +332,12 @@ class FTPClient(object):
             is_dir = line.upper().startswith("D")
             # Max 8, then the final is file which can contain something blank
             fields = re.split(r"\s+", line, maxsplit=8)
-            # This is because how informations in LIST are presented
-            # Nov 11 12:34 filename (from the end)
-            try:
-                date = strptime(
-                    f"{datetime.now().year} {fields[-4]} {fields[-3]} {fields[-2]}",
-                    "%Y %b %d %H:%M",
-                )
-            except ValueError:
-                date = strptime(f"{datetime.now().year} {fields[-4]} {fields[-3]}", "%Y %b %d")
+            # This is because how information in LIST are presented
+            # `Nov 11 12:34 filename (from the end)` for current year files
+            # `Nov 11 2019 filename (from the end)` for back year files
+            yr = datetime.now().year if ":" in fields[-2] else fields[-2]
+            time = fields[-2] if ":" in fields[-2] else "00:00"
+            date = strptime(f"{yr} {fields[-4]} {fields[-3]} {time}", "%Y %b %d %H:%M")
             # convert time.struct_time into datetime
             date = datetime.fromtimestamp(mktime(date))
             result.append((is_dir, fields[-1], date))


### PR DESCRIPTION
## Purpose or Intent
- __Fixing__ `FTPClient.ls()` which in my opinion is failing due to the change in year.

**Normal lines**
-rwxrwxrwx   1 ftp      ftp          1602 Jul 25 **05:02** filter_report.yaml

**Changed lines**                   
-rwxrwxrwx   1 ftp      ftp          1361 Jun 10  **2019** import_report.yaml

Error:
```
ValueError                                Traceback (most recent call last)
<ipython-input-13-eec0aba7fc42> in <module>
----> 1 fs.ls()

~/code/cfme_workspace/integration_tests/cfme/utils/ftp.py in ls(self)
    343             result.append((is_dir, fields[-1], date))
    344 
--> 345         self.ftp.dir(_callback)
    346         return result
    347 

/usr/lib64/python3.7/ftplib.py in dir(self, *args)
    573             if arg:
    574                 cmd = cmd + (' ' + arg)
--> 575         self.retrlines(cmd, func)
    576 
    577     def mlsd(self, path="", facts=[]):

/usr/lib64/python3.7/ftplib.py in retrlines(self, cmd, callback)
    480                 elif line[-1:] == '\n':
    481                     line = line[:-1]
--> 482                 callback(line)
    483             # shutdown ssl layer
    484             if _SSLSocket is not None and isinstance(conn, _SSLSocket):

~/code/cfme_workspace/integration_tests/cfme/utils/ftp.py in _callback(line)
    336             # Nov 11 12:34 filename (from the end)
    337             import ipdb; ipdb.set_trace()
--> 338             date = strptime(str(datetime.now().year) + " " + fields[-4] + " " + fields[-3] + " " +
    339                             fields[-2],
    340                             "%Y %b %d %H:%M")

/usr/lib64/python3.7/_strptime.py in _strptime_time(data_string, format)
    569     """Return a time struct based on the input string and the
    570     format string."""
--> 571     tt = _strptime(data_string, format)[0]
    572     return time.struct_time(tt[:time._STRUCT_TM_ITEMS])
    573 

/usr/lib64/python3.7/_strptime.py in _strptime(data_string, format)
    357     if not found:
    358         raise ValueError("time data %r does not match format %r" %
--> 359                          (data_string, format))
    360     if len(data_string) != found.end():
    361         raise ValueError("unconverted data remains: %s" %

ValueError: time data '2020 Jun 10 2019' does not match format '%Y %b %d %H:%M'
```