### PR TITLE
[1LP][RFR] Automating service dialog default selection test

### DIFF
--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -554,23 +554,6 @@ def test_search_field_at_the_top_of_a_dynamic_drop_down_dialog_element_should_di
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_default_selection_of_dropdown_list_is_should_display_properly():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/6h
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1579405
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_service_dialog_saving_elements_when_switching_elements():
     """


### PR DESCRIPTION


## Purpose or Intent

### PRT Run
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_dialog_default_value_selection --long-running }}
