### PR TITLE
[WIPTEST][NOMERGE] (trying to) fix flakiness of test_advanced_search tests

### DIFF
--- a/widgetastic_manageiq/expression_editor.py
+++ b/widgetastic_manageiq/expression_editor.py
@@ -55,7 +55,7 @@ class ExpressionEditor(View, Pretty):
 
     @View.nested
     class field_form_view(View):  # noqa
-        fill_strategy = WaitFillViewStrategy()
+        fill_strategy = WaitFillViewStrategy(wait_widget="20s")
         type = BootstrapSelect("chosen_typ")
         field = BootstrapSelect("chosen_field")
         key = BootstrapSelect("chosen_key")


### PR DESCRIPTION
Just trying if this change fixes the flakiness of a specific test_advanced_search test. The problem is that it works fine locally, but sometimes fails in PRT due to timeout, so I have to try trough a PRT.

During trying to fix these tests a bug was found, which could be the cause of flakiness. 
https://bugzilla.redhat.com/show_bug.cgi?id=1803947

It seems that tests could be fixed by workaround:
reloading the page when the bug occurs, if the Bugzilla would be decided not to be fixed

{{ pytest: cfme/tests/webui/test_advanced_search.py -v }}
the flaky test:
pytest: cfme/tests/webui/test_advanced_search.py::TestServices::test_filter_crud[myservices-all] -v 