### PR TITLE
[1LP][RFR] test_sdn_balancers_tagvis to run only on one azure provider

### DIFF
--- a/cfme/tests/networks/test_sdn_balancers.py
+++ b/cfme/tests/networks/test_sdn_balancers.py
@@ -7,6 +7,7 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.exceptions import DestinationNotFound
+from cfme.markers.env_markers.provider import ONE
 from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
@@ -72,7 +73,7 @@ def test_sdn_balancers_detail(provider, network_prov_with_load_balancers):
 
 
 # only one provider is needed for that test, used Azure as it has balancers
-@pytest.mark.provider([AzureProvider], scope='module')
+@pytest.mark.provider([AzureProvider], scope='module', selector=ONE)
 @test_requirements.tag
 @pytest.mark.parametrize('visibility', [True, False], ids=['visible', 'notVisible'])
 def test_sdn_balancers_tagvis(check_item_visibility, visibility, network_prov_with_load_balancers):


### PR DESCRIPTION
## Purpose or Intent
There's no need to run it in different subscriptions.

### PRT Run

{{ pytest: -v cfme/tests/networks/test_sdn_balancers.py::test_sdn_balancers_tagvis  --use-provider complete }}