### PR TITLE
[1LP][RFR] Fix Tests

### DIFF
--- a/cfme/tests/cloud_infra_common/test_power_control_rest.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_rest.py
@@ -5,6 +5,7 @@ from cfme.cloud.provider.azure import AzureProvider
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.gce import GCEProvider
 from cfme.common.provider import BaseProvider
+from cfme.infrastructure.config_management import ConfigManagerProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import providers
@@ -18,6 +19,10 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.provider([BaseProvider], scope='module'),
     pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"]),
+    pytest.mark.uncollectif(
+        lambda provider: provider.one_of(ConfigManagerProvider),
+        reason="Config Manager providers do not support this feature."
+    )
 ]
 
 

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -130,7 +130,7 @@ def test_cluster_relationships(appliance, soft_assert):
 
 
 @pytest.mark.rhv2
-def test_operations_vm_on(soft_assert, appliance, request):
+def test_operations_vm_on(soft_assert, temp_appliance_preconfig_funcscope, request):
     """Tests vm power options from on
 
     Metadata:
@@ -145,7 +145,7 @@ def test_operations_vm_on(soft_assert, appliance, request):
         caseimportance: high
         initialEstimate: 1/6h
     """
-
+    appliance = temp_appliance_preconfig_funcscope
     adb = appliance.db.client
     vms = adb['vms']
     hosts = adb['hosts']

--- a/cfme/tests/intelligence/reports/test_canned_corresponds.py
+++ b/cfme/tests/intelligence/reports/test_canned_corresponds.py
@@ -189,7 +189,7 @@ def test_operations_vm_on(soft_assert, temp_appliance_preconfig_funcscope, reque
 
 
 @pytest.mark.rhv3
-def test_datastores_summary(soft_assert, appliance, request):
+def test_datastores_summary(soft_assert, temp_appliance_preconfig_funcscope, request):
     """Checks Datastores Summary report with DB data. Checks all data in report, even rounded
     storage sizes.
 
@@ -202,6 +202,7 @@ def test_datastores_summary(soft_assert, appliance, request):
         caseimportance: high
         initialEstimate: 1/6h
     """
+    appliance = temp_appliance_preconfig_funcscope
     adb = appliance.db.client
     storages = adb['storages']
     vms = adb['vms']

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -17,6 +17,7 @@ from cfme.common.provider_views import ProviderDetailsView
 from cfme.common.provider_views import ProviderTimelinesView
 from cfme.common.topology import BaseTopologyView
 from cfme.containers.provider import ContainersProvider
+from cfme.infrastructure.config_management import ConfigManagerProvider
 from cfme.infrastructure.config_management.ansible_tower import AnsibleTowerProvider
 from cfme.infrastructure.config_management.satellite import SatelliteProvider
 from cfme.infrastructure.datastore import DatastoresCompareView
@@ -734,6 +735,10 @@ def test_ui_notification_icon():
 @pytest.mark.tier(1)
 @pytest.mark.meta(automates=[1532404])
 @pytest.mark.provider([BaseProvider], selector=ONE_PER_CATEGORY)
+@pytest.mark.uncollectif(
+    lambda provider: provider.one_of(ConfigManagerProvider),
+    reason="Config Manager providers do not support this feature.",
+)
 def test_provider_summary_topology(setup_provider, provider):
     """
     Polarion:


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ 
    1. `test_operations_vm_on`
    2. `test_datastores_summary`
    3. Uncollect `test_power_control_rest.py` and `test_provider_summary_topology` for Config Manager providers.

### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_canned_corresponds.py -k "test_operations_vm_on or test_datastores_summary"  --use-provider=complete  -svvv}}