### PR TITLE
[1LP][RFR] Add new ProviderCompareHostsView and replace with CompareHostsView in…

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -331,6 +331,18 @@ class HostsCompareView(ComputeInfrastructureHostsView):
                 )
 
 
+class ProviderHostsCompareView(ComputeInfrastructureHostsView):
+    """Compare Host / Node page, but for a specific provider."""
+
+    @property
+    def is_displayed(self):
+        title = "Compare Host / Node"
+        return (self.logged_in_as_current_user and
+                self.title.text == title and
+                self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers']
+                )
+
+
 class ProviderAllHostsView(HostsView):
     """
     This view is used in Provider and HostCollection contexts

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -9,6 +9,7 @@ from cfme import test_requirements
 from cfme.base.credential import Credential
 from cfme.common.host_views import HostsCompareView
 from cfme.common.host_views import HostsEditView
+from cfme.common.host_views import ProviderHostsCompareView
 from cfme.common.provider_views import InfraProviderDetailsView
 from cfme.common.provider_views import InfraProvidersView
 from cfme.common.provider_views import ProviderNodesView
@@ -464,7 +465,7 @@ def test_compare_hosts_from_provider_allhosts(appliance, setup_provider_min_host
         h.ensure_checked()
     hosts_view.toolbar.configuration.item_select('Compare Selected items',
                                                  handle_alert=True)
-    compare_hosts_view = provider.create_view(HostsCompareView)
+    compare_hosts_view = provider.create_view(ProviderHostsCompareView)
     assert compare_hosts_view.is_displayed
 
 

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -446,7 +446,7 @@ def test_infrastructure_hosts_navigation_after_download(
 
 @test_requirements.infra_hosts
 @pytest.mark.parametrize("num_hosts", [2, 4])
-@pytest.mark.meta(blockers=[BZ(1746214, forced_streams=["5.10"])], automates=[1746214])
+@pytest.mark.meta(blockers=[BZ(1746214, forced_streams=["5.10"])], automates=[1746214, 1784181])
 def test_compare_hosts_from_provider_allhosts(appliance, setup_provider_min_hosts, provider,
                                               num_hosts):
     """


### PR DESCRIPTION
… test_compare_hosts_from_provider_allhosts

## Purpose or Intent

- __Updating tests__ for fix to BZ1784181. The test was failing because an error was displayed instead of the expected view. After the error was fixed, I needed to update the test to go to a provider specific compare view instead of the appliance allhosts view.

### PRT Run
{{ pytest: cfme/tests/infrastructure/test_host.py::test_compare_hosts_from_provider_allhosts }}