### PR TITLE
[1LP][RFR] - Fixed test_appliance_console_ipa testcase

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -443,9 +443,9 @@ def test_appliance_console_ipa(ipa_crud, configured_appliance):
         initialEstimate: 1/4h
     """
 
-    command_set = ('ap', RETURN, '12', ipa_crud.host1, ipa_crud.ipadomain, ipa_crud.iparealm,
-                   ipa_crud.ipaprincipal, ipa_crud.bind_password, TimedCommand('y', 60),
-                   RETURN, RETURN)
+    command_set = ('ap', RETURN, app_con_menu["config_external_auth"], ipa_crud.host1,
+                   ipa_crud.ipadomain, ipa_crud.iparealm, ipa_crud.ipaprincipal,
+                   ipa_crud.bind_password, TimedCommand('y', 60), RETURN, RETURN)
     configured_appliance.appliance_console.run_commands(command_set, timeout=20)
     configured_appliance.sssd.wait_for_running()
     assert configured_appliance.ssh_client.run_command("cat /etc/ipa/default.conf |"
@@ -453,8 +453,9 @@ def test_appliance_console_ipa(ipa_crud, configured_appliance):
 
     # Unconfigure to cleanup
     # When setup_ipa option selected, will prompt to unconfigure, then to proceed with new config
-    command_set = ('ap', RETURN, '12', TimedCommand('y', 40), TimedCommand('n', 5), RETURN, RETURN)
-    configured_appliance.appliance_console.run_commands(command_set)
+    command_set = ('ap', RETURN, app_con_menu["config_external_auth"], TimedCommand('y', 40),
+                   TimedCommand('n', 5), RETURN, RETURN)
+    configured_appliance.appliance_console.run_commands(command_set, timeout=20)
     wait_for(lambda: not configured_appliance.sssd.running)
 
 


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->
__Fixing__  Testcase: **test_appliance_console_ipa** was failing due to timeout error while unconfigure IPA so fixed this issue
## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: ./cfme/tests/cli/test_appliance_console.py::test_appliance_console_ipa --long-running -v}}