### PR TITLE
[1LP][RFR] Add uncollect for more than 2 hosts and RHEVM and SCVMM providers

### DIFF
--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -363,8 +363,14 @@ def setup_provider_min_hosts(request, appliance, provider, num_hosts):
     setup_or_skip(request, provider)
 
 
+UNCOLLECT_REASON = "Not enough hosts on provider type."
+
+
 @test_requirements.infra_hosts
 @pytest.mark.parametrize("num_hosts", [1, 2, 4])
+@pytest.mark.uncollectif(
+    lambda provider, num_hosts: provider.one_of(RHEVMProvider, SCVMMProvider) and num_hosts > 2,
+    reason=UNCOLLECT_REASON)
 def test_infrastructure_hosts_refresh_multi(appliance, setup_provider_min_hosts, provider,
                                             num_hosts):
     """


### PR DESCRIPTION
## Purpose or Intent

- __Updating tests__ so test_infrastructure_hosts_refresh_multi will not run with rhevm and scvmm providers for more than 2 hosts. These providers will not have the needed hosts and the tests are getting uploaded into Polarion and must be marked blocked, manually.

### PRT Run
{{ pytest: --long-running cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_refresh_multi }}
