### PR TITLE
[1LP][RFR] Automate: test_reports_generate_custom_conditional_filter_report

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -232,7 +232,6 @@ def generic_service(appliance, generic_catalog_item):
 
     service = MyService(appliance, generic_catalog_item.dialog.label)
     yield service, generic_catalog_item
-
     if service.exists:
         service.delete()
     if provision_request.exists:

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -9,7 +9,6 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Dropdown
-from widgetastic_patternfly import Input
 
 from cfme.common import BaseLoggedInPage
 from cfme.common import TagPageView
@@ -32,6 +31,7 @@ from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import JSBaseEntity
 from widgetastic_manageiq import ManageIQTree
 from widgetastic_manageiq import ParametrizedSummaryTable
+from widgetastic_manageiq import ReactTextInput
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
 
@@ -91,8 +91,8 @@ class ServiceRetirementForm(MyServicesView):
 class ServiceEditForm(MyServicesView):
     title = Text('#explorer_title_text')
 
-    name = Input(name='name')
-    description = Input(name='description')
+    name = ReactTextInput(name='name')
+    description = ReactTextInput(name='description')
 
 
 class SetOwnershipForm(MyServicesView):

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -187,6 +187,15 @@ def setup_vm(configure_fleecing, appliance, provider):
 
     vm.cleanup_on_provider()
 
+
+@pytest.fixture
+def edit_service_name(service_vm, request):
+    service, vm = service_vm
+    new_name = f"vm-test_{service.name}"
+    service.update({"name": new_name})
+    service.name = new_name
+    return service, vm
+
 # =========================================== Tests ===============================================
 
 
@@ -735,3 +744,38 @@ def test_vm_volume_free_space_less_than_20_percent(
     assert all(
         [float(row) <= 20.0 for row in rows if row]
     ), "Volume Free Space Percent is greater than 20%"
+
+
+@pytest.mark.tier(1)
+@pytest.mark.customer_scenario
+@pytest.mark.meta(automates=[1521167])
+@pytest.mark.provider([InfraProvider], selector=ONE_PER_CATEGORY)
+def test_reports_generate_custom_conditional_filter_report(
+    setup_provider, get_report, edit_service_name, provider
+):
+    """
+    Bugzilla:
+        1521167
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Reporting
+        caseimportance: medium
+        initialEstimate: 1/6h
+        startsin: 5.8
+        setup:
+            1. Create or edit a service with one of the above naming conventions (vm-test, My-Test)
+            2. Have at least one VM in the service so the reporting will parse it
+            3. Create a report with a conditional filter in it, such as:
+               conditions: !ruby/object:MiqExpression exp: and: - IS NOT NULL: field:
+               Vm.service-name - IS NOT NULL: field: Vm-ems_cluster_name.
+        testSteps:
+            1. Queue the report.
+        expectedResults:
+            1. Report must be generated successfully.
+    """
+    service, vm = edit_service_name
+    report = get_report("vm_service_report", "VM Service")
+    saved_report = report.queue(wait_for_finish=True)
+    view = navigate_to(saved_report, "Details")
+    assert view.table.row(name__contains=vm.name)["Service Name"].text == service.name

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -17,6 +17,8 @@ from cfme.utils.ftp import FTPException
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.rest import assert_response
+from cfme.utils.update import update
+
 
 pytestmark = [test_requirements.report, pytest.mark.tier(3), pytest.mark.sauce]
 
@@ -189,11 +191,11 @@ def setup_vm(configure_fleecing, appliance, provider):
 
 
 @pytest.fixture
-def edit_service_name(service_vm, request):
+def edit_service_name(service_vm):
     service, vm = service_vm
     new_name = f"vm-test_{service.name}"
-    service.update({"name": new_name})
-    service.name = new_name
+    with update(service):
+        service.name = new_name
     return service, vm
 
 # =========================================== Tests ===============================================

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -10,32 +10,6 @@ pytestmark = [pytest.mark.manual]
 
 
 @test_requirements.report
-@pytest.mark.tier(1)
-def test_reports_generate_custom_conditional_filter_report():
-    """
-    Bugzilla:
-        1521167
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.8
-        setup:
-            1. Create a service with one of the above naming conventions (vm-test,My-Test)
-            2. Have at least one VM in the service so the reporting will parse it
-            3. Create a report with a conditional filter in it, such as:
-               conditions: !ruby/object:MiqExpression exp: and: - IS NOT NULL: field:
-               Vm.service-name - IS NOT NULL: field: Vm-ems_cluster_name.
-        testSteps:
-            1. Queue the report.
-        expectedResults:
-            1. Report must be generated successfully.
-    """
-
-
-@test_requirements.report
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("5.10")
 def test_reports_timezone():


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__ 
    1. Automate: `test_reports_generate_custom_conditional_filter_report` and remove manual test.

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_reports.py -k "test_reports_generate_custom_conditional_filter_report" -vvv }}