### PR TITLE
[1LP][RFR] Use FlashMessages view

### DIFF
--- a/cfme/automate/import_export.py
+++ b/cfme/automate/import_export.py
@@ -19,7 +19,10 @@ from widgetastic_manageiq import V2VFlashMessages
 
 
 class AutomateImportExportBaseView(BaseLoggedInPage):
-    flash = FlashMessages("div.import-flash-message")
+    @View.nested
+    class flash(FlashMessages):
+        ROOT = 'div.import-flash-message'
+
     title = Text('.//div[@id="main-content"]//h1')
 
     @property
@@ -36,7 +39,9 @@ class AutomateImportExportBaseView(BaseLoggedInPage):
 
 
 class AutomateImportExportView(AutomateImportExportBaseView):
-    flash = V2VFlashMessages(locator="div.import-flash-message")
+    @View.nested
+    class flash(V2VFlashMessages):
+        ROOT = 'div.import-flash-message'
 
     @View.nested
     class import_file(View):  # noqa
@@ -71,7 +76,10 @@ class AutomateImportExportView(AutomateImportExportBaseView):
 
 
 class FileImportSelectorView(AutomateImportExportBaseView):
-    flash = V2VFlashMessages(locator="div.import-flash-message")
+    @View.nested
+    class flash(V2VFlashMessages):
+        ROOT = 'div.import-flash-message'
+
     import_into = BootstrapSelect(id="selected_domain_to_import_to")
     import_from = BootstrapSelect(
         locator=".//div[contains(@class, 'bootstrap-select importing-domains')]"

--- a/cfme/base/ssui.py
+++ b/cfme/base/ssui.py
@@ -40,7 +40,7 @@ class SSUIBaseLoggedInPage(View):
     """This page should be subclassed by any page that models any other page that is available as
     logged in.
     """
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    flash = View.nested(FlashMessages)
     # TODO don't use `help` here, its a built-in
     help = SSUIHelpNavDropdown()
     navigation = SSUIVerticalNavigation('//ul[@class="list-group"]')
@@ -90,7 +90,7 @@ class SSUIBaseLoggedInPage(View):
 
 
 class LoginPage(View):
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    flash = View.nested(FlashMessages)
     username = Input(id='inputUsername')
     password = Input(id='inputPassword')
     login = Button('Log In')

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -65,7 +65,7 @@ def address(self):
 
 
 class LoginPage(View):
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    flash = View.nested(FlashMessages)
 
     class details(View):  # noqa
         region = Text('.//p[normalize-space(text())="Region:"]/span')

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -45,7 +45,7 @@ class BaseLoggedInPage(View):
     logged in.
     """
     CSRF_TOKEN = '//meta[@name="csrf-token"]'
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    flash = View.nested(FlashMessages)
     # TODO don't use `help` here, its a built-in
     help = NavDropdown(id="help-menu")
     configuration_settings = Text('//li[.//a[@title="Configuration"]]')  # 5.11+

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -705,7 +705,7 @@ class BaseVMCollection(BaseCollection):
 
             view = vm.appliance.browser.create_view(RequestsView)
             if not BZ(1608967, forced_streams=['5.10']).blocks:
-                wait_for(lambda: view.flash.messages, fail_condition=[], timeout=10, delay=2,
+                wait_for(lambda: view.flash.read(), fail_condition=[], timeout=10, delay=2,
                         message='wait for Flash Success')
             view.flash.assert_no_error()
             if wait:

--- a/cfme/configure/configuration/server_settings.py
+++ b/cfme/configure/configuration/server_settings.py
@@ -80,8 +80,9 @@ class ServerRolesView511(BaseServerRolesView):
 class ServerInformationView(View):
     """ Class represents full Server tab view"""
     title = Text("//div[@id='settings_server']/h3[1]")
-    # Local Flash widget for validation since class nested under a class inheriting BaseLoggedInPage
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    # Use local FlashMessages view for validation, since this class is nested under
+    # under a class inheriting BaseLoggedInPage.
+    flash = View.nested(FlashMessages)
     save = Button('Save')
     reset = Button('Reset')
 
@@ -549,8 +550,9 @@ class ExternalAuthenticationView(View):
 class ServerAuthenticationView(View):
     """ Server Authentication View."""
     title = Text("//div[@id='settings_authentication']/h3[1]")
-    # Local Flash widget for validation since class nested under a class inheriting BaseLoggedInPage
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    # Use local FlashMessages view for validation,
+    # since this class is nested under a class inheriting BaseLoggedInPage.
+    flash = View.nested(FlashMessages)
     hours_timeout = BootstrapSelect(id='session_timeout_hours')
     minutes_timeout = BootstrapSelect(id='session_timeout_mins')
     # TODO new button widget to handle buttons_on buttons_off divs

--- a/cfme/containers/image.py
+++ b/cfme/containers/image.py
@@ -83,8 +83,7 @@ class Image(BaseEntity, Taggable, Labelable, LoadDetailsMixin, PolicyProfileAssi
         # the str compile on tasks module
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Perform SmartState Analysis', handle_alert=True)
-        # TODO: Modify accordingly once there is FlashMessages.assert_massage_contains()
-        assert [m for m in view.flash.messages if 'Analysis successfully initiated' in m.text]
+        view.flash.assert_message('Analysis successfully initiated', partial=True)
         if wait_for_finish:
             try:
                 task = self.appliance.collections.tasks.instantiate(

--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -767,7 +767,7 @@ def navigate_and_get_rows(provider, obj, count, silent_failure=False):
 
     view = navigate_to(obj, 'All')
     view.toolbar.view_selector.list_button.click()
-    if [msg for msg in view.flash.messages if 'No Records Found.' in msg.text] and silent_failure:
+    if view.flash.read(text='No Records Found.', partial=True) and silent_failure:
         return []
     view.paginator.set_items_per_page(1000)
     rows = list(view.table.rows())

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1059,7 +1059,7 @@ class InfraVm(VM):
                 view.form.cancel_button.click()
             else:
                 view.form.save_button.click()
-                wait_for(lambda: len(view.flash.messages) > 0)
+                wait_for(lambda: len(view.flash.read()) > 0)
                 view.flash.assert_success_message('Management Engine Relationship saved')
                 view = navigate_to(self.vm, 'Details')
                 server_details = view.entities.summary("Properties").get_text_of("Server")
@@ -1069,7 +1069,7 @@ class InfraVm(VM):
             view = self.navigate()
             view.form.fill({'server': '<Not a Server>'})
             view.form.save_button.click()
-            wait_for(lambda: len(view.flash.messages) > 0)
+            wait_for(lambda: len(view.flash.read()) > 0)
             view.flash.assert_success_message('Management Engine Relationship saved')
             view = navigate_to(self.vm, 'Details')
             fields = view.entities.summary("Properties").fields

--- a/cfme/intelligence/reports/schedules.py
+++ b/cfme/intelligence/reports/schedules.py
@@ -62,7 +62,7 @@ class BootstrapSelectRetry(BootstrapSelect):
 
 
 class SchedulesFormCommon(CloudIntelReportsView):
-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    flash = View.nested(FlashMessages)
     # Basic Information
     title = Text("#explorer_title_text")
     name = TextInput(name="name")

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -760,10 +760,9 @@ def test_azure_instance_password_requirements(appliance, request,
                "abcdefgh_1A"):
         view.form.customize.fill({"root_password": pw})
         view.form.submit_button.click()
-        wait_for(lambda: message in (m.read() for m in view.flash.messages),
+        wait_for(lambda: message in view.flash.read(),
                  fail_condition=False, num_sec=10, delay=.1)
-        for m in view.flash.messages:
-            m.dismiss()
+        view.flash.dismiss()
 
 
 @pytest.mark.tier(3)
@@ -940,7 +939,7 @@ def test_domain_id_validation(request, provider):
     view = prov.create_view(CloudProviderAddView)
 
     # ToDo: Assert proper flash message after BZ-1545520 fix.
-    assert view.flash.messages[0].type == 'error'
+    assert view.flash[0].type == 'error'
 
 
 @test_requirements.azure

--- a/cfme/tests/configure/test_schedule_operations.py
+++ b/cfme/tests/configure/test_schedule_operations.py
@@ -115,9 +115,8 @@ def test_schedule_analysis_in_the_past(appliance, current_server_time, request):
     )
     request.addfinalizer(schedule.delete)
     view = appliance.browser.create_view(BaseLoggedInPage)
-    assert (
-        "Warning: This 'Run Once' timer is in the past and will never"
-        " run as currently configured" in [message.text for message in view.flash.messages]
+    view.flash.assert_message(
+        "Warning: This 'Run Once' timer is in the past and will never run as currently configured"
     )
 
 

--- a/cfme/tests/physical_infrastructure/ui/test_physical_server_list_buttons.py
+++ b/cfme/tests/physical_infrastructure/ui/test_physical_server_list_buttons.py
@@ -87,7 +87,7 @@ def test_server_actions(physical_servers_collection, physical_servers, provider,
 
     def assert_handler_displayed():
         if view.flash.is_displayed:
-            return view.flash.messages[0].text == message
+            return view.flash[0].text == message
 
         return False
 

--- a/cfme/v2v/infrastructure_mapping.py
+++ b/cfme/v2v/infrastructure_mapping.py
@@ -106,7 +106,11 @@ class InfrastructureMappingForm(InfrastructureMappingView):
         plan_type = BootstrapSelect("targetProvider")
         name_help_text = Text(locator='.//div[contains(@id,"name")]/span')
         description_help_text = Text(locator='.//div[contains(@id,"description")]/span')
-        flash = V2VFlashMessages('.//div[@class="modal-wizard-alert"]')
+
+        @View.nested
+        class flash(V2VFlashMessages):
+            ROOT = './/div[@class="modal-wizard-alert"]'
+
         fill_strategy = WaitFillViewStrategy()
 
         def after_fill(self, was_change):

--- a/cfme/v2v/migration_plans.py
+++ b/cfme/v2v/migration_plans.py
@@ -318,7 +318,9 @@ class MigrationPlanRequestDetailsView(View):
     migration_request_details_list = MigrationPlanRequestDetailsList("plan-request-details-list")
     paginator_view = View.include(V2VPaginatorPane, use_parent=True)
     download_logs = Dropdown("Download Log")
-    flash = V2VFlashMessages('.//div[@class="modal-wizard-alert"]')
+    @View.nested
+    class flash(V2VFlashMessages):
+        ROOT = './/div[@class="modal-wizard-alert"]'
 
     @property
     def is_displayed(self):

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -337,9 +337,9 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.16.0
 widgetastic.core==0.51
-widgetastic.patternfly==1.2.2
+widgetastic.patternfly==1.3.0
 widgetsnbextension==3.4.2
-wrapanapi== 3.5.6
+wrapanapi==3.5.6
 wrapt==1.11.1
 xmltodict==0.12.0
 yaycl==0.3.0

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -5924,26 +5924,15 @@ class DiagnosticsTreeView(BootstrapTreeview):
 
 
 class V2VFlashMessage(FlashMessage):
-    """Overriding text method of FlashMessage for V2V"""
+    """Override the text locator for inline notifications in V2V."""
 
-    @property
-    def text(self):
-        return self.browser.text(self)
+    TEXT_LOCATOR = "."
 
 
 class V2VFlashMessages(FlashMessages):
-    """Overriding FlashMessages method for xpath of alerts in V2V"""
+    """Override the default ParametrizedView class for inline notifications in V2V."""
 
-    @property
-    def messages(self):
-        result = []
-        msg_xpath = './/div[contains(@class, "alert")]'
-        try:
-            for flash_div in self.browser.elements(msg_xpath, check_visibility=True):
-                result.append(V2VFlashMessage(self, flash_div, logger=self.logger))
-        except NoSuchElementException:
-            pass
-        return result
+    msg_class = V2VFlashMessage
 
 
 class SSUICardPFInfoStatus(Widget):


### PR DESCRIPTION
Use the FlashMessages view, which replaces the widget implementation in widgetastic_patternfly 1.3.0.

Most of the changes are of the form
```
-    flash = FlashMessages("div.import-flash-message")
+    @View.nested
+    class flash(FlashMessages):
+        ROOT = 'div.import-flash-message'

-    flash = FlashMessages('.//div[@id="flash_msg_div"]')
+    flash = View.nested(FlashMessages)
```
and any subsequent method/attribute access is unchanged. Adding some basic PRT with representative test cases that call flash methods.

{{ pytest: -k 'test_vm_filter_without_user_input or test_reports_schedule_crud' cfme/tests/infrastructure/test_advanced_search_vms.py cfme/tests/intelligence/reports/test_crud.py -v }}