### PR TITLE
[1LP][RFR] Fix for - test_appliance_console_external_auth_all TC

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -501,17 +501,40 @@ def test_appliance_console_external_auth_all(configured_appliance):
         caseimportance: high
         casecomponent: Auth
         initialEstimate: 1/4h
+        testSteps:
+            1. 'ap' launches appliance_console.
+            2. RETURN clears info screen.
+            3. press "13" to "Update External Authentication Options"
+            4. Press "1" to "Enable Single Sign-On"
+            5. Press "2" to "Enable SAML"
+            6. press "4" to "Disable Local Login for SAML or OIDC"
+            7. press "5" to "Apply updates"
+            8. Press "1" to "Disable Single Sign-On"
+            9. Press "2" to "Disable SAML"
+            10. press "4" to "Enable Local Login for SAML or OIDC"
+            11. press "5" to "Apply updates"
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6.
+            7. Verify log messages
+            8.
+            9.
+            10.
+            11. Verify log messages
     """
-
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
                             matched_patterns=['.*sso_enabled to true.*',
                                               '.*saml_enabled to true.*',
                                               '.*local_login_disabled to true.*'],
                             hostname=configured_appliance.hostname)
     evm_tail.start_monitoring()
-    command_set = ('ap', RETURN, TimedCommand('13', 20), '1', '2', TimedCommand('5', 20),
+    command_set = ('ap', RETURN, TimedCommand('13', 40), '1', '2', '4', TimedCommand('5', 40),
                    RETURN, RETURN)
-    configured_appliance.appliance_console.run_commands(command_set)
+    configured_appliance.appliance_console.run_commands(command_set, timeout=30)
     assert evm_tail.validate("30s")
 
     evm_tail = LogValidator('/var/www/miq/vmdb/log/evm.log',
@@ -521,9 +544,9 @@ def test_appliance_console_external_auth_all(configured_appliance):
                             hostname=configured_appliance.hostname)
 
     evm_tail.start_monitoring()
-    command_set = ('ap', RETURN, TimedCommand('13', 20), '1', '2', TimedCommand('5', 20),
+    command_set = ('ap', RETURN, TimedCommand('13', 40), '1', '2', '4', TimedCommand('5', 40),
                    RETURN, RETURN)
-    configured_appliance.appliance_console.run_commands(command_set)
+    configured_appliance.appliance_console.run_commands(command_set, timeout=30)
     assert evm_tail.validate(wait="30s")
 
 


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
To grep` "local_login_disabled to true"` message in log file we have to call `"13) Update External Authentication Options"`=> `"4) Disable Local Login for SAML or OIDC"` function from CLI so added logic for the same.
### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: ./cfme/tests/cli/test_appliance_console.py::test_appliance_console_external_auth_all -v}}