### PR TITLE
[1LP][RFR] Automate: test_created_on_time_report_field

### DIFF
--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -65,29 +65,6 @@ def test_reports_in_global_region(context, report):
     pass
 
 
-@test_requirements.report
-@pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1743579])
-def test_created_on_time_report_field():
-    """
-    Bugzilla:
-        1743579
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/2h
-        setup:
-            1. Add a provider and provision a VM
-        testSteps:
-            1. Create a report based on 'VMs and Instances' with [Created on Time, Name] field.
-        expectedResults:
-            1. `Created on Time` field column must not be empty for the recently created VM.
-    """
-    pass
-
-
 @pytest.mark.ignore_stream("5.10")
 @test_requirements.report
 @pytest.mark.tier(2)

--- a/cfme/tests/test_rest_manual.py
+++ b/cfme/tests/test_rest_manual.py
@@ -11,6 +11,7 @@ pytestmark = [pytest.mark.manual]
 @test_requirements.rest
 @pytest.mark.customer_scenario
 @pytest.mark.tier(1)
+@pytest.mark.manual("manualonly")
 @pytest.mark.meta(coverage=[1700378])
 def test_notification_url_parallel_requests():
     """

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -686,7 +686,7 @@ def test_compare_vm_from_datastore_relationships(appliance, setup_provider, prov
     assert compare_view.is_displayed
 
 
-@pytest.mark.manual
+@pytest.mark.manual("manualonly")
 @pytest.mark.tier(1)
 def test_ui_pinning_after_relog():
     """


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
   1. `test_created_on_time_report_field`
- __Updating tests__ 
    1. Mark tests `test_notification_url_parallel_requests` and `test_ui_pinning_after_relog` cases as "manualonly"
    2. Improvise `test_reports_generate_custom_conditional_filter_report`


### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_reports.py -k "test_created_on_time_report_field"
-vvv }}