### PR TITLE
[1LP][RFR] Adding credential as attribute to provider object

### DIFF
--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -39,6 +39,7 @@ class OpenStackProvider(CloudProvider):
     keystone_v3_domain_id = attr.ib(default=None)
     tenant_mapping = attr.ib(default=None)
     infra_provider = attr.ib(default=None)
+    credentials = attr.ib(default=None)
 
     # todo: move it to collections later
     def create(self, *args, **kwargs):
@@ -114,6 +115,7 @@ class OpenStackProvider(CloudProvider):
             keystone_v3_domain_id=prov_config.get('domain_id'),
             sec_protocol=prov_config.get('sec_protocol', "Non-SSL"),
             tenant_mapping=prov_config.get('tenant_mapping', False),
+            credentials=prov_config.get('credentials'),
             infra_provider=infra_provider)
 
     # Following methods will only work if the remote console window is open

--- a/cfme/infrastructure/provider/rhevm.py
+++ b/cfme/infrastructure/provider/rhevm.py
@@ -64,6 +64,7 @@ class RHEVMProvider(InfraProvider):
     catalog_item_type = RHVCatalogItem
     vm_utilization_view = RHEVMVMUtilizationView
     type_name = "rhevm"
+    credentials = attr.ib(default=None)
     mgmt_class = RHEVMSystem
     db_types = ["Redhat::InfraManager"]
     endpoints_form = RHEVMEndpointForm
@@ -115,6 +116,7 @@ class RHEVMProvider(InfraProvider):
         return appliance.collections.infra_providers.instantiate(
             prov_class=cls,
             name=prov_config['name'],
+            credentials=prov_config.get('credentials'),
             endpoints=endpoints,
             zone=prov_config.get('server_zone', 'default'),
             key=prov_key,

--- a/cfme/infrastructure/provider/virtualcenter.py
+++ b/cfme/infrastructure/provider/virtualcenter.py
@@ -34,6 +34,7 @@ class VMwareProvider(InfraProvider):
     catalog_item_type = VMwareCatalogItem
     vm_utilization_view = VirtualCenterVMUtilizationView
     type_name = "virtualcenter"
+    credentials = attr.ib(default=None)
     mgmt_class = VMWareSystem
     db_types = ["Vmware::InfraManager"]
     endpoints_form = VirtualCenterEndpointForm
@@ -88,6 +89,7 @@ class VMwareProvider(InfraProvider):
         return appliance.collections.infra_providers.instantiate(
             prov_class=cls,
             name=prov_config['name'],
+            credentials=prov_config.get('credentials'),
             endpoints=endpoints,
             zone=prov_config['server_zone'],
             key=prov_key,


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

Adding credential attribute to the OSP, Vsphere, RHV provider object, it is required for IMS testing where we need to get provider based credential at run time.