### PR TITLE
[1LP][RFR] Automate remaining test_set_memory_threshold test cases & check in advanced settings

### DIFF
--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -339,33 +339,6 @@ def test_subscription_region_unavailable():
 
 
 @pytest.mark.manual
-@test_requirements.settings
-@pytest.mark.meta(coverage=[1715633])
-def test_memory_thresholds_in_advanced_config():
-    """
-    Test whether change made to thresholds in Advanced Config shows on the
-    workers page.
-
-    Polarion:
-        assignee: jhenner
-        casecomponent: Configuration
-        caseimportance: high
-        initialEstimate: 1/4h
-        testSteps:
-            1. Settings > Advanced
-            2. Change web_services worker to 1.5.gigabytes
-            3. Change the web_services worker to 2.gigabytes
-        expectedResults:
-            1.
-            2.  UI shows 1.5GB for the web_services in the Workers tab.
-            3.  UI shows 2GB for the web_services in the Workers tab.
-    Bugzilla:
-        1715633
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.meta(coverage=[1625788])
 def test_default_miq_group_is_tenant_group():
     """

--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -366,38 +366,6 @@ def test_memory_thresholds_in_advanced_config():
 
 
 @pytest.mark.manual
-@test_requirements.settings
-@pytest.mark.meta(coverage=[1658373])
-@pytest.mark.meta(blocker=[1787350])
-def test_memory_thresholds_workers_tab():
-    """
-    Test whether change made to thresholds in the Workers tab affect the values in
-    the advanced config
-
-    Polarion:
-        assignee: jhenner
-        casecomponent: Configuration
-        caseimportance: high
-        initialEstimate: 1/4h
-        testSteps:
-            1. Settings > [pick server in zone] > Workers
-            2. Change Generic workers to 1.1 GB
-            3. Change the Priority Workers to 1.1 GB
-        expectedResults:
-            1.
-            2.  The memory_threshold field for the generic_worker shows value
-                1181116006.4 which is 1.1 * (1024**3)
-                (BZ 1787350)
-            3.  The memory_threshold field for the priority_worker shows value
-                1181116006.4 which is 1.1 * (1024**3)
-                (BZ 1787350)
-    Bugzilla:
-        1658373
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.meta(coverage=[1625788])
 def test_default_miq_group_is_tenant_group():
     """

--- a/cfme/tests/configure/test_workers.py
+++ b/cfme/tests/configure/test_workers.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from copy import deepcopy
 
 import pytest
 
@@ -8,23 +9,22 @@ from cfme.utils.wait import wait_for
 
 pytestmark = [pytest.mark.rhel_testing]
 
-Dropdown = namedtuple('Dropdown', 'dropdown id')
+Worker = namedtuple('Worker', 'dropdown id advanced')
 
-DROPDOWNS = [
-    Dropdown('generic_worker_threshold', 'generic'),
-    Dropdown('cu_data_collector_worker_threshold', 'cu_data_coll'),
-    Dropdown('event_monitor_worker_threshold', 'event_monitor'),
-    Dropdown('connection_broker_worker_threshold', 'conn_broker'),
-    Dropdown('reporting_worker_threshold', 'reporting'),
-    Dropdown('web_service_worker_threshold', 'web_service'),
-    Dropdown('priority_worker_threshold', 'priority'),
-    Dropdown('cu_data_processor_worker_threshold', 'cu_data_proc'),
-    Dropdown('refresh_worker_threshold', 'refresh'),
-    Dropdown('vm_analysis_collectors_worker_threshold', 'vm_analysis')
+WORKERS = [
+    Worker('generic_worker_threshold', 'generic', 'generic_worker'),
+    Worker('cu_data_collector_worker_threshold', 'cu_data_coll', 'ems_metrics_collector_worker'),
+    Worker('event_monitor_worker_threshold', 'event_monitor', 'event_catcher'),
+    Worker('connection_broker_worker_threshold', 'conn_broker', 'vim_broker_worker'),
+    Worker('reporting_worker_threshold', 'reporting', 'reporting_worker'),
+    Worker('web_service_worker_threshold', 'web_service', 'web_service_worker'),
+    Worker('priority_worker_threshold', 'priority', 'priority_worker'),
+    Worker('cu_data_processor_worker_threshold', 'cu_data_proc', 'ems_metrics_processor_worker'),
+    Worker('refresh_worker_threshold', 'refresh', 'ems_refresh_worker'),
+    Worker('vm_analysis_collectors_worker_threshold', 'vm_analysis', 'smart_proxy_worker')
 ]
 
 
-@test_requirements.settings
 @pytest.mark.tier(3)
 @pytest.mark.sauce
 def test_restart_workers(appliance):
@@ -47,12 +47,67 @@ def test_restart_workers(appliance):
              message="Wait for all original workers are back online")
 
 
+@pytest.fixture(scope="module")
+def _workers_default_settings(appliance):
+    a = deepcopy(appliance.server.advanced_settings['workers'])
+    return a
+
+
+def set_memory_threshold_in_ui(appliance, worker, new_threshold, new_threshold_if_taken):
+    view = navigate_to(appliance.server, 'Workers')
+    view.browser.refresh()
+    mem_threshold = getattr(view.workers, worker.dropdown)
+    before = mem_threshold.selected_option
+    if before[:3] == new_threshold[:3]:
+        new_threshold = new_threshold_if_taken
+    mem_threshold.select_by_visible_text(new_threshold.replace('.gigabytes', ' GB'))
+    view.workers.save.click()
+    view.wait_displayed()
+    return before, new_threshold
+
+
+def set_memory_threshold_in_advanced_settings(appliance, worker, new_threshold,
+                                              new_threshold_if_taken):
+    worker_base = appliance.server.advanced_settings['workers']['worker_base']
+    workerro = worker_base.get(worker.advanced, None)
+    queue_worker = not workerro
+    if not workerro:
+        workerro = worker_base['queue_worker_base'][worker.advanced]
+        worker_base = worker_base['queue_worker_base']
+    before = workerro.get('memory_threshold', worker_base['defaults']['memory_threshold'])
+    if before[:3] == new_threshold[:3]:
+        new_threshold = new_threshold_if_taken
+    change_defaults = worker.advanced in ['ems_refresh_worker', 'ems_metrics_collector_worker']
+    if not change_defaults:
+        worker_base[worker.advanced]['memory_threshold'] = new_threshold
+    else:
+        worker_base[worker.advanced]['defaults']['memory_threshold'] = new_threshold
+    if queue_worker:
+        worker_base = {'queue_worker_base': worker_base}
+    patch = {
+        'workers': {
+            'worker_base': worker_base
+        }
+    }
+    # set worker threshold
+    appliance.server.update_advanced_settings(patch)
+    return before, new_threshold
+
+
+CHECK_UI = "ui"
+CHECK_ADVANCED_SETTINGS = "advanced"
+
+
 @test_requirements.settings
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1658373])
-@pytest.mark.meta(blocker=[1787350])
-@pytest.mark.parametrize("dropdown", [x.dropdown for x in DROPDOWNS], ids=[x.id for x in DROPDOWNS])
-def test_set_memory_threshold_in_ui(appliance, dropdown):
+@pytest.mark.parametrize("set_memory_threshold",
+                         [set_memory_threshold_in_ui, set_memory_threshold_in_advanced_settings],
+                         ids=["in_UI", "in_advanced_setting"])
+@pytest.mark.parametrize("threshold_change", ["1.1.gigabytes"])
+@pytest.mark.parametrize("worker", WORKERS, ids=[x.id for x in WORKERS])
+@pytest.mark.meta(blocker=[1787350], coverage=[1658373, 1715633])
+def test_set_memory_threshold(appliance, worker, set_memory_threshold, threshold_change,
+                              _workers_default_settings):
     """
     Bugzilla:
         1656873
@@ -73,33 +128,36 @@ def test_set_memory_threshold_in_ui(appliance, dropdown):
             3.
             4. the change should be reflected in the dropdown
     """
+    other = {
+        "1.1.gigabytes": "1.2.gigabytes",
+        "1.2.gigabytes": "1.1.gigabytes"
+    }
+    before, change = set_memory_threshold(appliance, worker, threshold_change,
+                                          other[threshold_change])
+    # check UI
     view = navigate_to(appliance.server, 'Workers')
-    mem_threshold = getattr(view.workers, dropdown)
-    before = mem_threshold.selected_option
-    change = "1.1 GB"
-    if before == change:
-        change = "1.2 GB"
-    mem_threshold.select_by_visible_text(change)
-    view.workers.save.click()
-    view.wait_displayed()
+    view.browser.refresh()
+    mem_threshold = getattr(view.workers, worker.dropdown)
     after = mem_threshold.selected_option
-
-    assert before != after
-    assert after == change
-    # check if the value was also changed in advanced setting
-    for worker_type in ["priority", "generic"]:
-        if dropdown.startswith(worker_type):
-            change_val = float(change[:-3])
-            mem_threshold_real = (appliance.server.advanced_settings['workers']['worker_base']
-            ['queue_worker_base'][f'{worker_type}_worker']['memory_threshold'])
-            GB = 2 ** 30
-            MESSAGE = "memory threshold changed incorrectly in advanced settings"
-            if appliance.version >= "5.11":
-                assert mem_threshold_real == f"{change_val}.gigabytes", MESSAGE
-            else:
-                expected_value = change_val * GB
-                # this tests if memory threshold has changed and is approximately correct
-                assert abs(mem_threshold_real - expected_value) < expected_value * 0.01, MESSAGE
-
-    # reset the mem threshold after the test
-    view.workers.reset.click()
+    assert after.startswith(change.replace(".gigabytes", " GB")), "failed UI check"
+    # check advanced settings
+    worker_type = worker.advanced
+    change_val = float(change.replace('.gigabytes', ''))
+    try:
+        mem_threshold_real = (appliance.server.advanced_settings['workers']['worker_base']
+        ['queue_worker_base'][f'{worker_type}']['memory_threshold'])
+    except KeyError:
+        mem_threshold_real = (appliance.server.advanced_settings['workers']['worker_base']
+        [f'{worker_type}']['memory_threshold'])
+    GB = 2 ** 30
+    MESSAGE = "memory threshold have changed incorrectly in advanced settings"
+    if appliance.version >= "5.11":
+        assert mem_threshold_real == f"{change_val}.gigabytes", MESSAGE
+    else:
+        expected_value = change_val * GB
+        # this tests if memory threshold has changed and is approximately correct
+        assert abs(mem_threshold_real - expected_value) < expected_value * 0.01, MESSAGE
+    # reset settings back to default
+    appliance.server.update_advanced_settings(
+        {'workers': _workers_default_settings}
+    )


### PR DESCRIPTION
Added as a check if memory threshold changed in advanced setting after change in UI inside `test_set_memory_threshold_in_ui` test case.
EDIT: Added the advanced settings check to all test cases.
Also automated `test_set_memory_threshold_in_advanced_settings` and merged it with this test case
During that, paradoxically a UI bug - blocker was found: https://bugzilla.redhat.com/show_bug.cgi?id=1799443 , so also `test_set_memory_threshold_in_ui` test cases were fixed to recognize the bug.

~All the tests happen on the same page, adding `_view` module scope fixture almost halved the execution time.~

{{ pytest: cfme/tests/configure/test_workers.py::test_set_memory_threshold -v }}
