### PR TITLE
[1LP][RFR] Fix rh updates

### DIFF
--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -744,7 +744,7 @@ class RedHatUpdates(Navigatable, Pretty):
             appliance_names: Names of appliances to check; will check all if empty
         """
         for row in self.get_appliance_rows(*appliance_names):
-            if row.update_status.text.lower() in {'not registered', 'unsubscribed'}:
+            if row.update_status.text.lower() != 'subscribed':
                 return False
         return True
 

--- a/cfme/tests/configure/test_register_appliance.py
+++ b/cfme/tests/configure/test_register_appliance.py
@@ -157,7 +157,7 @@ def test_rh_creds_validation(reg_method, reg_data, proxy_url, proxy_creds):
 
 @pytest.mark.rhel_testing
 @pytest.mark.ignore_stream("upstream")
-@pytest.mark.meta(automates=[1532201])
+@pytest.mark.meta(automates=[1532201, 1673136])
 def test_rh_registration(
         temp_appliance_preconfig_funcscope, request, reg_method, reg_data, proxy_url, proxy_creds):
     """ Tests whether an appliance can be registered against RHSM and SAT6
@@ -217,12 +217,16 @@ def test_rh_registration(
             fail_func=red_hat_updates.refresh
         )
 
+        # This bit automates BZ#1673136
         wait_for(
-            func=appliance.is_registration_complete,
-            func_args=[used_repo_or_channel],
-            delay=20,
-            num_sec=400
+            func=red_hat_updates.is_subscribed,
+            func_args=[appliance.server.name],
+            delay=10,
+            num_sec=600,
+            fail_func=red_hat_updates.refresh
         )
+
+        assert appliance.is_registration_complete(used_repo_or_channel)
 
 
 @pytest.mark.rhel_testing


### PR DESCRIPTION
## Purpose or Intent
__Fixing__ test_rh_updates
 * make it fail when ssh command fails
 * version-pick correct repo for 5.10 and 5.11

Also __do better job__ in testing BZ  1673136 and mark the test with automates

I am expecting failure of the satellite tests unitl we get the repos defined in config present in our satellite.

I have slight problems with one test. The  `cfme/tests/configure/test_register_appliance.py/test_rh_registration[sat6-proxy_off]` of CFME 5.10 fails due to CFME failing to reach the state `subscribed`. It passed 16 times in the row on my machine though. I am not 100% but I think this is a bug in CFME or is it that we have our satellite somehow misconfigured. I was opening some bugs about the subscription feature has problems, but AFAIR some were closed as WONTFIX and it starts to be confusing.