### PR TITLE
[1LP][RFR] Update snapshot tests to use create_vm fixture

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -963,7 +963,7 @@ class VM(BaseVM, RetirementMixin):
         """
         if self.exists_on_provider:
             wait_for(lambda: self.mgmt.cleanup, handle_exception=handle_cleanup_exception,
-                     timeout=900)
+                     timeout=300)
         else:
             logger.debug('cleanup_on_provider: entity "%s" does not exist', self.name)
 

--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -956,13 +956,14 @@ class VM(BaseVM, RetirementMixin):
             raise
         return vm
 
-    def cleanup_on_provider(self):
+    def cleanup_on_provider(self, handle_cleanup_exception=True):
         """Clean up entity on the provider if it has been created on the provider
 
         Helper method to avoid NotFoundError's during test case tear down.
         """
         if self.exists_on_provider:
-            self.mgmt.cleanup()
+            wait_for(lambda: self.mgmt.cleanup, handle_exception=handle_cleanup_exception,
+                     timeout=900)
         else:
             logger.debug('cleanup_on_provider: entity "%s" does not exist', self.name)
 

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -13,7 +13,6 @@ from cfme.infrastructure.virtual_machines import InfraVmSnapshotView
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
-from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.path import data_path

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -290,9 +290,9 @@ def test_verify_revert_snapshot(full_test_vm, provider, soft_assert, register_ev
     """
     verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request)
 
-
+@pytest.mark.parametrize('create_vm', ['full_template'], indirect=True)
 @pytest.mark.provider([VMwareProvider])
-def test_revert_active_snapshot(full_test_vm, provider, soft_assert, register_event, request):
+def test_revert_active_snapshot(create_vm, provider, soft_assert, register_event, request):
     """Tests revert active snapshot
 
     Metadata:
@@ -304,14 +304,14 @@ def test_revert_active_snapshot(full_test_vm, provider, soft_assert, register_ev
         caseimportance: medium
         initialEstimate: 1/3h
     """
-    verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, request,
+    verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request,
                            active_snapshot=True)
 
 
 @pytest.mark.rhv2
 @pytest.mark.provider([RHEVMProvider])
 @pytest.mark.meta(automates=[BZ(1552732)])
-def test_revert_to_active_vm(small_test_vm, provider):
+def test_revert_to_active_vm(small_test_vm, provider):#This test causes failures upon cleanup. Address.
     """
     Test that it's not possible to revert to "Active VM" on RHV.
 

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -64,7 +64,7 @@ def new_snapshot(test_vm, has_name=True, memory=False, create_description=True):
 
 
 @pytest.mark.rhv2
-def test_memory_checkbox(small_test_vm, provider, soft_assert):
+def test_memory_checkbox(create_vm, provider, soft_assert):
     """Tests snapshot memory checkbox
 
     Memory checkbox should be displayed and active when VM is running ('Power On').
@@ -80,18 +80,18 @@ def test_memory_checkbox(small_test_vm, provider, soft_assert):
         initialEstimate: 1/3h
     """
     # Make sure the VM is powered on
-    small_test_vm.power_control_from_cfme(option=small_test_vm.POWER_ON, cancel=False)
+    create_vm.power_control_from_cfme(option=create_vm.POWER_ON, cancel=False)
     # Try to create snapshot with memory on powered on VM
     has_name = not provider.one_of(RHEVMProvider)
-    snapshot1 = new_snapshot(small_test_vm, has_name=has_name, memory=True)
+    snapshot1 = new_snapshot(create_vm, has_name=has_name, memory=True)
     snapshot1.create()
     assert snapshot1.exists
     # Power off the VM
-    small_test_vm.power_control_from_cfme(option=small_test_vm.POWER_OFF, cancel=False)
-    small_test_vm.wait_for_vm_state_change(desired_state=small_test_vm.STATE_OFF)
-    soft_assert(small_test_vm.mgmt.is_stopped, "VM is not stopped!")
+    create_vm.power_control_from_cfme(option=create_vm.POWER_OFF, cancel=False)
+    create_vm.wait_for_vm_state_change(desired_state=create_vm.STATE_OFF)
+    soft_assert(create_vm.mgmt.is_stopped, "VM is not stopped!")
     # Check that checkbox is not displayed
-    view = navigate_to(small_test_vm, 'SnapshotsAdd')
+    view = navigate_to(create_vm, 'SnapshotsAdd')
     assert not view.snapshot_vm_memory.is_displayed, (
         "Memory checkbox is displayed when VM is stopped")
 
@@ -100,7 +100,7 @@ def test_memory_checkbox(small_test_vm, provider, soft_assert):
 @pytest.mark.rhv3
 @test_requirements.rhev
 @pytest.mark.meta(automates=[1571291, 1608475])
-def test_snapshot_crud(small_test_vm, provider):
+def test_snapshot_crud(create_vm, provider):
     """Tests snapshot crud
 
     Metadata:
@@ -117,7 +117,7 @@ def test_snapshot_crud(small_test_vm, provider):
     )
     result.start_monitoring()
     # has_name is false if testing RHEVMProvider
-    snapshot = new_snapshot(small_test_vm, has_name=(not provider.one_of(RHEVMProvider)))
+    snapshot = new_snapshot(create_vm, has_name=(not provider.one_of(RHEVMProvider)))
     snapshot.create()
     # check for the size as "read" check
     if provider.appliance.version >= "5.11" and provider.one_of(RHEVMProvider):
@@ -131,7 +131,7 @@ def test_snapshot_crud(small_test_vm, provider):
 @test_requirements.rhev
 @pytest.mark.provider([RHEVMProvider])
 @pytest.mark.meta(automates=[BZ(1443411)])
-def test_delete_active_vm_snapshot(small_test_vm):
+def test_delete_active_vm_snapshot(create_vm):
     """
     Check that it's not possible to delete an Active VM from RHV snapshots
 
@@ -145,15 +145,15 @@ def test_delete_active_vm_snapshot(small_test_vm):
         caseposneg: negative
         initialEstimate: 1/12h
     """
-    view = navigate_to(small_test_vm, 'SnapshotsAll')
-    view.tree.click_path(small_test_vm.name, 'Active VM (Active)')
+    view = navigate_to(create_vm, 'SnapshotsAll')
+    view.tree.click_path(create_vm.name, 'Active VM (Active)')
     assert not view.toolbar.delete.is_displayed
 
 
 @pytest.mark.rhv3
 @test_requirements.rhev
 @pytest.mark.provider([RHEVMProvider])
-def test_create_without_description(small_test_vm):
+def test_create_without_description(create_vm):
     """
     Test that we get an error message when we try to create a snapshot with
     blank description on RHV provider.
@@ -166,12 +166,12 @@ def test_create_without_description(small_test_vm):
         initialEstimate: 1/4h
         casecomponent: Infra
     """
-    if small_test_vm.appliance.version >= '5.10':
+    if create_vm.appliance.version >= '5.10':
         # In 5.10 it's not possible to create a snapshot w/o description,"Create" button is disabled
-        view = navigate_to(small_test_vm, 'SnapshotsAdd')
+        view = navigate_to(create_vm, 'SnapshotsAdd')
         assert view.create.disabled
     else:
-        snapshot = new_snapshot(small_test_vm, has_name=False, create_description=False)
+        snapshot = new_snapshot(create_vm, has_name=False, create_description=False)
         with pytest.raises(AssertionError):
             snapshot.create()
         view = snapshot.parent_vm.create_view(InfraVmSnapshotAddView)

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -9,7 +9,7 @@ from cfme.markers.env_markers.provider import providers
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
-from cfme.utils.wait import wait_for
+
 
 filter_fields = {
     'required_fields': [['provisioning', 'template'],
@@ -34,7 +34,7 @@ def clone_vm_name():
 
 
 @pytest.fixture
-def create_vm(appliance, provider, request, handle_cleanup_exception=True):
+def create_vm(appliance, provider, request):
     """Fixture to provision vm to the provider being tested"""
     vm_name = fauxfactory.gen_alphanumeric(15, start="test_clone_")
     vm = appliance.collections.infra_vms.instantiate(vm_name, provider)
@@ -44,8 +44,7 @@ def create_vm(appliance, provider, request, handle_cleanup_exception=True):
         logger.info("deploying %s on provider %s", vm.name, provider.key)
         vm.create_on_provider(allow_skip="default", find_in_cfme=True)
     yield vm
-    wait_for(lambda: vm.cleanup_on_provider, handle_exception=handle_cleanup_exception,
-             timeout=900)
+    vm.cleanup_on_provider()
 
 
 @pytest.mark.provider([VMwareProvider], **filter_fields)

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -9,7 +9,7 @@ from cfme.markers.env_markers.provider import providers
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
-
+from cfme.utils.wait import wait_for
 
 filter_fields = {
     'required_fields': [['provisioning', 'template'],
@@ -34,7 +34,7 @@ def clone_vm_name():
 
 
 @pytest.fixture
-def create_vm(appliance, provider, request):
+def create_vm(appliance, provider, request, handle_cleanup_exception=True):
     """Fixture to provision vm to the provider being tested"""
     vm_name = fauxfactory.gen_alphanumeric(15, start="test_clone_")
     vm = appliance.collections.infra_vms.instantiate(vm_name, provider)
@@ -44,7 +44,8 @@ def create_vm(appliance, provider, request):
         logger.info("deploying %s on provider %s", vm.name, provider.key)
         vm.create_on_provider(allow_skip="default", find_in_cfme=True)
     yield vm
-    vm.cleanup_on_provider()
+    wait_for(lambda: vm.cleanup_on_provider, handle_exception=handle_cleanup_exception,
+             timeout=900)
 
 
 @pytest.mark.provider([VMwareProvider], **filter_fields)


### PR DESCRIPTION
## Purpose or Intent

- __Updating tests__ in test_snapshot.py to use new create_vm global fixture.

### PRT Run

The function test_verify_revert_snapshot fails for rhv providers. This was failing before the update to create_vm and is not caused by it. I am going to begin work on fixing test_verify_revert_snapshot for rhv providers in another PR shortly.