### PR TITLE
Updating tests

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -1250,28 +1250,6 @@ def test_appliance_console_restore_db_network_negative():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_appliance_console_cli_rh_registration():
-    """
-    Test RHSM registration through cli and check if changes are made
-    within the ui
-
-    Polarion:
-        assignee: dgaikwad
-        casecomponent: Appliance
-        caseimportance: medium
-        initialEstimate: 1/12h
-        testSteps:
-            1. Provision appliace
-            2. SSH to it and run "subscription-manager register"
-        expectedResults:
-            1.
-            2. Check changes within the ui
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(1)
 def test_appliance_console_extend_storage_negative():
     """
@@ -1392,7 +1370,7 @@ def test_appliance_console_key_fetch_negative(temp_appliance_preconfig_funcscope
         "Overriding Encryption Key should fail when we enter invalid IP address")
 
 
-@pytest.mark.manual
+@pytest.mark.manual("manualonly")
 @pytest.mark.tier(1)
 def test_appliance_console_negative():
     """


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
__Updating tests__  Test `test_appliance_console_cli_rh_registration` removed because this is not valid test. reference BZ(https://bugzilla.redhat.com/show_bug.cgi?id=1789785)

__Updating tests__  Test `test_appliance_console_negative` marked as manual only because we can not perform test in the automation without network adapter

### PRT Run

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
