### PR TITLE
[1LP][RFR] Add compare_hosts function to handle navigation and checking compare items 

### DIFF
--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -390,8 +390,7 @@ class ComparableMixin:
     Constants:
             DROPDOWN_TEXT: (str) the text in the Configuration dropdown for comparing entities
             NAV_STRING: (str) used as second arg in call to navigate_to()
-            COMPARE_VIEW_PROVIDER: (VIEW) view class to create and return when filtering on provider
-            COMPARE_VIEW_ALL: (VIEW) view class to create and return when no provider filtering
+            COMPARE_VIEW: (VIEW) view class to create and return
     Usage:
         If added to collection's class,
 
@@ -404,8 +403,7 @@ class ComparableMixin:
     """
     DROPDOWN_TEXT = 'Compare Selected items'
     NAV_STRING = 'All'
-    COMPARE_VIEW_PROVIDER = CompareView
-    COMPARE_VIEW_ALL = CompareView
+    COMPARE_VIEW = CompareView
 
     def compare_entities(self, provider, entities_list=None):
         """
@@ -421,10 +419,7 @@ class ComparableMixin:
             v_entity.ensure_checked()
         entity_view.toolbar.configuration.item_select(
             self.DROPDOWN_TEXT, handle_alert=True)
-        if self.parent is provider:
-            compare_entity_view = provider.create_view(self.COMPARE_VIEW_PROVIDER)
-        else:
-            compare_entity_view = provider.create_view(self.COMPARE_VIEW_ALL)
+        compare_entity_view = provider.create_view(self.COMPARE_VIEW)
         return compare_entity_view
 
 

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -413,7 +413,10 @@ class ComparableMixin:
         Returns:
             (View) View object displayed for compare
         """
-        entity_view = navigate_to(self, self.NAV_STRING)
+        try:
+            entity_view = navigate_to(self, self.NAV_STRING)
+        except NavigationDestinationNotFound:
+            entity_view = navigate_to(self.parent, self.NAV_STRING)
         for item in entities_list:
             v_entity = entity_view.entities.get_entity(name=item.name)
             v_entity.ensure_checked()

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -405,7 +405,7 @@ class ComparableMixin:
     NAV_STRING = 'All'
     COMPARE_VIEW = CompareView
 
-    def compare_entities(self, provider, entities_list=None):
+    def compare_entities(self, entities_list=None):
         """
         Args:
             provider: (InfraProvider) Provider for the entities
@@ -422,7 +422,7 @@ class ComparableMixin:
             v_entity.ensure_checked()
         entity_view.toolbar.configuration.item_select(
             self.DROPDOWN_TEXT, handle_alert=True)
-        compare_entity_view = provider.create_view(self.COMPARE_VIEW)
+        compare_entity_view = self.create_view(self.COMPARE_VIEW)
         return compare_entity_view
 
 

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -13,6 +13,7 @@ from widgetastic_patternfly import BootstrapSelect
 from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import CheckableBootstrapTreeview
+from widgetastic_patternfly import Dropdown
 from widgetastic_patternfly import DropdownItemNotFound
 from widgetastic_patternfly import FlashMessages
 from widgetastic_patternfly import NavDropdown
@@ -35,6 +36,7 @@ from cfme.utils.version import VersionPicker
 from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for
 from widgetastic_manageiq import BaseNonInteractiveEntitiesView
+from widgetastic_manageiq import ItemsToolBarViewSelector
 from widgetastic_manageiq import ReactSelect
 from widgetastic_manageiq import ServerTimelinesView
 from widgetastic_manageiq import SettingsNavDropdown
@@ -363,6 +365,67 @@ class ManagePolicies(CFMENavigateStep):
         self.prerequisite_view.entities.get_entity(name=self.obj.name,
                                                    surf_pages=True).ensure_checked()
         self.prerequisite_view.toolbar.policy.item_select('Manage Policies')
+
+
+class CompareView(BaseLoggedInPage):
+    """generic class for compare views"""
+    title = Text('.//div[@id="center_div" or @id="main-content"]//h1')
+    comparison_table = Table(locator='//div[@id="compare-grid"]/table')
+
+    @View.nested
+    class toolbar(View):
+        all_attributes = Button(title="All attributes")
+        different_values_attributes = Button(title="Attributes with different values")
+        same_values_attributes = Button(title="Attributes with same values")
+        details_mode = Button(title="Details Mode")
+        exists_mode = Button(title="Exists Mode")
+        # add expanded view, compressed view buttons.
+        download = Dropdown('Download')
+        view_selector = View.nested(ItemsToolBarViewSelector)
+
+
+class ComparableMixin:
+    """
+    Mixin for comparing entities. Should be added to Collection class.
+    Constants:
+            DROPDOWN_TEXT: (str) the text in the Configuration dropdown for comparing entities
+            NAV_STRING: (str) used as second arg in call to navigate_to()
+            COMPARE_VIEW_PROVIDER: (VIEW) view class to create and return when filtering on provider
+            COMPARE_VIEW_ALL: (VIEW) view class to create and return when no provider filtering
+    Usage:
+        If added to collection's class,
+
+        entity_coll = collection.all()[:2]
+        compare_view = collection.compare_entities(provider, entities_list=entity_coll)
+
+        will navigate to the correct view, select the items in entity_col (first two items returned
+        from all()), click on the compare dropdown item and verify the compare view is
+        displayed. It then returns the compare view.
+    """
+    DROPDOWN_TEXT = 'Compare Selected items'
+    NAV_STRING = 'All'
+    COMPARE_VIEW_PROVIDER = CompareView
+    COMPARE_VIEW_ALL = CompareView
+
+    def compare_entities(self, provider, entities_list=None):
+        """
+        Args:
+            provider: (InfraProvider) Provider for the entities
+            entities_list: (list) Entities to compare
+        Returns:
+            (View) View object displayed for compare
+        """
+        entity_view = navigate_to(self, self.NAV_STRING)
+        for item in entities_list:
+            v_entity = entity_view.entities.get_entity(name=item.name)
+            v_entity.ensure_checked()
+        entity_view.toolbar.configuration.item_select(
+            self.DROPDOWN_TEXT, handle_alert=True)
+        if self.parent is provider:
+            compare_entity_view = provider.create_view(self.COMPARE_VIEW_PROVIDER)
+        else:
+            compare_entity_view = provider.create_view(self.COMPARE_VIEW_ALL)
+        return compare_entity_view
 
 
 class AssignedTags(ParametrizedView):

--- a/cfme/common/__init__.py
+++ b/cfme/common/__init__.py
@@ -408,7 +408,6 @@ class ComparableMixin:
     def compare_entities(self, entities_list=None):
         """
         Args:
-            provider: (InfraProvider) Provider for the entities
             entities_list: (list) Entities to compare
         Returns:
             (View) View object displayed for compare

--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -10,6 +10,7 @@ from widgetastic_patternfly import CheckableBootstrapTreeview
 from widgetastic_patternfly import Dropdown
 
 from cfme.common import BaseLoggedInPage
+from cfme.common import CompareView
 from cfme.common import TimelinesView
 from cfme.exceptions import displayed_not_implemented
 from cfme.utils.log import logger
@@ -319,7 +320,7 @@ class HostsEditView(HostEditView):
         return self.in_compute_infrastructure_hosts and self.title.text == 'Credentials/Settings'
 
 
-class HostsCompareView(ComputeInfrastructureHostsView):
+class HostsCompareView(CompareView, ComputeInfrastructureHostsView):
     """Compare Host / Node page."""
 
     @property
@@ -331,9 +332,8 @@ class HostsCompareView(ComputeInfrastructureHostsView):
                 )
 
 
-class ProviderHostsCompareView(ComputeInfrastructureHostsView):
+class ProviderHostsCompareView(HostsCompareView):
     """Compare Host / Node page, but for a specific provider."""
-
     @property
     def is_displayed(self):
         title = "Compare Host / Node"

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -261,9 +261,12 @@ class ProviderTemplatesView(ProviderVmsTemplatesView):
     @property
     def is_displayed(self):
         title = VersionPicker({
-            Version.lowest(): '{name} (All VM Templates)'.format(name=self.context['object'].name),
-            '5.10': '{name} (All VM Templates and Images)'.format(name=self.context[
-                'object'].name or self.context['object'].parent.name),
+            Version.lowest(): '{name} (All VM Templates)'.format(
+                name=getattr(self.context['object'], 'name', None) or getattr(
+                    self.context['object'].parent, 'name', None)),
+            '5.10': '{name} (All VM Templates and Images)'.format(
+                name=getattr(self.context['object'], 'name', None) or getattr(
+                    self.context['object'].parent, 'name', None)),
         }).pick(self.extra.appliance.version)
         return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -260,14 +260,13 @@ class ProviderTemplatesView(ProviderVmsTemplatesView):
 
     @property
     def is_displayed(self):
-        title = VersionPicker({
-            Version.lowest(): '{name} (All VM Templates)'.format(
-                name=getattr(self.context['object'], 'name', None) or getattr(
-                    self.context['object'].parent, 'name', None)),
-            '5.10': '{name} (All VM Templates and Images)'.format(
-                name=getattr(self.context['object'], 'name', None) or getattr(
-                    self.context['object'].parent, 'name', None)),
-        }).pick(self.extra.appliance.version)
+        expected_name = getattr(
+            self.context['object'], 'name', None) or getattr(
+            self.context['object'].parent, 'name', None)
+        title = VersionPicker(
+            {Version.lowest(): f'{expected_name} (All VM Templates)',
+            '5.10': f'{expected_name} (All VM Templates and Images)'
+             }).pick(self.extra.appliance.version)
         return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and
                 self.title.text == title)

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -262,7 +262,8 @@ class ProviderTemplatesView(ProviderVmsTemplatesView):
     def is_displayed(self):
         title = VersionPicker({
             Version.lowest(): '{name} (All VM Templates)'.format(name=self.context['object'].name),
-            '5.10': '{name} (All VM Templates and Images)'.format(name=self.context['object'].name),
+            '5.10': '{name} (All VM Templates and Images)'.format(name=self.context[
+                'object'].name or self.context['object'].parent.name),
         }).pick(self.extra.appliance.version)
         return (self.logged_in_as_current_user and
                 self.navigation.currently_selected == ['Compute', 'Infrastructure', 'Providers'] and

--- a/cfme/common/provider_views.py
+++ b/cfme/common/provider_views.py
@@ -3,7 +3,6 @@ from lxml.html import document_fromstring
 from widgetastic.exceptions import NoSuchElementException
 from widgetastic.utils import Version
 from widgetastic.widget import ConditionalSwitchableView
-from widgetastic.widget import Table
 from widgetastic.widget import Text
 from widgetastic.widget import View
 from widgetastic_patternfly import BootstrapNav
@@ -12,6 +11,7 @@ from widgetastic_patternfly import BreadCrumb
 from widgetastic_patternfly import Dropdown
 
 from cfme.common import BaseLoggedInPage
+from cfme.common import CompareView
 from cfme.common import TimelinesView
 from cfme.common.host_views import HostEntitiesView
 from cfme.utils.version import VersionPicker
@@ -580,10 +580,8 @@ class ContainerProviderEditView(ProviderEditView):
                 getattr(self, widget).fill(values.get(widget))
 
 
-class TemplatesCompareView(InfraProvidersView):
+class TemplatesCompareView(CompareView):
     """Compare Templates page."""
-    title = Text('.//div[@id="center_div" or @id="main-content"]//h1')
-    comparison_table = Table(locator='//div[@id="compare-grid"]/table')
 
     @property
     def is_displayed(self):

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -8,6 +8,7 @@ from navmazing import NavigateToSibling
 from selenium.common.exceptions import NoSuchElementException
 
 from cfme.base.credential import Credential as BaseCredential
+from cfme.common import ComparableMixin
 from cfme.common import CustomButtonEventsMixin
 from cfme.common import PolicyProfileAssignable
 from cfme.common import Taggable
@@ -19,9 +20,11 @@ from cfme.common.host_views import HostDriftAnalysis
 from cfme.common.host_views import HostDriftHistory
 from cfme.common.host_views import HostEditView
 from cfme.common.host_views import HostNetworkDetailsView
+from cfme.common.host_views import HostsCompareView
 from cfme.common.host_views import HostsView
 from cfme.common.host_views import HostTimelinesView
 from cfme.common.host_views import ProviderAllHostsView
+from cfme.common.host_views import ProviderHostsCompareView
 from cfme.exceptions import ItemNotFound
 from cfme.exceptions import RestLookupError
 from cfme.infrastructure.datastore import HostAllDatastoresView
@@ -41,9 +44,8 @@ from cfme.utils.wait import wait_for
 
 
 @attr.s
-class Host(
-    BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable, CustomButtonEventsMixin
-):
+class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
+           CustomButtonEventsMixin):
     """Model of an infrastructure host in cfme.
 
     Args:
@@ -476,10 +478,13 @@ class Host(
 
 
 @attr.s
-class HostsCollection(BaseCollection):
+class HostsCollection(ComparableMixin, BaseCollection):
     """Collection object for the :py:class:`cfme.infrastructure.host.Host`."""
 
     ENTITY = Host
+
+    COMPARE_VIEW_PROVIDER = ProviderHostsCompareView
+    COMPARE_VIEW_ALL = HostsCompareView
 
     def check_hosts(self, hosts):
         hosts = list(hosts)

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -483,8 +483,10 @@ class HostsCollection(ComparableMixin, BaseCollection):
 
     ENTITY = Host
 
-    COMPARE_VIEW_PROVIDER = ProviderHostsCompareView
-    COMPARE_VIEW_ALL = HostsCompareView
+    @property
+    def COMPARE_VIEW(self):
+        provider = self.filters.get('provider')  # None if no filter
+        return ProviderHostsCompareView if provider else HostsCompareView
 
     def check_hosts(self, hosts):
         hosts = list(hosts)

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -485,8 +485,7 @@ class HostsCollection(ComparableMixin, BaseCollection):
 
     @property
     def COMPARE_VIEW(self):
-        provider = self.filters.get('provider')  # None if no filter
-        return HostsCompareView if provider else ProviderHostsCompareView
+        return ProviderHostsCompareView if self.filters.get('parent') else HostsCompareView
 
     def check_hosts(self, hosts):
         hosts = list(hosts)

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -486,7 +486,7 @@ class HostsCollection(ComparableMixin, BaseCollection):
     @property
     def COMPARE_VIEW(self):
         provider = self.filters.get('provider')  # None if no filter
-        return ProviderHostsCompareView if provider else HostsCompareView
+        return HostsCompareView if provider else ProviderHostsCompareView
 
     def check_hosts(self, hosts):
         hosts = list(hosts)

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -29,6 +29,7 @@ from cfme.infrastructure.cluster import ClusterToolbar
 from cfme.infrastructure.cluster import ClusterView
 from cfme.infrastructure.host import HostsCollection
 from cfme.infrastructure.virtual_machines import InfraTemplate
+from cfme.infrastructure.virtual_machines import InfraTemplateCollection
 from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.modeling.base import BaseCollection
 from cfme.optimize.utilization import ProviderUtilizationTrendsView
@@ -104,7 +105,7 @@ class InfraProvider(BaseProvider, CloudInfraProviderMixin, Pretty, Fillable,
     end_ip = attr.ib(default=None)
     provider_data = attr.ib(default=None)
 
-    _collections = {'hosts': HostsCollection}
+    _collections = {'hosts': HostsCollection, 'templates': InfraTemplateCollection}
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -105,7 +105,7 @@ class InfraProvider(BaseProvider, CloudInfraProviderMixin, Pretty, Fillable,
     end_ip = attr.ib(default=None)
     provider_data = attr.ib(default=None)
 
-    _collections = {'hosts': HostsCollection, 'templates': InfraTemplateCollection}
+    _collections = {'hosts': HostsCollection, 'infra_templates': InfraTemplateCollection}
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1362,11 +1362,6 @@ class InfraTemplateCollection(ComparableMixin, TemplateCollection):
     DROPDOWN_TEXT = 'Compare Selected Templates'
     NAV_STRING = 'TemplatesOnly'
 
-    @property
-    def name(self):
-        provider = self.filters.get('provider')
-        return provider.name if provider else None
-
     def all(self):
         """Return entities for all items in collection"""
         # provider filter means we're viewing templates through provider details relationships

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1319,6 +1319,7 @@ class InfraVmCollection(VMCollection):
         """Return entities for all items in collection"""
         # provider filter means we're viewing vms through provider details relationships
         # provider filtered 'All' view includes vms and templates, can't be used
+        # TODO: prichard add support for slicing as in host collections
         provider = self.filters.get('provider')  # None if no filter, need for entity instantiation
         view = navigate_to(provider or self,
                            'ProviderVms' if provider else 'VMsOnly')
@@ -1366,6 +1367,7 @@ class InfraTemplateCollection(ComparableMixin, TemplateCollection):
         """Return entities for all items in collection"""
         # provider filter means we're viewing templates through provider details relationships
         # provider filtered 'All' view includes vms and templates, can't be used
+        # TODO: prichard add support for slicing as in host collections
         provider = self.filters.get('provider')  # None if no filter, need for entity instantiation
         view = navigate_to(provider or self,
                            'ProviderTemplates' if provider else 'TemplatesOnly')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1696,17 +1696,14 @@ class TemplatesAll(CFMENavigateStep):
     prerequisite = NavigateToSibling('All')
 
     def step(self, *args, **kwargs):
-        if self.obj.parent is self.obj.appliance:
-            if 'filter_folder' not in kwargs:
-                self.view.sidebar.templates.tree.click_path('All Templates')
-            elif 'filter_folder' in kwargs and 'filter_name' in kwargs:
-                self.view.sidebar.templates.tree.click_path('All Templates',
-                                                            kwargs['filter_folder'],
-                                                            kwargs['filter_name'])
-            else:
-                raise DestinationNotFound("the destination isn't found")
+        if 'filter_folder' not in kwargs:
+            self.view.sidebar.templates.tree.click_path('All Templates')
+        elif 'filter_folder' in kwargs and 'filter_name' in kwargs:
+            self.view.sidebar.templates.tree.click_path('All Templates',
+                                                        kwargs['filter_folder'],
+                                                        kwargs['filter_name'])
         else:
-            self.prerequisite_view.entities.summary("Relationships").click_at("Templates")
+            raise DestinationNotFound("the destination isn't found")
 
 
 @navigator.register(InfraVmCollection, 'Provision')

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -51,7 +51,6 @@ from cfme.exceptions import displayed_not_implemented
 from cfme.exceptions import ItemNotFound
 from cfme.infrastructure.provider import ProviderTemplatesView
 from cfme.services.requests import RequestsView
-from cfme.utils.appliance import IPAppliance
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
@@ -1690,22 +1689,24 @@ class SetRetirement(CFMENavigateStep):
 class TemplatesAll(CFMENavigateStep):
 
     def prerequisite(self):
-        from cfme.infrastructure.provider import InfraProvider
-        if isinstance(self.obj.parent, InfraProvider):
-            return navigate_to(self.obj.parent, 'Details')
-        elif isinstance(self.obj.parent, IPAppliance):
-            return navigate_to(self.obj, 'All')
+        if self.obj.parent is self.obj.appliance:
+            nav_inst = self.obj
+            nav_dest = 'All'
+        else:
+            nav_inst = self.obj.parent
+            nav_dest = 'Details'
+        return navigate_to(nav_inst, nav_dest)
 
     @property
     def VIEW(self):  # noqa
-        from cfme.infrastructure.provider import InfraProvider
-        if isinstance(self.obj.parent, InfraProvider):
-            return ProviderTemplatesView
-        elif isinstance(self.obj.parent, IPAppliance):
-            return TemplatesOnlyAllView
+        if self.obj.parent is self.obj.appliance:
+            view_class = TemplatesOnlyAllView
+        else:
+            view_class = ProviderTemplatesView
+        return view_class
 
     def step(self, *args, **kwargs):
-        if isinstance(self.obj.parent, IPAppliance):
+        if self.obj.parent is self.obj.appliance:
             if 'filter_folder' not in kwargs:
                 self.view.sidebar.templates.tree.click_path('All Templates')
             elif 'filter_folder' in kwargs and 'filter_name' in kwargs:

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1359,20 +1359,21 @@ class InfraTemplateCollection(ComparableMixin, TemplateCollection):
 
     @property
     def COMPARE_VIEW(self):
-        provider = self.filters.get('provider')  # None if no filter
-        return TemplatesCompareView if provider else VmTemplatesCompareView
+        parent = self.filters.get('parent')  # None if no filter
+        return TemplatesCompareView if parent else VmTemplatesCompareView
 
     @property
     def NAV_STRING(self):
-        provider = self.filters.get('provider')  # None if no filter
-        return 'ProviderTemplates' if provider else 'TemplatesOnly'
+        parent = self.filters.get('parent')  # None if no filter
+        return 'ProviderTemplates' if parent else 'TemplatesOnly'
 
     def all(self):
         """Return entities for all items in collection"""
         # provider filter means we're viewing templates through provider details relationships
         # provider filtered 'All' view includes vms and templates, can't be used
         # TODO: prichard add support for slicing as in host collections
-        provider = self.filters.get('provider')  # None if no filter, need for entity instantiation
+        provider = self.filters.get('parent')
+        # instantiation
         view = navigate_to(provider or self,
                            'ProviderTemplates' if provider else 'TemplatesOnly')
         # iterate pages here instead of use surf_pages=True because data is needed

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1691,7 +1691,13 @@ class SetRetirement(CFMENavigateStep):
 
 @navigator.register(InfraTemplateCollection, 'TemplatesOnly')
 class TemplatesAll(CFMENavigateStep):
-    prerequisite = NavigateToSibling('All')
+
+    def prerequisite(self):
+        from cfme.infrastructure.provider import InfraProvider
+        if isinstance(self.obj.parent, InfraProvider):
+            return navigate_to(self.obj.parent, 'Details')
+        elif isinstance(self.obj.parent, IPAppliance):
+            return navigate_to(self.obj, 'All')
 
     @property
     def VIEW(self):  # noqa
@@ -1711,6 +1717,8 @@ class TemplatesAll(CFMENavigateStep):
                                                             kwargs['filter_name'])
             else:
                 raise DestinationNotFound("the destination isn't found")
+        else:
+            self.prerequisite_view.entities.summary("Relationships").click_at("Templates")
 
 
 @navigator.register(InfraVmCollection, 'Provision')

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -466,7 +466,7 @@ def test_infrastructure_hosts_compare(appliance, setup_provider_min_hosts, provi
     """
 
     h_coll = locals()[hosts_collection].collections.hosts
-    compare_view = h_coll.compare_entities(provider, entities_list=h_coll.all()[:num_hosts])
+    compare_view = h_coll.compare_entities(entities_list=h_coll.all()[:num_hosts])
     assert compare_view.is_displayed
 
 

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -222,7 +222,6 @@ def test_tag_host_after_provider_delete(provider, appliance, setup_provider, req
         initialEstimate: 1/8h
         casecomponent: Tagging
     """
-    # TODO: prichard pass in slice kwarg instead of slicing output.
     host_on_provider = provider.hosts.all()[0]
     provider.delete()
     provider.wait_for_delete()
@@ -288,7 +287,6 @@ def test_infrastructure_hosts_icons_states(
                 `UPDATE hosts SET power_state = ':power_state' WHERE name=':host_name';`
     """
     # get host and host details
-    # TODO: prichard pass in slice kwarg instead of slicing output.
     host = provider.hosts.all()[0]
     host_name = host.name
     reset_state = host.rest_api_entity.power_state

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -87,6 +87,7 @@ def navigate_and_select_quads(provider):
 
     Returns:
         view: the provider nodes view, quadicons already selected"""
+    # TODO: prichard navigate instead of creating views and consider creaing EditableMixin
     hosts_view = navigate_to(provider, 'ProviderNodes')
     assert hosts_view.is_displayed
     [h.ensure_checked() for h in hosts_view.entities.get_all()]
@@ -221,6 +222,7 @@ def test_tag_host_after_provider_delete(provider, appliance, setup_provider, req
         initialEstimate: 1/8h
         casecomponent: Tagging
     """
+    # TODO: prichard pass in slice kwarg instead of slicing output.
     host_on_provider = provider.hosts.all()[0]
     provider.delete()
     provider.wait_for_delete()
@@ -286,6 +288,7 @@ def test_infrastructure_hosts_icons_states(
                 `UPDATE hosts SET power_state = ':power_state' WHERE name=':host_name';`
     """
     # get host and host details
+    # TODO: prichard pass in slice kwarg instead of slicing output.
     host = provider.hosts.all()[0]
     host_name = host.name
     reset_state = host.rest_api_entity.power_state
@@ -430,6 +433,8 @@ def test_infrastructure_hosts_navigation_after_download(
     Bugzilla:
         1738664
     """
+    # TODO: prichard use locals()
+    # TODO: prichard consider putting download functionality into it's own function
     if hosts_collection == "provider":
         hosts_view = navigate_to(provider.collections.hosts, "All")
     elif hosts_collection == "appliance":

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -516,7 +516,6 @@ def test_compare_templates(appliance, setup_provider_min_templates, provider, mi
     """
     t_coll = locals()[templates_collection].collections.infra_templates.all()[:min_templates]
     compare_view = locals()[templates_collection].collections.infra_templates.compare_entities(
-        provider,
         entities_list=t_coll)
     assert compare_view.is_displayed
 

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -16,7 +16,6 @@ from cfme.infrastructure.provider.rhevm import RHEVMEndpoint
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VirtualCenterEndpoint
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
-from cfme.infrastructure.virtual_machines import InfraTemplateCollection
 from cfme.markers.env_markers.provider import ONE
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -515,18 +514,12 @@ def test_compare_templates(appliance, setup_provider_min_templates, provider, mi
     Bugzilla:
         1746449
     """
-    if templates_collection == 'provider':
-        provider.collections.templates = InfraTemplateCollection(provider,
-                                                                 filters={'provider': provider})
-        t_coll = provider.collections.templates.all()[:min_templates]
-        compare_view = provider.collections.templates.compare_entities(provider,
-                                                                       entities_list=t_coll)
-    elif templates_collection == 'appliance':
-        appliance.collections.templates = InfraTemplateCollection(appliance)
-        t_coll = appliance.collections.templates.all()[:min_templates]
-        compare_view = appliance.collections.templates.compare_entities(provider,
-                                                                        entities_list=t_coll)
+    t_coll = appliance.collections.infra_templates.all()[:min_templates]
+    compare_view = locals()[templates_collection].collections.infra_templates.compare_entities(
+        provider,
+        entities_list=t_coll)
     assert compare_view.is_displayed
+
     t_list = []
     for t in t_coll:
         t_list.append(t.name)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -520,7 +520,5 @@ def test_compare_templates(appliance, setup_provider_min_templates, provider, mi
         entities_list=t_coll)
     assert compare_view.is_displayed
 
-    t_list = []
-    for t in t_coll:
-        t_list.append(t.name)
+    t_list = [t.name for t in t_coll]
     assert compare_view.verify_checked_items_compared(t_list, compare_view)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -514,7 +514,7 @@ def test_compare_templates(appliance, setup_provider_min_templates, provider, mi
     Bugzilla:
         1746449
     """
-    t_coll = appliance.collections.infra_templates.all()[:min_templates]
+    t_coll = locals()[templates_collection].collections.infra_templates.all()[:min_templates]
     compare_view = locals()[templates_collection].collections.infra_templates.compare_entities(
         provider,
         entities_list=t_coll)


### PR DESCRIPTION
## Purpose or Intent

- __Enhancement__ for a common function to do the navigation, checking of items, and selecting compare item in dropdown for comparison of hosts tests. This is the first phase of development of common compare functionality for entities. I'll be extending to other entity types (and probably implementing the functionality via class methods etc.) in future PRs. Existing Host compare tests have been updated to use compare_hosts.


### PRT Run

{{ pytest: --long-running --use-provider rhv43 cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_navigation_after_download_from_compare cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_compare cfme/tests/infrastructure/test_providers.py::test_compare_templates }}