### PR TITLE
[1LP][RFR] Update vm retirement tests to use create_vm / create_vms

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -37,7 +37,6 @@ from cfme.utils.log import logger
 from cfme.utils.net import find_pingable
 from cfme.utils.pretty import Pretty
 from cfme.utils.rest import assert_response
-from cfme.utils.timeutil import parsetime
 from cfme.utils.update import Updateable
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import wait_for
@@ -184,7 +183,8 @@ class BaseVM(
     # Titles of the delete buttons in configuration
     REMOVE_SELECTED = 'Remove selected items from Inventory'
     REMOVE_SINGLE = 'Remove Virtual Machine from Inventory'
-    RETIRE_DATE_FMT = parsetime.saved_report_title_format
+    RETIRE_DATE_FMT = '%a, %d %b %Y %H:%M:%S +0000'
+    RETIRE_DATE_MSG_FMT = '%m/%d/%y %H:%M UTC'
     _param_name = ParamClassName('name')
     DETAILS_VIEW_CLASS = None
 


### PR DESCRIPTION
This PR updates vm retirement tests to use the new create_vm and create_vms fixtures.

Also, the following change in PR 9904 broke VM retirement tests:
```
cfme/utils/timeutil.py:

-    saved_report_title_format = "%a, %d %b %Y %H:%M:%S +0000"
+    saved_report_title_format = "%a, %d %b %Y %H:%M:%S"
```

That's because BaseVM uses this format string for retirement date formatting:
```
cfme/common/vm.py:

    RETIRE_DATE_FMT = parsetime.saved_report_title_format
```

The retirement date formatting logic in verify_retirement_date() then fails. This PR makes the following additional changes to fix this:

1.) Update BaseVM.RETIRE_DATE_FMT. Also add BaseVM.RETIRE_DATE_MSG_FMT for formatting retirement dates when they appear in a flash message.

2.) Simplify the logic in verify_retirement_date(). Uses datetime.strptime() directly and removes use of parsetime.

{{ pytest: cfme/tests/cloud_infra_common/test_retirement.py -v --long-running --use-provider vsphere67-nested --use-provider ec2west }}
