### PR TITLE
[1LP][RFR] Fixed vm retire now error message in logs

### DIFF
--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -451,8 +451,10 @@ def test_retire_vm_now(setup_provider, create_vm, new_user):
             2. No errors in evm logs
     """
     with new_user:
-        with LogValidator("/var/www/miq/vmdb/log/evm.log",
-                          failure_patterns=[".*ERROR.*"]).waiting(timeout=720):
+        with LogValidator(
+                "/var/www/miq/vmdb/log/evm.log",
+                failure_patterns=[".*ERROR.*NoMethodError]: undefined method `tenant_id'.*"]
+        ).waiting(timeout=720):
             create_vm.retire()
             assert create_vm.wait_for_vm_state_change(desired_state="retired", timeout=720,
-                        from_details=True)
+                                                      from_details=True)


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>


## Purpose or Intent
- Added specific error in failures patterns
- Fixed error:
```
>               raise FailPatternMatchError(pattern, "Expected failure pattern found in log.", line)
E               cfme.utils.log_validator.FailPatternMatchError: "Pattern '.*ERROR.*': Expected failure pattern found in log."

cfme/utils/log_validator.py:82: FailPatternMatchError
FailPatternMatchError
b'"Pattern \'.*ERROR.*\': Expected failure pattern found in log."'

```
### PRT Run
{{pytest: cfme/tests/automate/test_service_automate.py -k 'test_retire_vm_now' --use-template-cache -qsvv --long-running --use-provider=complete }}