### PR TITLE
[1LP][RFR] CLI - Test to fail DB config command - negative

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -1409,14 +1409,11 @@ def test_appliance_console_negative():
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1753687])
-def test_ap_failed_dbconfig_status():
+@pytest.mark.meta(automates=[BZ(1753687)])
+def test_ap_failed_dbconfig_status(temp_appliance_preconfig_funcscope):
     """ Test failed DB config command returns non-zero status.
 
-    Bugzilla:
-        1753687
     Polarion:
         assignee: mnadeem
         casecomponent: Appliance
@@ -1433,4 +1430,9 @@ def test_ap_failed_dbconfig_status():
             2.
             3. The command "echo $?" should be non-zero
     """
-    pass
+    appliance = temp_appliance_preconfig_funcscope
+    command = ("/opt/rh/cfme-gemset/bin/appliance_console_cli -i -b /dev/sdz -S"
+               " -d ${db_name} -U ${db_root} -p '${db_pass}'")
+    result = appliance.ssh_client.run_command(command, timeout=30)
+    assert not result.success, ('DB configuration should fail because used disk "/dev/sdz" '
+                                'which will not be available')


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
 __Adding tests__ testing DB configuration command by providing the disk which is not available on the host
### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: ./cfme/tests/cli/test_appliance_console.py::test_ap_failed_dbconfig_status -v}}