### PR TITLE
[1LP][WIPTEST] Add create_vms fixture for multiple VMs, add deploy_args support.

### DIFF
--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -134,3 +134,14 @@ class EC2Provider(CloudProvider):
             'password': getattr(credential, 'secret', None),
             'confirm_password': getattr(credential, 'verify_secret', None)
         }
+
+    def deployment_helper(self, deploy_args):
+        """Used in utils.virtual_machines. For ec2, look up any non-default instance_type
+        that is specified under the template in the provider's YAML, and return the value."""
+        d = {}
+        templates = self.data['templates']
+        for template_type, template in templates.items():
+            if deploy_args['template'] == template['name'] and 'instance_type' in template:
+                d = {'instance_type': template['instance_type']}
+                break
+        return d


### PR DESCRIPTION
This PR makes a couple changes to the create_vm / create_vm_modscope fixtures and adds create_vms / create_vms_modscope, for creating a specified number of vms/instances.

1.)  The vm name creation was split between the _get_vm_name and _create_vm methods. I think it makes more sense to have all of the vm name creation within _get_vm_name, so it's all in one method now.

2.) EC2Provider.deployment_helper now looks in the provider YAML for an 'instance_type' key under the template, and passes any value it finds back to vm.create_on_provider. (I originally had this in the fixture code under _create_vm, but this is really an EC2-specific thing, so I've moved it EC2Provider.) 

3.) Updated create_vm / create_vm_modscope parameter checking code, so that template_type isn't required. (The provisioning code under deploy_template attempts to look up and use small_template as the default.)

4.) Two new fixtures, create_vms and create_vms_modscope, are added. They are parametrized to accept a dict of the form:

param = {'template_type': str, 'num_vms': int},

where 'template_type' is the same template type name as is used by create_vm / create_vm_modscope (default: None), and 'num_vms' is the number of VMs/Instances to provision (default: 2).

These fixtures return a list of the vm/instance objects.

5.) The template dictionaries are now looked up by using the existing method _get_template from cfme.fixtures.templates.

{{ pytest: -k test_vm_right_size_recommendation_back_button cfme/tests/webui/test_general_ui.py }}