### PR TITLE
[1LP][RFR] Automating copy catalog item with tags

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -35,9 +35,11 @@ from cfme.utils.version import VersionPicker
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import AutomateRadioGroup
 from widgetastic_manageiq import EntryPoint
+from widgetastic_manageiq import FileInput
 from widgetastic_manageiq import FonticonPicker
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import SummaryFormItem
+from widgetastic_manageiq import SummaryTable
 from widgetastic_manageiq import Table
 from widgetastic_manageiq import WaitTab
 from widgetastic_manageiq.expression_editor import ExpressionEditor
@@ -153,6 +155,11 @@ class AllCatalogItemView(ServicesCatalogView):
         )
 
 
+class DetailsEntitiesCatalogItemView(View):
+    custom_image = FileInput("upload_image")
+    smart_management = SummaryTable("Smart Management")
+
+
 class DetailsCatalogItemView(ServicesCatalogView):
     title = Text('#explorer_title_text')
 
@@ -163,6 +170,8 @@ class DetailsCatalogItemView(ServicesCatalogView):
             self.catalog_items.is_opened and
             self.title.text == 'Service Catalog Item "{}"'.format(self.context['object'].name)
         )
+
+    entities = View.nested(DetailsEntitiesCatalogItemView)
 
 
 class ChooseCatalogItemTypeView(ServicesCatalogView):

--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -583,11 +583,10 @@ def test_catalog_item_price_currency():
     pass
 
 
-@pytest.mark.meta(coverage=[1740399])
-@pytest.mark.manual
 @pytest.mark.ignore_stream('5.10')
+@pytest.mark.meta(blockers=[BZ(1740399, forced_streams=["5.11"])], automates=[1740399])
 @pytest.mark.tier(2)
-def test_copy_catalog_item_with_tags():
+def test_copy_catalog_item_with_tags(request, generic_catalog_item, tag):
     """
     Bugzilla:
         1740399
@@ -608,4 +607,11 @@ def test_copy_catalog_item_with_tags():
             3.
             4. Tags to be copied with catalog item
     """
-    pass
+    generic_catalog_item.add_tag(tag)
+    new_cat_item = generic_catalog_item.copy()
+    request.addfinalizer(new_cat_item.delete_if_exists)
+    assert all([
+        tag_available.category.display_name == tag.category.display_name and
+        tag_available.display_name == tag.display_name
+        for tag_available in new_cat_item.get_tags()
+    ]), 'Assigned tag was not found on the details page'

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -388,17 +388,6 @@ def test_host_credentials_web():
 
 
 @pytest.mark.manual
-def test_group_quota_via_ssui():
-    """
-    Polarion:
-        assignee: sshveta
-        initialEstimate: 1/4h
-        casecomponent: SelfServiceUI
-    """
-    pass
-
-
-@pytest.mark.manual
 @test_requirements.service
 @pytest.mark.tier(3)
 def test_delete_orchestration_template_in_use():


### PR DESCRIPTION
## Purpose or Intent


### PRT Run
{{pytest: cfme/tests/services/test_catalog_item.py::test_copy_catalog_item_with_tags }}


No PRT run, the BZ is still in Post state. I have tested locally with ipdb. 