### PR TITLE
[1LP][RFR] Use appliance provisioning fixtures for distributed and replicated appliance testing

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -494,6 +494,8 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
                 self.db.create_db_lvm()
             if on_openstack:
                 self.set_resolvable_hostname(log_callback=log_callback)
+            if db_address:
+                self.db_host = db_address
 
             self.db.setup(region=region, key_address=key_address,
                           db_address=db_address, is_pod=self.is_pod)


### PR DESCRIPTION
This PR updates test_appliance_replication.py to provision unconfigured appliances using sprout fixtures. This addresses the following issue:

Distributed tests don't use random names
https://github.com/ManageIQ/integration_tests/issues/3784

The function-scoped fixture temp_appliances_unconfig_funcscope_rhevm is used to return a pair of unconfigured appliances. Using the 'rhevm' provider type ensures that the two appliances can reach each other's IP address, unlike with, e.g., openstack vm's.

I've also removed the test_appliance_replicate_sync_role_change and test_appliance_replicate_sync_role_change_with_backlog tests, which are no longer relevant (they test the database_synchronization server role, which was removed in CFME 5.7).

{{ pytest: cfme/tests/distributed/test_appliance_replication.py --long-running }}
