### PR TITLE
[1LP][RFR] Fix KeyError for reports

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -584,9 +584,13 @@ class SavedReport(Updateable, BaseEntity):
 
     @cached_property
     def queued_datetime_in_title(self):
+        # when the timezone is changed,
         # "display" key will not be available without clearing the cache
         delattr(self.appliance, "rest_api")
-        area = self.appliance.rest_api.settings["display"]["timezone"]
+        try:
+            area = self.appliance.rest_api.settings["display"]["timezone"]
+        except KeyError:
+            area = "UTC"
         return parsetime.from_american(
             self.queued_datetime, self.report_timezone
         ).to_saved_report_title_format(area)


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ 
    1. Reporting test cases failing from KeyError

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_canned_corresponds.py -k "test_providers_summary" -vvv }}