### PR TITLE
[1LP][RFR] Replace usage of entity.check() with entity.ensure_checked. Part 2.

### DIFF
--- a/cfme/ansible/playbooks.py
+++ b/cfme/ansible/playbooks.py
@@ -128,5 +128,6 @@ class EditTagsFromListCollection(CFMENavigateStep):
     prerequisite = NavigateToAttribute("appliance.server", "AnsiblePlaybooks")
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(surf_pages=True, name=self.obj.name).check()
+        self.prerequisite_view.entities.get_entity(surf_pages=True,
+                                                   name=self.obj.name).ensure_checked()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -360,7 +360,8 @@ class ManagePolicies(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   surf_pages=True).ensure_checked()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
 
 
@@ -671,7 +672,7 @@ class TaggableCollection(TaggableCommonBase):
                                  entity_filter_key)
                 raise
             # checkbox for given entity
-            view.entities.get_entity(surf_pages=True, **entity_kwargs).check()
+            view.entities.get_entity(surf_pages=True, **entity_kwargs).ensure_checked()
         view = self._open_edit_tag_page(view)
         added_tag, updated = self._assign_tag_action(view, tag)
         # In case if field is not updated cancel the edition
@@ -714,7 +715,7 @@ class TaggableCollection(TaggableCommonBase):
                                  entity_filter_key)
                 raise
             # checkbox for given entity
-            view.entities.get_entity(surf_pages=True, **entity_kwargs).check()
+            view.entities.get_entity(surf_pages=True, **entity_kwargs).ensure_checked()
         view = self._open_edit_tag_page(view)
         self._unassign_tag_action(view, tag)
         self._tags_action(view, cancel, reset)
@@ -772,9 +773,10 @@ class EditTagsFromListCollection(CFMENavigateStep):
             for entity in args:
                 name = entity.name if isinstance(entity, BaseEntity) else entity
                 self.prerequisite_view.entities.get_entity(
-                    surf_pages=True, name=name).check()
+                    surf_pages=True, name=name).ensure_checked()
         else:
-            self.prerequisite_view.entities.get_entity(surf_pages=True, name=self.obj.name).check()
+            self.prerequisite_view.entities.get_entity(surf_pages=True,
+                                                       name=self.obj.name).ensure_checked()
         # not for all entities we have select like 'Edit Tags',
         # users, groups, tenants have specific dropdown title
         try:

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -458,7 +458,7 @@ class Edit(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.entities.get_entity(name=self.obj.name,
-                                                   surf_pages=True).check()
+                                                   surf_pages=True).ensure_checked()
         self.prerequisite_view.toolbar.configuration.item_select(
             'Edit Selected Containers Provider')
 

--- a/cfme/generic_objects/instance/ui.py
+++ b/cfme/generic_objects/instance/ui.py
@@ -142,7 +142,8 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToAttribute('definition', 'Instances')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   surf_pages=True).ensure_checked()
         self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
 
 

--- a/cfme/infrastructure/config_management/__init__.py
+++ b/cfme/infrastructure/config_management/__init__.py
@@ -389,7 +389,7 @@ class ConfigManagerProvider(BaseProvider, Updateable, Pretty):
             return
         view = navigate_to(self, 'AllOfType')
         provider_entity = view.entities.get_entities_by_keys(provider_name=self.ui_name)
-        provider_entity[0].check()
+        provider_entity[0].ensure_checked()
         remove_item = 'Remove selected items from Inventory'
         view.toolbar.configuration.item_select(remove_item, handle_alert=not cancel)
         if not cancel:
@@ -480,7 +480,7 @@ class ConfigManagerProvider(BaseProvider, Updateable, Pretty):
         view = navigate_to(self, 'AllOfType')
         view.toolbar.view_selector.select('List View')
         provider_entity = view.entities.get_entities_by_keys(provider_name=self.ui_name)[0]
-        provider_entity.check()
+        provider_entity.ensure_checked()
         if view.toolbar.configuration.item_enabled('Refresh Relationships and Power states'):
             view.toolbar.configuration.item_select('Refresh Relationships and Power states',
                                                    handle_alert=not cancel)

--- a/cfme/infrastructure/deployment_roles.py
+++ b/cfme/infrastructure/deployment_roles.py
@@ -226,7 +226,7 @@ class DeploymentRoleCollection(BaseCollection):
         if view.entities.get_all(surf_pages=True) and roles:
             for role in roles:
                 try:
-                    view.entities.get_entity(name=role.name).check()
+                    view.entities.get_entity(name=role.name).ensure_checked()
                 except ItemNotFound:
                     raise ItemNotFound("Deployment role {} not found".format(role.name))
 

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -476,7 +476,7 @@ class HostsCollection(BaseCollection):
 
         for host in hosts:
             try:
-                view.entities.get_entity(name=host.name, surf_pages=True).check()
+                view.entities.get_entity(name=host.name, surf_pages=True).ensure_checked()
                 checked_hosts.append(host)
             except ItemNotFound:
                 raise ItemNotFound('Could not find host {} in the UI'.format(host.name))

--- a/cfme/infrastructure/pxe.py
+++ b/cfme/infrastructure/pxe.py
@@ -1128,5 +1128,5 @@ def remove_all_pxe_servers():
     view = navigate_to(PXEServer, 'All')
     if view.entities.is_displayed:
         for entity in view.entities.rows():
-            entity[0].check()
+            entity[0].ensure_checked()
         view.toolbar.configuration.item_select('Remove PXE Servers', handle_alert=True)

--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -363,7 +363,8 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   surf_pages=True).ensure_checked()
         self.prerequisite_view.toolbar.configuration.item_select('Edit Selected Network Provider')
 
 

--- a/cfme/physical/physical_rack.py
+++ b/cfme/physical/physical_rack.py
@@ -167,7 +167,7 @@ class PhysicalRackCollection(BaseCollection):
         view = navigate_to(self, 'All')
 
         for physical_rack in physical_racks:
-            view.entities.get_entity(name=physical_rack.name, surf_pages=True).check()
+            view.entities.get_entity(name=physical_rack.name, surf_pages=True).ensure_checked()
             checked_physical_racks.append(physical_rack)
         return view
 

--- a/cfme/physical/physical_server.py
+++ b/cfme/physical/physical_server.py
@@ -293,7 +293,7 @@ class PhysicalServerCollection(BaseCollection):
         view = navigate_to(self, 'All')
 
         for physical_server in physical_servers:
-            view.entities.get_entity(name=physical_server.name, surf_pages=True).check()
+            view.entities.get_entity(name=physical_server.name, surf_pages=True).ensure_checked()
             checked_physical_servers.append(physical_server)
         return view
 

--- a/cfme/physical/physical_storage.py
+++ b/cfme/physical/physical_storage.py
@@ -173,7 +173,7 @@ class PhysicalStorageCollection(BaseCollection):
         view = navigate_to(self, 'All')
 
         for physical_storage in physical_storages:
-            view.entities.get_entity(name=physical_storage.name, surf_pages=True).check()
+            view.entities.get_entity(name=physical_storage.name, surf_pages=True).ensure_checked()
 
     def all(self):
         """returning all physical_storages objects"""

--- a/cfme/physical/physical_switch.py
+++ b/cfme/physical/physical_switch.py
@@ -167,7 +167,7 @@ class PhysicalSwitchCollection(BaseCollection):
         view = navigate_to(self, 'All')
 
         for physical_switch in physical_switches:
-            view.entities.get_entity(name=physical_switch.name, surf_pages=True).check()
+            view.entities.get_entity(name=physical_switch.name, surf_pages=True).ensure_checked()
             checked_physical_switches.append(physical_switch)
         return view
 

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -413,7 +413,7 @@ def test_no_template_power_control(provider, soft_assert):
     # Check the power button with checking the quadicon
     view = navigate_to(selected_template, 'AllForProvider', use_resetter=False)
     entity = view.entities.get_entity(name=selected_template.name, surf_pages=True)
-    entity.check()
+    entity.ensure_checked()
     for action in view.toolbar.power.items:
         # Performing power actions on template
         view.toolbar.power.item_select(action, handle_alert=True)
@@ -648,7 +648,7 @@ def test_retire_vm_with_vm_user_role(new_user, appliance, testing_vm):
     # Log in with new user to retire the vm
     with new_user:
         view = navigate_to(testing_vm.parent, "All")
-        view.entities.get_entity(name=testing_vm.name, surf_pages=True).check()
+        view.entities.get_entity(name=testing_vm.name, surf_pages=True).ensure_checked()
         assert view.toolbar.lifecycle.item_enabled("Retire selected items")
         testing_vm.retire()
         assert testing_vm.wait_for_vm_state_change(desired_state="retired", timeout=720,


### PR DESCRIPTION
## Purpose or Intent
- __Updating tests and framework__ to use entity ensure_checked() instead of entity.check(). ensure_checked() is an enhancement to check() functionality that accounts for the checked state of an entity when selecting it.

### PRT Run
{{ pytest: --use-provider rhv42 --use-provider rhos13 --long-running cfme/tests/physical_infrastructure/ui/test_physical_server_list_buttons.py::test_manage_button cfme/tests/infrastructure/test_pxe.py::test_pxe_server_crud cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_navigation_after_download_from_compare cfme/tests/infrastructure/test_vm_power_control.py::test_no_template_power_control cfme/tests/infrastructure/test_vm_power_control.py::test_retire_vm_with_vm_user_role }}
