### PR TITLE
[1LP][RFR] Update v2v inframap view

### DIFF
--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -461,7 +461,7 @@ def test_v2v_with_no_providers(appliance, source_provider, provider, soft_assert
     if appliance.version < '5.11':
         soft_assert(view.configure_providers.is_displayed)
     else:
-        soft_assert(view.missing_providers.text == 'Missing Providers')
+        soft_assert(view.missing_providers.is_displayed)
 
     # Test2: Check 'add infra map' don't get displayed on overview page
     soft_assert(not view.create_infra_mapping.is_displayed)

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -440,7 +440,7 @@ def test_v2v_with_no_providers(appliance, source_provider, provider, soft_assert
     Test V2V UI with no source and target provider
 
     Polarion:
-        assignee: sshveta
+        assignee: nachandr
         initialEstimate: 1/2h
         caseimportance: high
         caseposneg: positive
@@ -457,8 +457,11 @@ def test_v2v_with_no_providers(appliance, source_provider, provider, soft_assert
     is_target_provider_deleted = provider.delete_if_exists(cancel=False)
     view = navigate_to(map_collection, "All")
 
-    # Test1: Check 'Configure provider' get displayed after provider deletion
-    soft_assert(view.configure_providers.is_displayed)
+    # Test1: Check 'Configure provider/Missing Providers' gets displayed after provider deletion
+    if appliance.version < '5.11':
+        soft_assert(view.configure_providers.is_displayed)
+    else:
+        soft_assert(view.missing_providers.text == 'Missing Providers')
 
     # Test2: Check 'add infra map' don't get displayed on overview page
     soft_assert(not view.create_infra_mapping.is_displayed)

--- a/cfme/v2v/infrastructure_mapping.py
+++ b/cfme/v2v/infrastructure_mapping.py
@@ -148,6 +148,7 @@ class AllInfraMappingView(InfrastructureMappingView):
     infra_mapping_list = InfraMappingList("infra-mappings-list-view")
     create_infra_mapping = Text(locator='(//a|//button)[text()="Create Infrastructure Mapping"]')
     configure_providers = Text(locator='//a[text()="Configure Providers"]')
+    missing_providers = Text(locator='.//h4[contains(@class,"blank-slate-pf-title")]')
     paginator_view = View.include(V2VPaginatorPane, use_parent=True)
     search_box = TextInput(locator=".//div[contains(@class,'input-group')]/input")
     clear_filters = Text(".//a[text()='Clear All Filters']")
@@ -161,6 +162,7 @@ class AllInfraMappingView(InfrastructureMappingView):
             self.create_infra_mapping.is_displayed
             or self.infra_mapping_list.is_displayed
             or self.configure_providers.is_displayed
+            or self.missing_providers.text == 'Missing Providers'
         )
 
 

--- a/cfme/v2v/infrastructure_mapping.py
+++ b/cfme/v2v/infrastructure_mapping.py
@@ -148,7 +148,7 @@ class AllInfraMappingView(InfrastructureMappingView):
     infra_mapping_list = InfraMappingList("infra-mappings-list-view")
     create_infra_mapping = Text(locator='(//a|//button)[text()="Create Infrastructure Mapping"]')
     configure_providers = Text(locator='//a[text()="Configure Providers"]')
-    missing_providers = Text(locator='.//h4[contains(@class,"blank-slate-pf-title")]')
+    missing_providers = Text(locator='.//h4[text()="Missing Providers"]')
     paginator_view = View.include(V2VPaginatorPane, use_parent=True)
     search_box = TextInput(locator=".//div[contains(@class,'input-group')]/input")
     clear_filters = Text(".//a[text()='Clear All Filters']")
@@ -162,7 +162,7 @@ class AllInfraMappingView(InfrastructureMappingView):
             self.create_infra_mapping.is_displayed
             or self.infra_mapping_list.is_displayed
             or self.configure_providers.is_displayed
-            or self.missing_providers.text == 'Missing Providers'
+            or self.missing_providers.is_displayed
         )
 
 


### PR DESCRIPTION
PRT results:
510 - PASS
511 - PASS

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/v2v/test_v2v_migrations_ui.py -k  test_v2v_with_no_providers --use-template-cache --provider-limit 2 --use-provider rhv43 --use-provider vsphere65-nested -qsvv }}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
