### PR TITLE
[1LP][RFR] Replace inline slice in entity.get_all() with slice kwarg and use ensure_checked()

### DIFF
--- a/cfme/tests/configure/test_default_views_cloud.py
+++ b/cfme/tests/configure/test_default_views_cloud.py
@@ -93,7 +93,8 @@ def test_cloud_compare_view(appliance, expected_view):
     old_default = default_views.get_default_view(group_name)
     default_views.set_default_view(group_name, expected_view)
     inst_view = navigate_to(appliance.collections.cloud_instances, 'All')
-    [e.check() for e in inst_view.entities.get_all()[:2]]
+    e_slice = slice(0, 2, None)
+    [e.ensure_checked() for e in inst_view.entities.get_all(slice=e_slice)]
     inst_view.toolbar.configuration.item_select('Compare Selected items')
     selected_view = getattr(inst_view.actions, selector_type).selected
     assert expected_view == selected_view, '{} setting failed'.format(expected_view)

--- a/cfme/tests/configure/test_default_views_infra.py
+++ b/cfme/tests/configure/test_default_views_infra.py
@@ -140,7 +140,8 @@ def test_infra_compare_view(appliance, expected_view):
     old_default = default_views.get_default_view(group_name)
     default_views.set_default_view(group_name, expected_view)
     vm_view = navigate_to(appliance.collections.infra_vms, 'All')
-    [e.check() for e in vm_view.entities.get_all()[:2]]
+    e_slice = slice(0, 2, None)
+    [e.ensure_checked() for e in vm_view.entities.get_all(slice=e_slice)]
     vm_view.toolbar.configuration.item_select('Compare Selected items')
     selected_view = getattr(vm_view.actions, selector_type).selected
     assert expected_view == selected_view, '{} setting failed'.format(expected_view)


### PR DESCRIPTION
## Purpose or Intent


- __Updating tests__  test_infra_compare_view and test_cloud_compare_view to use slice kwarg in entities.get_all() call instead of the inline slice of the returned values. Since I was testing I also updated these tests to use ensure_checked().
