### PR TITLE
[1LP][RFR] Replace usage of entity.check() with entity.ensure_checked. Part 3.

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -316,7 +316,7 @@ class PolicyProfileAssignable(object):
         view.paginator.set_items_per_page(1000)
 
         # check the entity's on collection ALL view
-        view.entities.apply(func=lambda e: e.check(), conditions=conditions)
+        view.entities.apply(func=lambda e: e.ensure_checked(), conditions=conditions)
 
         wait_for(lambda: view.toolbar.policy.is_enabled, num_sec=5,
                  message='Policy drop down menu is disabled after checking some entities')

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -184,7 +184,7 @@ class BaseVM(
                                                    handle_alert=not cancel)
         else:
             view = navigate_to(self.parent, 'All')
-            self.find_quadicon().check()
+            self.find_quadicon().ensure_checked()
             view.toolbar.configuration.item_select(self.REMOVE_SELECTED, handle_alert=not cancel)
 
     @property
@@ -361,7 +361,7 @@ class BaseVM(
             view = navigate_to(self, 'Details', use_resetter=False)
         else:
             view = navigate_to(self.parent, 'All')
-            self.find_quadicon(from_any_provider=from_any_provider).check()
+            self.find_quadicon(from_any_provider=from_any_provider).ensure_checked()
         view.toolbar.configuration.item_select("Refresh Relationships and Power States",
                                                handle_alert=not cancel)
 
@@ -386,7 +386,7 @@ class BaseVM(
             view = navigate_to(self, 'Details', use_resetter=False)
         else:
             view = navigate_to(self.parent, 'All')
-            self.find_quadicon().check()
+            self.find_quadicon().ensure_checked()
         view.toolbar.configuration.item_select('Perform SmartState Analysis',
                                                handle_alert=not cancel)
         if wait_for_task_result:
@@ -834,7 +834,7 @@ class VM(BaseVM):
         else:
             view = navigate_to(self.parent, "All")
             entity = self.find_quadicon()
-            entity.check()
+            entity.ensure_checked()
         if view.toolbar.power.has_item(option):
             return view.toolbar.power.item_enabled(option)
         else:

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -226,7 +226,8 @@ class ImageCollection(GetRandomInstancesMixin, BaseCollection, PolicyProfileAssi
         conditions = []
         for image_entity in image_entities:
             conditions.append({'id': image_entity.id})
-        entities = images_view.entities.apply(func=lambda e: e.check(), conditions=conditions)
+        entities = images_view.entities.apply(func=lambda e: e.ensure_checked(),
+                                              conditions=conditions)
         return entities
 
     def perform_smartstate_analysis_multiple_images(

--- a/cfme/infrastructure/datastore.py
+++ b/cfme/infrastructure/datastore.py
@@ -251,7 +251,7 @@ class Datastore(Pretty, BaseEntity, Taggable, CustomButtonEventsMixin):
         # todo: to replace with correct view
         vms_view = view.browser.create_view(DatastoresView)
         for entity in vms_view.entities.get_all():
-            entity.check()
+            entity.ensure_checked()
         view.toolbar.configuration.item_select('Remove selected items from Inventory',
                                                handle_alert=True)
 
@@ -264,7 +264,7 @@ class Datastore(Pretty, BaseEntity, Taggable, CustomButtonEventsMixin):
         view.entities.relationships.click_at('Hosts')
         hosts_view = view.browser.create_view(RegisteredHostsView)
         for entity in hosts_view.entities.get_all():
-            entity.check()
+            entity.ensure_checked()
         view.toolbar.configuration.item_select('Remove items from Inventory',
                                                handle_alert=True)
 
@@ -381,7 +381,7 @@ class DatastoreCollection(BaseCollection):
 
         for datastore in datastores:
             try:
-                view.entities.get_entity(name=datastore.name, surf_pages=True).check()
+                view.entities.get_entity(name=datastore.name, surf_pages=True).ensure_checked()
                 checked_datastores.append(datastore)
             except ItemNotFound:
                 raise ValueError('Could not find datastore {} in the UI'.format(datastore.name))
@@ -404,7 +404,7 @@ class DatastoreCollection(BaseCollection):
 
         for datastore in datastores:
             try:
-                view.entities.get_entity(name=datastore.name, surf_pages=True).check()
+                view.entities.get_entity(name=datastore.name, surf_pages=True).ensure_checked()
                 checked_datastores.append(datastore)
             except ItemNotFound:
                 raise ValueError('Could not find datastore {} in the UI'.format(datastore.name))

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -366,7 +366,8 @@ class EditTags(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   surf_pages=True).ensure_checked()
         try:
             self.prerequisite_view.toolbar.policy.item_select('Edit Tags')
         except MoveTargetOutOfBoundsException:
@@ -380,7 +381,8 @@ class Edit(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.entities.get_entity(name=self.obj.name, surf_pages=True).check()
+        self.prerequisite_view.entities.get_entity(name=self.obj.name,
+                                                   surf_pages=True).ensure_checked()
         try:
             self.prerequisite_view.toolbar.configuration.item_select(
                 'Edit Selected Infrastructure Providers')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1780,5 +1780,6 @@ class PolicySimulationOnCollection(CFMENavigateStep):
     def step(self, *args, **kwargs):
         # click the checkbox of every object in the filtered collection
         for entity in self.obj.all():
-            self.prerequisite_view.entities.get_entity(name=entity.name, surf_pages=True).check()
+            self.prerequisite_view.entities.get_entity(name=entity.name,
+                                                       surf_pages=True).ensure_checked()
         self.prerequisite_view.toolbar.policy.item_select("Policy Simulation")

--- a/cfme/storage/object_store_object.py
+++ b/cfme/storage/object_store_object.py
@@ -163,7 +163,7 @@ class ObjectStoreObjectCollection(BaseCollection):
 
         for obj in objects:
             try:
-                view.entities.get_entity(key=obj.key, surf_pages=True).check()
+                view.entities.get_entity(key=obj.key, surf_pages=True).ensure_checked()
             except ItemNotFound:
                 raise ItemNotFound('Could not locate object {}'.format(obj.key))
 

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -274,7 +274,6 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         if from_manager:
             view = navigate_to(self.parent.manager, 'Volumes')
             view.entities.get_entity(surf_pages=True, name=self.name).ensure_checked()
-            _
             view.toolbar.configuration.item_select('Edit selected Cloud Volume')
             view = view.browser.create_view(VolumeEditView, additional_context={'object': self})
         else:

--- a/cfme/storage/volume.py
+++ b/cfme/storage/volume.py
@@ -273,7 +273,8 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         """Edit cloud volume"""
         if from_manager:
             view = navigate_to(self.parent.manager, 'Volumes')
-            view.entities.get_entity(surf_pages=True, name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).ensure_checked()
+            _
             view.toolbar.configuration.item_select('Edit selected Cloud Volume')
             view = view.browser.create_view(VolumeEditView, additional_context={'object': self})
         else:
@@ -292,7 +293,7 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         """Delete the Volume"""
         if from_manager:
             view = navigate_to(self.parent.manager, 'Volumes')
-            view.entities.get_entity(surf_pages=True, name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).ensure_checked()
             view.toolbar.configuration.item_select(
                 'Delete selected Cloud Volumes', handle_alert=True)
         else:
@@ -329,7 +330,7 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
         snapshot_collection = self.appliance.collections.volume_snapshots
         if from_manager:
             view = navigate_to(self.parent.manager, 'Volumes')
-            view.entities.get_entity(surf_pages=True, name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).ensure_checked()
             view.toolbar.configuration.item_select('Create a Snapshot of selected Cloud Volume')
             view = view.browser.create_view(VolumeSnapshotView, additional_context={'object': self})
         else:
@@ -355,7 +356,7 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
                         from_manager=None):
         if from_manager:
             view = navigate_to(self.parent.manager, 'Volumes')
-            view.entities.get_entity(surf_pages=True, name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).ensure_checked()
             view.toolbar.configuration.item_select('Attach selected Cloud Volume to an Instance')
             view = view.browser.create_view(AttachInstanceView, additional_context={'object': self})
         else:
@@ -380,7 +381,7 @@ class Volume(BaseEntity, CustomButtonEventsMixin, Updateable, Taggable):
     def detach_instance(self, name, cancel=False, from_manager=None):
         if from_manager:
             view = navigate_to(self.parent.manager, 'Volumes')
-            view.entities.get_entity(surf_pages=True, name=self.name).check()
+            view.entities.get_entity(surf_pages=True, name=self.name).ensure_checked()
             view.toolbar.configuration.item_select('Detach selected Cloud Volume from an Instance')
             view = view.browser.create_view(DetachInstanceView, additional_context={'object': self})
         else:
@@ -529,7 +530,7 @@ class VolumeCollection(BaseCollection, TaggableCollection):
         if view.entities.get_all():
             for volume in volumes:
                 try:
-                    view.entities.get_entity(name=volume.name).check()
+                    view.entities.get_entity(name=volume.name).ensure_checked()
                 except ItemNotFound:
                     raise ItemNotFound("Volume {} not found".format(volume.name))
 

--- a/cfme/storage/volume_backup.py
+++ b/cfme/storage/volume_backup.py
@@ -241,7 +241,7 @@ class VolumeBackupCollection(BaseCollection):
         if view.entities.get_all():
             for backup in backups:
                 try:
-                    view.entities.get_entity(name=backup.name).check()
+                    view.entities.get_entity(name=backup.name).ensure_checked()
                 except ItemNotFound:
                     raise ItemNotFound("Volume backup {} not found".format(backup.name))
 

--- a/cfme/tests/cloud/test_instance_power_control.py
+++ b/cfme/tests/cloud/test_instance_power_control.py
@@ -795,7 +795,7 @@ def test_power_options_on_archived_instance_all_page(testing_instance):
     view = navigate_to(cloud_instance, 'ArchivedAll')
 
     # Selecting particular archived instance
-    testing_instance.find_quadicon(from_archived_all=True).check()
+    testing_instance.find_quadicon(from_archived_all=True).ensure_checked()
 
     # After selecting particular archived instance; 'Power' drop down gets enabled.
     # Reading all the options available in 'power' drop down

--- a/cfme/tests/infrastructure/test_vm_power_control.py
+++ b/cfme/tests/infrastructure/test_vm_power_control.py
@@ -700,12 +700,12 @@ def test_power_options_on_archived_orphaned_vms_all_page(appliance, archive_orph
         view = navigate_to(infra_vms, 'ArchivedAll')
 
         # Selecting particular archived vm
-        testing_vm.find_quadicon(from_archived_all=True).check()
+        testing_vm.find_quadicon(from_archived_all=True).ensure_checked()
     else:
         view = navigate_to(infra_vms, 'OrphanedAll')
 
         # Selecting particular orphaned vm
-        testing_vm.find_quadicon(from_orphaned_all=True).check()
+        testing_vm.find_quadicon(from_orphaned_all=True).ensure_checked()
 
     # After selecting particular archived/orphaned vm; 'Power' drop down gets enabled.
     # Reading all the options available in 'power' drop down


### PR DESCRIPTION
## Purpose or Intent
- __Updating tests and framework__ to use entity ensure_checked() instead of entity.check(). ensure_checked() is an enhancement to check() functionality that accounts for the checked state of an entity when selecting it.

###PRT
{{ pytest: --long-running --use-provider ec2west cfme/tests/cloud/test_instance_power_control.py::test_power_options_on_archived_instance_all_page --use-provider rhv43 cfme/tests/infrastructure/test_vm_power_control.py::test_power_options_on_archived_orphaned_vms_all_page }}