### PR TITLE
[1LP][RFR] Remove openshift provider in genealogy tests

### DIFF
--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -3,9 +3,9 @@ import pytest
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
 from cfme.common.provider import BaseProvider
+from cfme.containers.provider.openshift import OpenshiftProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
-from cfme.containers.provider.openshift import OpenshiftProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
@@ -17,7 +17,8 @@ pytestmark = [
     pytest.mark.provider(
         gen_func=providers,
         filters=[ProviderFilter(classes=[BaseProvider]),
-                 ProviderFilter(classes=[SCVMMProvider, RHEVMProvider, OpenshiftProvider], inverted=True)],
+                 ProviderFilter(classes=[SCVMMProvider, RHEVMProvider, OpenshiftProvider],
+                                inverted=True)],
         scope='module'),
     test_requirements.genealogy
 ]

--- a/cfme/tests/cloud_infra_common/test_genealogy.py
+++ b/cfme/tests/cloud_infra_common/test_genealogy.py
@@ -5,6 +5,7 @@ from cfme.cloud.provider import CloudProvider
 from cfme.common.provider import BaseProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
+from cfme.containers.provider.openshift import OpenshiftProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
@@ -16,12 +17,10 @@ pytestmark = [
     pytest.mark.provider(
         gen_func=providers,
         filters=[ProviderFilter(classes=[BaseProvider]),
-                 ProviderFilter(classes=[SCVMMProvider, RHEVMProvider], inverted=True)],
+                 ProviderFilter(classes=[SCVMMProvider, RHEVMProvider, OpenshiftProvider], inverted=True)],
         scope='module'),
     test_requirements.genealogy
 ]
-
-
 # uncollected above in pytest_generate_tests
 @pytest.mark.parametrize("from_edit", [True, False], ids=["via_edit", "via_summary"])
 @pytest.mark.uncollectif(lambda provider, from_edit:


### PR DESCRIPTION
The purpose of this PR is to remove openshift as a provider in test_genealogy.py

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
