### PR TITLE
[1LP][RFR] Moving custom button to use AttributeValueForm

### DIFF
--- a/cfme/automate/buttons.py
+++ b/cfme/automate/buttons.py
@@ -3,11 +3,9 @@ import re
 import attr
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling
-from widgetastic.utils import ParametrizedString
 from widgetastic.widget import Checkbox
 from widgetastic.widget import ColourInput
 from widgetastic.widget import ConditionalSwitchableView
-from widgetastic.widget import ParametrizedView
 from widgetastic.widget import Select
 from widgetastic.widget import Table
 from widgetastic.widget import Text
@@ -28,6 +26,7 @@ from cfme.utils.log import logger
 from cfme.utils.update import Updateable
 from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for
+from widgetastic_manageiq import AttributeValueForm
 from widgetastic_manageiq import AutomateRadioGroup
 from widgetastic_manageiq import FonticonPicker
 from widgetastic_manageiq import MultiBoxOrderedSelect
@@ -107,17 +106,7 @@ class ButtonFormCommon(AutomateCustomizationView):
         system = BootstrapSelect("instance_name")
         message = Input(name="object_message")
         request = Input(name="object_request")
-
-        @ParametrizedView.nested
-        class attribute(ParametrizedView):  # noqa
-            PARAMETERS = ("number",)
-            key = Input(name=ParametrizedString("attribute_{number}"))
-            value = Input(name=ParametrizedString("value_{number}"))
-
-            @classmethod
-            def all(cls, browser):
-                return [(i,) for i in range(1, 6)]
-
+        attributes = AttributeValueForm("attribute_", "value_")
         role_show = BootstrapSelect(id="visibility_typ")
         roles = RolesSelector(locator="//label[contains(text(),'User Roles')]/../div/table")
 
@@ -515,9 +504,8 @@ class ButtonCollection(BaseCollection):
 
         view.fill({"advanced": {"system": system, "request": request}})
 
-        if attributes is not None:
-            for i, attribute in enumerate(attributes, 1):
-                view.advanced.attribute(i).fill({"key": attribute[0], "value": attribute[1]})
+        if attributes:
+            view.advanced.attributes.fill(attributes)
 
         if roles:
             view.advanced.role_show.fill("<By Role>")

--- a/cfme/tests/automate/custom_button/test_buttons.py
+++ b/cfme/tests/automate/custom_button/test_buttons.py
@@ -223,18 +223,17 @@ def test_button_avp_displayed(appliance, dialog, request):
         1460774
     """
     # This is optional, our nav tree does not have unassigned button
-    buttongroup = appliance.collections.button_groups.create(
-        text=fauxfactory.gen_alphanumeric(start="grp_"),
-        hover=fauxfactory.gen_alphanumeric(15, start="grp_hvr_"),
-        type=appliance.collections.button_groups.VM_INSTANCE,
+    buttongroup = appliance.collections.button_groups.instantiate(
+        text="[Unassigned Buttons]",
+        hover="Unassigned buttons",
+        type=appliance.collections.button_groups.VM_INSTANCE
     )
-    request.addfinalizer(buttongroup.delete_if_exists)
     buttons_collection = appliance.collections.buttons
     buttons_collection.group = buttongroup
     view = navigate_to(buttons_collection, "Add")
     for n in range(1, 6):
-        assert view.advanced.attribute(n).key.is_displayed
-        assert view.advanced.attribute(n).value.is_displayed
+        assert view.advanced.attributes.fields(str(n)).attribute.is_displayed
+        assert view.advanced.attributes.fields(str(n)).value.is_displayed
     view.cancel_button.click()
 
 
@@ -634,12 +633,12 @@ def test_attribute_override(appliance, request, provider, setup_provider, obj_ty
     Bugzilla:
         1651099
     """
-    attributes = [
-        ("class", "Request"),
-        ("instance", "TestNotification"),
-        ("message", "digitronik_msg"),
-        ("namespace", "/System"),
-    ]
+    attributes = {
+        "class": "Request",
+        "instance": "TestNotification",
+        "message": "digitronik_msg",
+        "namespace": "/System",
+    }
     req = "call_instance_with_message"
     patterns = [
         "[miqaedb:/System/Request/TestNotification#create]",
@@ -738,10 +737,10 @@ def test_simulated_object_copy_on_button(appliance, provider, setup_provider, bu
     assert view.advanced.message.read() == "test_bz"
     assert view.advanced.request.read() == "InspectMe"
 
-    attributes_on_page = [kv for kv in view.advanced.attribute.read().values() if kv["key"] != ""]
+    attributes_on_page = view.advanced.attributes.read()
 
-    for attr in attributes_on_page:
-        assert attributes[attr["key"]] == attr["value"]
+    for key, value in attributes_on_page.items():
+        assert attributes[key] == value
 
 
 @pytest.mark.tier(1)


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
- Moving custom button attributes to use `AttributeValueForm`
- It will also fix failing tests

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/automate/custom_button/test_buttons.py -k "test_button_avp_displayed or test_simulated_object_copy_on_button or test_attribute_override"}}

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
