### PR TITLE
[1LP][WIPTEST] CLI - Setting up date and time - negative

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -1329,11 +1329,17 @@ def test_appliance_console_apache_reload_log_rotate():
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(1)
-def test_appliance_console_datetime_negative():
+@pytest.mark.automates([1790311])
+@pytest.mark.meta(blockers=[BZ(1745895)])
+@pytest.mark.parametrize("invalid", ["invalid_date", "invalid_time"])
+def test_appliance_console_datetime_negative(appliance, invalid):
     """
     test setting invalid date/time
+
+    Note: Raised BZ(1790311) for invalid_date ( date example 2020-13-40 ) but
+     they marked as WON'T FIX,
+    TODO(BZ-1790311): Please add invalid date if BZ got fixed.
 
     Polarion:
         assignee: dgaikwad
@@ -1352,7 +1358,19 @@ def test_appliance_console_datetime_negative():
             3.
             4. Invalid date/time should not be applied, check for failure there.
     """
-    pass
+
+    if invalid == "invalid_date":
+        invalid_dates = ['202020-12-3', '2020-13-3']
+        cmd_sets = [("ap", RETURN, "3", "Y", date) for date in invalid_dates]
+    else:
+        invalid_times = ['25:13:01', '22:61:01', '24:11:61']
+        cmd_sets = [("ap", RETURN, "3", "Y", str(fauxfactory.gen_date()), time)
+                    for time in invalid_times]
+
+    for cmd in cmd_sets:
+        result = appliance.appliance_console.run_commands(cmd, timeout=30)
+        assert ("Please provide in the specified format" in result[-1]
+                ), ("Should not able to set %s." % invalid)
 
 
 @pytest.mark.manual


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
__Adding tests__  Setting up the appliance date and time by providing negative values

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: ./cfme/tests/cli/test_appliance_console.py::test_appliance_console_datetime_negative -v}}
