### PR TITLE
[1LP][RFR] Test provider compare regions provider and backup

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -1187,10 +1187,50 @@ class RegionDiagnosticsView(ConfigurationView):
         )
 
 
+class SambaProtocolEntities(View):
+    """ Samba Protocol fields on the shedule configuration page """
+    samba_username = Input(id='log_userid')
+    samba_password = Input(id='log_password')
+    samba_confirm_password = Input(id='log_verify')
+
+
+class AWSS3ProtocolEntities(View):
+    """ AWS S3 Protocol fields on the shedule configuration page"""
+    aws_region = BootstrapSelect(id='log_aws_region')
+    aws_username = Input(id='log_userid')
+    aws_password = Input(id='log_password')
+    aws_confirm_password = Input(id='log_verify')
+
+
+class OpenstackSwiftProtocolEntities(View):
+    """ Openstack Swift Protocol fields on the shedule configuration page"""
+    openstack_keystone_version = BootstrapSelect(id='keystone_api_version')
+    openstack_region = Input('openstack_region')
+    openstack_security_protocol = BootstrapSelect(id='security_protocol')
+    openstack_api_port = Input('swift_api_port')
+    openstack_username = Input(id='log_userid')
+    openstack_password = Input(id='log_password')
+    openstack_confirm_password = Input(id='log_verify')
+
+
+class RegionDiagnosticsDatabaseBackupEntities(View):
+    """ Database Backup fields on the shedule configuration page """
+    backup_type = BootstrapSelect('log_protocol')
+    depot_name = Input(id='depot_name')
+    uri = Input(id='uri')
+
+    samba_protocol = View.nested(SambaProtocolEntities)
+    aws_s3_protocol = View.nested(AWSS3ProtocolEntities)
+    openstack_swift_protocol = View.nested(OpenstackSwiftProtocolEntities)
+
+
 class RegionDiagnosticsDatabaseView(RegionDiagnosticsView):
 
-    db_backup_settings_type = BootstrapSelect(id='log_protocol')
+    db_backup_settings = View.nested(RegionDiagnosticsDatabaseBackupEntities)
     submit_db_garbage_collection_button = Button(alt="Run Database Garbage Collection Now")
+
+    depot_name = Input(id='depot_name')
+    uri = Input(id='uri')
 
     @property
     def is_displayed(self):

--- a/cfme/configure/configuration/system_schedules.py
+++ b/cfme/configure/configuration/system_schedules.py
@@ -8,6 +8,7 @@ from widgetastic_patternfly import Button
 from widgetastic_patternfly import Input
 
 from cfme.base.ui import ConfigurationView
+from cfme.base.ui import DatabaseBackupEntities
 from cfme.modeling.base import BaseCollection
 from cfme.modeling.base import BaseEntity
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -35,43 +36,6 @@ class ItemsAnalysisEntities(View):
     """ Analysis fields on the shedule configuration page """
     filter_level1 = BootstrapSelect("filter_typ")
     filter_level2 = BootstrapSelect("filter_value")
-
-
-class SambaProtocolEntities(View):
-    """ Samba Protocol fields on the shedule configuration page """
-    samba_username = Input(id='log_userid')
-    samba_password = Input(id='log_password')
-    samba_confirm_password = Input(id='log_verify')
-
-
-class AWSS3ProtocolEntities(View):
-    """ AWS S3 Protocol fields on the shedule configuration page"""
-    aws_region = BootstrapSelect(id='log_aws_region')
-    aws_username = Input(id='log_userid')
-    aws_password = Input(id='log_password')
-    aws_confirm_password = Input(id='log_verify')
-
-
-class OpenstackSwiftProtocolEntities(View):
-    """ Openstack Swift Protocol fields on the shedule configuration page"""
-    openstack_keystone_version = BootstrapSelect(id='keystone_api_version')
-    openstack_region = Input('openstack_region')
-    openstack_security_protocol = BootstrapSelect(id='security_protocol')
-    openstack_api_port = Input('swift_api_port')
-    openstack_username = Input(id='log_userid')
-    openstack_password = Input(id='log_password')
-    openstack_confirm_password = Input(id='log_verify')
-
-
-class DatabaseBackupEntities(View):
-    """ Database Backup fields on the shedule configuration page """
-    backup_type = BootstrapSelect('log_protocol')
-    depot_name = Input(id='depot_name')
-    uri = Input(id='uri')
-
-    samba_protocol = View.nested(SambaProtocolEntities)
-    aws_s3_protocol = View.nested(AWSS3ProtocolEntities)
-    openstack_swift_protocol = View.nested(OpenstackSwiftProtocolEntities)
 
 
 class ScheduleAddEditEntities(View):
@@ -254,14 +218,14 @@ class SystemSchedule(BaseEntity, Updateable, Pretty):
             'start_hour': updates.get('start_hour'),
             'start_minute': updates.get('start_minute'),
             'database_backup': {
-                'depot_name': updates.get('depot_name'),
                 'backup_type': updates.get('backup_type'),
-                'uri': updates.get('uri'),
-            },
-            'samba_protocol': {
-                'samba_username': updates.get('samba_username'),
-                'samba_password': updates.get('samba_password'),
-                'samba_password_verify': updates.get('samba_password'),
+                'backup_settings': {
+                    'depot_name': updates.get('depot_name'),
+                    'uri': updates.get('uri'),
+                    'samba_username': updates.get('samba_username'),
+                    'samba_password': updates.get('samba_password'),
+                    'samba_password_verify': updates.get('samba_password')
+                }
             },
             'items_analysis': {
                 'filter_level1': updates.get('filter_level1'),
@@ -361,18 +325,18 @@ class SystemSchedulesCollection(BaseCollection):
         if action_type == 'Database Backup':
             details.update({
                 'database_backup': {
-                    'depot_name': depot_name,
                     'backup_type': backup_type,
-                    'uri': uri
+                    'backup_settings': {
+                        'depot_name': depot_name,
+                        'uri': uri
+                    }
                 }
             })
             if backup_type == 'Samba':
-                details['database_backup'].update({
-                    'samba_protocol': {
-                        'samba_username': samba_username,
-                        'samba_password': samba_password,
-                        'samba_password_verify': samba_password
-                    }
+                details['database_backup']['backup_settings'].update({
+                    'samba_username': samba_username,
+                    'samba_password': samba_password,
+                    'samba_password_verify': samba_password
                 })
         else:
             details.update({

--- a/cfme/configure/configuration/system_schedules.py
+++ b/cfme/configure/configuration/system_schedules.py
@@ -43,6 +43,23 @@ class SambaProtocolEntities(View):
     samba_password = Input(id='log_password')
     samba_confirm_password = Input(id='log_verify')
 
+class AWSS3ProtocolEntities(View):
+    """ AWS S3 Protocol fields on the shedule configuration page"""
+    aws_region = BootstrapSelect(id='log_aws_region')
+    aws_username = Input(id='log_userid')
+    aws_password = Input(id='log_password')
+    aws_confirm_password = Input(id='log_verify')
+
+
+class OpenstackSwiftProtocolEntities(View):
+    """ Openstack Swift Protocol fields on the shedule configuration page"""
+    openstack_keystone_version = BootstrapSelect(data_id='keystone_api_version')
+    openstack_region = Input('openstack_region')
+    openstack_security_protocol = BootstrapSelect(data_id='security_protocol')
+    openstack_api_port = Input('swift_api_port')
+    openstack_username = Input(id='log_userid')
+    openstack_password = Input(id='log_password')
+    openstack_confirm_password = Input(id='log_verify')
 
 class DatabaseBackupEntities(View):
     """ Database Backup fields on the shedule configuration page """
@@ -51,6 +68,8 @@ class DatabaseBackupEntities(View):
     uri = Input(id='uri')
 
     samba_protocol = View.nested(SambaProtocolEntities)
+    aws_s3_protocol = View.nested(AWSS3ProtocolEntities)
+    openstack_swift_protocol = View.nested(OpenstackSwiftProtocolEntities)
 
 
 class ScheduleAddEditEntities(View):

--- a/cfme/configure/configuration/system_schedules.py
+++ b/cfme/configure/configuration/system_schedules.py
@@ -43,6 +43,7 @@ class SambaProtocolEntities(View):
     samba_password = Input(id='log_password')
     samba_confirm_password = Input(id='log_verify')
 
+
 class AWSS3ProtocolEntities(View):
     """ AWS S3 Protocol fields on the shedule configuration page"""
     aws_region = BootstrapSelect(id='log_aws_region')
@@ -53,13 +54,14 @@ class AWSS3ProtocolEntities(View):
 
 class OpenstackSwiftProtocolEntities(View):
     """ Openstack Swift Protocol fields on the shedule configuration page"""
-    openstack_keystone_version = BootstrapSelect(data_id='keystone_api_version')
+    openstack_keystone_version = BootstrapSelect(id='keystone_api_version')
     openstack_region = Input('openstack_region')
-    openstack_security_protocol = BootstrapSelect(data_id='security_protocol')
+    openstack_security_protocol = BootstrapSelect(id='security_protocol')
     openstack_api_port = Input('swift_api_port')
     openstack_username = Input(id='log_userid')
     openstack_password = Input(id='log_password')
     openstack_confirm_password = Input(id='log_verify')
+
 
 class DatabaseBackupEntities(View):
     """ Database Backup fields on the shedule configuration page """

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1486,3 +1486,59 @@ def test_add_second_provider(setup_provider, provider, request):
     second_provider.refresh_provider_relationships()
     second_provider.validate_stats(ui=True)
     assert provider.exists and second_provider.exists
+
+
+@test_requirements.ec2
+@pytest.mark.automates([1710599, 1710623])
+@pytest.mark.ignore_stream("5.10")  # BZ 1710623 was not merged into 5.10
+def test_provider_compare_ec2_provider_and_backup_regions(appliance):
+    """
+    Polarion:
+        assignee: mmojzis
+        casecomponent: Cloud
+        initialEstimate: 1/6h
+        caseimportance: medium
+        casecomponent: Cloud
+        testSteps:
+            1. Go to Compute -> Cloud -> Providers -> Add a new Cloud Provider
+            2. Select Provider: Amazon EC2 and list AWS Regions
+            3. Go to Configuration -> Settings -> Schedules -> Add a new Schedule
+            4. Select Action: Database Backup, Type: AWS S3 and list AWS Regions
+            5. Go to Configuration -> Diagnostics -> Region -> Database
+            6. Select Type: AWS S3 and list AWS Regions
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6. Compare all three lists. They should contain same regions.
+    """
+    view = navigate_to(CloudProvider, 'Add')
+    view.prov_type.fill("Amazon EC2")
+    regions_provider = view.region.all_options
+    # Delete option <Choose>
+    regions_provider.pop(0)
+    regions_provider_texts = [option.text for option in regions_provider]
+    regions_provider_texts.sort()
+
+    view = navigate_to(appliance.collections.system_schedules, 'Add')
+    view.form.action_type.fill("Database Backup")
+    view.form.database_backup.backup_type.fill("AWS S3")
+    regions_scheduled_backup = view.form.database_backup.aws_s3_protocol.aws_region.all_options
+    # Delete option <Choose>
+    regions_scheduled_backup.pop(0)
+    regions_scheduled_backup_texts = [option.text for option in regions_scheduled_backup]
+    regions_scheduled_backup_texts.sort()
+
+    view = navigate_to(appliance.server.zone.region, 'Database')
+    view.db_backup_settings.backup_type.fill("AWS S3")
+    regions_immediate_backup = view.db_backup_settings.aws_s3_protocol.aws_region.all_options
+    # Delete option <Choose>
+    regions_immediate_backup.pop(0)
+    regions_immediate_backup_texts = [option.text for option in regions_immediate_backup]
+    regions_immediate_backup_texts.sort()
+
+    assert regions_provider_texts == regions_scheduled_backup_texts
+    assert regions_provider_texts == regions_immediate_backup_texts
+    assert regions_scheduled_backup_texts == regions_immediate_backup_texts

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1493,6 +1493,7 @@ def test_add_second_provider(setup_provider, provider, request):
 @pytest.mark.ignore_stream("5.10")  # BZ 1710623 was not merged into 5.10
 def test_provider_compare_ec2_provider_and_backup_regions(appliance):
     """
+    Bugzilla: 1710599, 1710623
     Polarion:
         assignee: mmojzis
         casecomponent: Cloud
@@ -1516,29 +1517,24 @@ def test_provider_compare_ec2_provider_and_backup_regions(appliance):
     """
     view = navigate_to(CloudProvider, 'Add')
     view.prov_type.fill("Amazon EC2")
-    regions_provider = view.region.all_options
-    # Delete option <Choose>
-    regions_provider.pop(0)
-    regions_provider_texts = [option.text for option in regions_provider]
+    regions_provider_texts = [option.text for option in view.region.all_options if
+                              option.text != "<Choose>"]
     regions_provider_texts.sort()
 
     view = navigate_to(appliance.collections.system_schedules, 'Add')
     view.form.action_type.fill("Database Backup")
     view.form.database_backup.backup_type.fill("AWS S3")
     regions_scheduled_backup = view.form.database_backup.aws_s3_protocol.aws_region.all_options
-    # Delete option <Choose>
-    regions_scheduled_backup.pop(0)
-    regions_scheduled_backup_texts = [option.text for option in regions_scheduled_backup]
+    regions_scheduled_backup_texts = [option.text for option in regions_scheduled_backup if
+                                      option.text != "<Choose>"]
     regions_scheduled_backup_texts.sort()
 
     view = navigate_to(appliance.server.zone.region, 'Database')
     view.db_backup_settings.backup_type.fill("AWS S3")
     regions_immediate_backup = view.db_backup_settings.aws_s3_protocol.aws_region.all_options
-    # Delete option <Choose>
-    regions_immediate_backup.pop(0)
-    regions_immediate_backup_texts = [option.text for option in regions_immediate_backup]
+    regions_immediate_backup_texts = [option.text for option in regions_immediate_backup if
+                                      option.text != "<Choose>"]
     regions_immediate_backup_texts.sort()
 
     assert regions_provider_texts == regions_scheduled_backup_texts
     assert regions_provider_texts == regions_immediate_backup_texts
-    assert regions_scheduled_backup_texts == regions_immediate_backup_texts

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1524,14 +1524,14 @@ def test_provider_compare_ec2_provider_and_backup_regions(appliance):
     view = navigate_to(appliance.collections.system_schedules, 'Add')
     view.form.action_type.fill("Database Backup")
     view.form.database_backup.backup_type.fill("AWS S3")
-    regions_scheduled_backup = view.form.database_backup.aws_s3_protocol.aws_region.all_options
+    regions_scheduled_backup = view.form.database_backup.backup_settings.aws_region.all_options
     regions_scheduled_backup_texts = [option.text for option in regions_scheduled_backup if
                                       option.text != "<Choose>"]
     regions_scheduled_backup_texts.sort()
 
     view = navigate_to(appliance.server.zone.region, 'Database')
     view.db_backup_settings.backup_type.fill("AWS S3")
-    regions_immediate_backup = view.db_backup_settings.aws_s3_protocol.aws_region.all_options
+    regions_immediate_backup = view.db_backup_settings.backup_settings.aws_region.all_options
     regions_immediate_backup_texts = [option.text for option in regions_immediate_backup if
                                       option.text != "<Choose>"]
     regions_immediate_backup_texts.sort()


### PR DESCRIPTION
Added database backup options - openstack_swift and aws_s3.
Added test_provider_compare_ec2_provider_and_backup_regions.
I would like to have OpenstackSwiftProtocolEntities and AWSS3ProtocolEntities in single place, but I don't know what is the good place to be in. Now it is in system_schedules.py an base/ui.py.
{{ pytest: -k "test_provider_compare_ec2_provider_and_backup_regions" -k "test_db_backup_schedule" -v }}