### PR TITLE
[1LP][RFR] CLI - Fetching encryption key from invalid remote host - negative

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -10,6 +10,7 @@ from wait_for import TimedOutError
 from wait_for import wait_for
 
 from cfme import test_requirements
+from cfme.utils import conf
 from cfme.utils import os
 from cfme.utils.appliance.console import waiting_for_ha_monitor_started
 from cfme.utils.blockers import BZ
@@ -1355,9 +1356,8 @@ def test_appliance_console_datetime_negative():
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(1)
-def test_appliance_console_key_fetch_negative():
+def test_appliance_console_key_fetch_negative(temp_appliance_preconfig_funcscope):
     """
     test fetching key from fake remote host
 
@@ -1382,7 +1382,14 @@ def test_appliance_console_key_fetch_negative():
             5.
             6. Check Encryption Key fetch failure.
     """
-    pass
+    appliance = temp_appliance_preconfig_funcscope
+    invalid_ip = fauxfactory.gen_ipaddr()
+    command_set = ("ap", RETURN, "14", "Y", "2", invalid_ip,
+                   conf.credentials['default']['username'], conf.credentials['default']['password'],
+                   TimedCommand(RETURN, 180))
+    result = appliance.appliance_console.run_commands(command_set, timeout=30, output=True)
+    assert "Failed to fetch key" in result[-1], (
+        "Overriding Encryption Key should fail when we enter invalid IP address")
 
 
 @pytest.mark.manual

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -45,7 +45,7 @@ class ApplianceConsole(AppliancePlugin):
                 cmd, timeout = command
             channel.settimeout(timeout)
             cmd = "{}\n".format(cmd) if autoreturn else "{}".format(cmd)
-            logger.info("Executing sub-command: %s" % cmd)
+            logger.info("Executing sub-command: %s, timeout:%s" % (cmd, timeout))
             channel.send(cmd)
             result = ''
             try:


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
__Adding tests__ Adding encryption key from the invalid remote host
### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: ./cfme/tests/cli/test_appliance_console.py::test_appliance_console_key_fetch_negative -v}}
