### PR TITLE
[RFR][NOTEST] Already automated manual test remove

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -220,24 +220,6 @@ def test_service_ansible_playbook_machine_credentials_service_details_sui():
 
 
 @pytest.mark.tier(3)
-def test_custom_button_order_ansible_playbook_service():
-    """
-    Bugzilla:
-        1449361
-
-    An Ansible Service Playbook can be ordered from a Custom Button
-
-    Polarion:
-        assignee: sbulage
-        casecomponent: Automate
-        caseimportance: medium
-        initialEstimate: 1/3h
-        tags: ansible_embed
-    """
-    pass
-
-
-@pytest.mark.tier(3)
 def test_service_ansible_overridden_extra_vars():
     """
     Bugzilla:

--- a/cfme/tests/automate/custom_button/test_infra_objects_ansible.py
+++ b/cfme/tests/automate/custom_button/test_infra_objects_ansible.py
@@ -72,6 +72,7 @@ def setup_obj(button_group, provider):
     return obj
 
 
+@pytest.mark.meta(coverage=[1449361])
 @pytest.mark.meta(blockers=[BZ(1685555, unblock=lambda button_group: "SWITCH" not in button_group)])
 @pytest.mark.parametrize("inventory", INVENTORY, ids=["_".join(item.split()) for item in INVENTORY])
 @pytest.mark.uncollectif(lambda appliance, button_group, inventory:


### PR DESCRIPTION


## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

- [X] Added BZ flag to already automated tests.


