### PR TITLE
[1LP][RFR] Fix SSA fixture for failing tests.

### DIFF
--- a/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
+++ b/cfme/tests/cloud_infra_common/test_vm_instance_analysis.py
@@ -587,7 +587,8 @@ def test_ssa_template(local_setup_provider, provider, soft_assert, vm_analysis_p
 
 @pytest.mark.tier(2)
 def test_ssa_compliance(local_setup_provider, ssa_compliance_profile, ssa_vm,
-                        soft_assert, appliance, vm_system_type):
+                        soft_assert, appliance, vm_system_type,
+                        compare_linux_vm_data, compare_windows_vm_data):
     """ Tests SSA can be performed and returns sane results
 
     Metadata:
@@ -626,7 +627,8 @@ def test_ssa_compliance(local_setup_provider, ssa_compliance_profile, ssa_vm,
 
 @pytest.mark.rhv3
 @pytest.mark.tier(2)
-def test_ssa_schedule(ssa_vm, schedule_ssa, soft_assert, vm_system_type):
+def test_ssa_schedule(ssa_vm, schedule_ssa, soft_assert, vm_system_type,
+                      compare_linux_vm_data, compare_windows_vm_data):
     """ Tests SSA can be performed and returns sane results
 
     Metadata:
@@ -663,7 +665,8 @@ def test_ssa_schedule(ssa_vm, schedule_ssa, soft_assert, vm_system_type):
 
 @pytest.mark.rhv1
 @pytest.mark.tier(2)
-def test_ssa_vm(ssa_vm, scanned_vm, soft_assert, vm_system_type):
+def test_ssa_vm(ssa_vm, scanned_vm, soft_assert, vm_system_type,
+                compare_linux_vm_data, compare_windows_vm_data):
     """ Tests SSA can be performed and returns sane results
 
     Metadata:


### PR DESCRIPTION
## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

- This PR will fix calling of parametrized fixture.

- **Error in tests:**

```
Fixture "compare_linux_vm_data" called directly. Fixtures are not meant to be called directly,
but are created automatically when test functions request them as parameters.
See https://docs.pytest.org/en/latest/fixture.html for more information about fixtures, and
https://docs.pytest.org/en/latest/deprecations.html#calling-fixtures-directly about how to update your code.
```

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked


Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/cloud_infra_common/test_vm_instance_analysis.py -k "test_ssa_compliance or test_ssa_schedule or test_ssa_vm" --use-provider vsphere65-nested --long-running -vvv}}