### PR TITLE
[1LP][RFR] Automate: test_reports_timezone

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -584,16 +584,18 @@ class SavedReport(Updateable, BaseEntity):
 
     @cached_property
     def queued_datetime_in_title(self):
+        # "display" key will not be available without clearing the cache
+        delattr(self.appliance, "rest_api")
         area = self.appliance.rest_api.settings["display"]["timezone"]
-        return parsetime.from_american_with_dynamic_timezone(
+        return parsetime.from_american(
             self.queued_datetime, self.report_timezone
         ).to_saved_report_title_format(area)
 
     @cached_property
     def datetime_in_tree(self):
-        return parsetime.from_american_with_dynamic_timezone(
+        return parsetime.from_american(
             self.run_datetime, self.report_timezone
-        ).to_iso_with_dynamic_timezone(self.report_timezone)
+        ).to_iso(self.report_timezone)
 
     @cached_property
     def data(self):

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -578,13 +578,22 @@ class SavedReport(Updateable, BaseEntity):
     def report(self):
         return self.parent_obj
 
+    @property
+    def report_timezone(self):
+        return self.queued_datetime.split()[-1]
+
     @cached_property
     def queued_datetime_in_title(self):
-        return parsetime.from_american_with_utc(self.queued_datetime).to_saved_report_title_format()
+        area = self.appliance.rest_api.settings["display"]["timezone"]
+        return parsetime.from_american_with_dynamic_timezone(
+            self.queued_datetime, self.report_timezone
+        ).to_saved_report_title_format(area)
 
     @cached_property
     def datetime_in_tree(self):
-        return parsetime.from_american_with_utc(self.run_datetime).to_iso_with_utc()
+        return parsetime.from_american_with_dynamic_timezone(
+            self.run_datetime, self.report_timezone
+        ).to_iso_with_dynamic_timezone(self.report_timezone)
 
     @cached_property
     def data(self):

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -10,32 +10,6 @@ pytestmark = [pytest.mark.manual]
 
 
 @test_requirements.report
-@pytest.mark.tier(2)
-@pytest.mark.ignore_stream("5.10")
-def test_reports_timezone():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        caseimportance: medium
-        initialEstimate: 1/10h
-        startsin: 5.11
-        setup:
-            1. Navigate to My Settings and change the timezone.
-            2. Create a report with the date created field
-            3. Run report
-        testSteps:
-            1. Check the timezone in the report.
-        expectedResults:
-            1. Timezone must be same as set in My Settings.
-
-    Bugzilla:
-        1599849
-    """
-    pass
-
-
-@test_requirements.report
 @test_requirements.multi_region
 @pytest.mark.tier(2)
 @pytest.mark.parametrize('context', [ViaREST, ViaUI])


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. `test_reports_timezone`
- __Enhancement__ 
    1. Enhance `cfme.utils.timeutil.parsetime` to be compatible with different timezones. This may not work in case the timezone is not found in `pytz` module.
    2. Add a new property `report_timezone` to `SavedReport` entity and modify `queued_datetime_in_title` and `datetime_in_tree` accordingly.

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_reports.py -k "test_reports_timezone" -vvv }}