### PR TITLE
[1LP][RFR] Add test_replication_connect_to_vm_in_region

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -133,6 +133,16 @@ def temp_appliance_preconfig_long(request, appliance, pytestconfig):
         _collect_logs(request.config, appliances)
 
 
+@pytest.fixture(scope="function")
+def temp_appliance_preconfig_funcscope_rhevm(appliance, pytestconfig):
+    with sprout_appliances(
+            appliance,
+            config=pytestconfig, preconfigured=True,
+            provider_type='rhevm'
+    ) as appliances:
+        yield appliances[0]
+
+
 # Single appliance, unconfigured
 @pytest.fixture(scope="module")
 def temp_appliance_unconfig(temp_appliance_unconfig_modscope):

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -517,18 +517,18 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             # Some conditionally ran items require the evm service be
             # restarted:
             restart_evm = False
+            self.wait_for_web_ui(log_callback=log_callback)
             if self.version < '5.11':
                 self.configure_vm_console_cert(log_callback=log_callback)
                 restart_evm = True
 
             if fix_ntp_clock and not self.is_pod:
-                self.wait_for_web_ui(log_callback=log_callback)
                 self.set_ntp_sources(log_callback=log_callback)
                 restart_evm = True
 
             if restart_evm:
                 self.evmserverd.restart(log_callback=log_callback)
-            self.wait_for_web_ui(timeout=1800, log_callback=log_callback)
+                self.wait_for_web_ui(timeout=1800, log_callback=log_callback)
 
     def configure_gce(self, log_callback=None):
         # Force use of IPAppliance's configure method
@@ -757,7 +757,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
         try:
             return self.rest_api.product_info['name']
         except (AttributeError, KeyError, IOError, ConnectionError):
-            self.log.exception(
+            self.log.info(
                 'appliance.product_name could not be retrieved from REST, falling back')
             try:
                 # TODO: Review this section. Does not work unconfigured


### PR DESCRIPTION
1.) Add test_replication_connect_to_vm_in_region test, to automate BZ:

Bug 1678142 - [RFE] As a User, I want to open my VMs of a remote region from Global Region in a new browser tab to be able to performs all actions
https://bugzilla.redhat.com/show_bug.cgi?id=1678142

2.) Add a rhevm-specific preconfigured appliance fixture: temp_appliance_preconfig_funcscope_rhevm.

3.) Use the new temp_appliance_preconfig_funcscope_rhevm fixture for the remote (region 0) appliance in db replication tests, and for the primary database-owning appliance in distributed appliance tests. This cuts down the time to run each test by ~5-10 minutes, since now only the global or secondary appliance needs to be configured after checking it out from sprout.

{{ pytest: --long-running cfme/tests/distributed/test_appliance_replication.py -v }}
