### PR TITLE
[1LP][RFR] Update distributed appliance test to use create_vm fixture

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -476,6 +476,8 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
                 ssh_client.run_command(
                     "echo '-w /etc/sysconfig/network-scripts/ifcfg-eth0 -p wa' >> "
                     "/etc/audit/rules.d/audit.rules", ensure_host=True)
+
+            with self.ssh_client as ssh_client:
                 self.httpd.daemon_reload()
                 # cannot restart through systemctl
                 ssh_client.run_command('service auditd restart', ensure_host=True)


### PR DESCRIPTION
This PR updates the distributed appliance test test_distributed_vm_power_control to use the create_vm fixture. This requires using the parametrized provider fixture, instead of the unparametrized virtualcenter fixture that was used in this module previously. I've changed all of the other tests in the module to use it too, for consistency, even though they do not need it for VM creation.

I've also removed the get_ssh_client method, which is no longer used.

There was an issue with ssh clients getting connection refused errors in PRT testing, when configuring the appliance. This commit also includes a one line change to appliance.configure, to re-connect after the audit rule / network interface related command that triggers the connection closure.

{{ pytest: --long-running cfme/tests/distributed/test_appliance_replication.py -vv }}
