### PR TITLE
[1LP][RFR] - Fixed TCs

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -27,7 +27,6 @@ from cfme.utils.providers import list_providers_by_class
 from cfme.utils.version import Version
 from cfme.utils.wait import wait_for
 
-
 TimedCommand = namedtuple("TimedCommand", ["command", "timeout"])
 
 
@@ -98,8 +97,10 @@ def dedicated_db_appliance(app_creds, unconfigured_appliance):
     10. '' finish."""
     app = unconfigured_appliance
     pwd = app_creds["password"]
-    command_set = ("ap", "", "7", "1", "1", "2", "y", pwd, TimedCommand(pwd, 360), "")
-    app.appliance_console.run_commands(command_set)
+    menu = "5" if app.version > 5.11 else "7"
+    partition = "2" if unconfigured_appliance.version < "5.11" else "1"
+    command_set = ("ap", "", menu, "1", "1", partition, "y", pwd, TimedCommand(pwd, 360), "")
+    app.appliance_console.run_commands(command_set, timeout=20)
     wait_for(lambda: app.db.is_dedicated_active)
     yield app
 


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
Appliance console menu option's sequence changed recently so modified some testcases according to new appliance menu sequence
Due to this [PR](https://github.com/ManageIQ/manageiq-appliance_console/pull/99) appliance console option changed
### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: ./cfme/tests/cli/test_appliance_console.py -k "test_appliance_console_internal_db or test_appliance_console_dedicated_db or test_appliance_console_external_db or test_appliance_console_external_db_create or test_appliance_console_extend_storage or test_appliance_console_ipa or test_appliance_console_external_auth or test_appliance_console_external_auth_all or test_appliance_console_evm_stop or test_appliance_console_evm_start or test_appliance_console_shutdown or test_appliance_console_restore_db_network_negative or test_appliance_console_key_fetch_negative" -v}}