### PR TITLE
[1LP][RFR] CLI-Testing UI after restarting VMDB

### DIFF
--- a/cfme/tests/cli/__init__.py
+++ b/cfme/tests/cli/__init__.py
@@ -1,0 +1,49 @@
+from cfme.utils.version import Version
+from cfme.utils.version import VersionPicker
+
+app_menu_v5_10 = {
+    "config_net": "1",
+    "set_timezone": "2",
+    "set_date_time": "3",
+    "create_db_bak": "4",
+    "create_db_dump": "5",
+    "restore_db_from_bak": "6",
+    "config_db": "7",
+    "config_db_rep": "8",
+    "logfile_conf": "9",
+    "config_app_db_failover_monitor": "10",
+    "ext_temp_storage": "11",
+    "config_external_auth": "12",
+    "update_ext_auth_opt": "13",
+    "gen_custom_encry_key": "14",
+    "harden_app_scap_config": "15",
+    "stop_evm": "16",
+    "start_evm": "17",
+    "restart_app": "18",
+    "showdown_app": "19",
+    "summary_info": "20",
+    "quit": "21",
+}
+
+app_menu_v5_11 = {
+    "config_net": "1",
+    "create_db_bak": "2",
+    "create_db_dump": "3",
+    "restore_db_from_bak": "4",
+    "config_db": "5",
+    "config_db_rep": "6",
+    "logfile_conf": "7",
+    "config_app_db_failover_monitor": "8",
+    "ext_temp_storage": "9",
+    "config_external_auth": "10",
+    "update_ext_auth_opt": "11",
+    "gen_custom_encry_key": "12",
+    "harden_app_scap_config": "13",
+    "stop_evm": "14",
+    "start_evm": "15",
+    "restart_app": "16",
+    "showdown_app": "17",
+    "summary_info": "18",
+    "quit": "19",
+}
+app_con_menu = VersionPicker({Version.lowest(): app_menu_v5_10, "5.11": app_menu_v5_11}).pick()


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
__adding_test__ Testing the appliance UI after restarting the appliance database.
### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->

{{pytest: ./cfme/tests/cli/test_appliance_console.py::test_appliance_console_vmdb_httpd -v}}