### PR TITLE
[1LP][RFR] V2V : Update set_conversion_host_api function

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -212,8 +212,8 @@ def vddk_url():
     return url
 
 
-def get_conversion_data(target_provider):
-    if target_provider.one_of(RHEVMProvider):
+def get_conversion_data(appliance, target_provider):
+    if target_provider.one_of(RHEVMProvider) and appliance.version < '5.11':
         resource_type = "ManageIQ::Providers::Redhat::InfraManager::Host"
         engine_key = conf.credentials[target_provider.data["ssh_creds"]]
         auth_user = engine_key.username
@@ -266,7 +266,11 @@ def set_conversion_host_api(
         vmware_vddk_package_url = vddk_url()
 
     for host in conversion_data["hosts"]:
-        conversion_entity = "hosts" if target_provider.one_of(RHEVMProvider) else "vms"
+        conversion_entity = (
+            "hosts"
+            if target_provider.one_of(RHEVMProvider) and appliance.version < '5.11'
+            else "vms"
+        )
         host_id = (
             getattr(appliance.rest_api.collections, conversion_entity).filter(
                 Q.from_dict({"name": host})).resources[0].id)

--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -260,7 +260,11 @@ def get_conversion_data(appliance, target_provider):
 
 def set_conversion_host_api(
         appliance, transformation_method, source_provider, target_provider):
-    """Setting conversion host for RHV and OSP provider via REST"""
+    """
+    Setting conversion host for RHV and OSP provider via REST
+
+    Note: Support for using VM as UCI conversion hosts was added for RHV in 5.11.4.
+    """
     vmware_ssh_private_key = None
     vmware_vddk_package_url = None
 

--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -223,6 +223,10 @@ def get_conversion_data(appliance, target_provider):
             password=engine_key.password,
         )
         private_key = ssh_client.run_command("cat /etc/pki/ovirt-engine/keys/engine_id_rsa").output
+        try:
+            hosts = [h.name for h in target_provider.hosts.all()]
+        except KeyError:
+            pytest.skip("No conversion host on provider")
 
     elif target_provider.one_of(RHEVMProvider) and appliance.version > '5.10':
         resource_type = "ManageIQ::Providers::Redhat::InfraManager::Vm"
@@ -230,12 +234,8 @@ def get_conversion_data(appliance, target_provider):
             target_provider.data["private-keys"]["engine-rsa"]["credentials"]]
         auth_user = vm_key.username
         private_key = vm_key.password
-
         try:
-            if appliance.version < '5.11':
-                hosts = [h.name for h in target_provider.hosts.all()]
-            else:
-                hosts = target_provider.data["conversion_instances"]
+            hosts = target_provider.data["conversion_instances"]
         except KeyError:
             pytest.skip("No conversion host on provider")
 
@@ -249,6 +249,7 @@ def get_conversion_data(appliance, target_provider):
             hosts = target_provider.data["conversion_instances"]
         except KeyError:
             pytest.skip("No conversion instance on provider")
+
     return {
         "resource_type": resource_type,
         "private_key": private_key,

--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -213,31 +213,34 @@ def vddk_url():
 
 
 def get_conversion_data(appliance, target_provider):
-    if target_provider.one_of(RHEVMProvider) and appliance.version < '5.11':
-        resource_type = "ManageIQ::Providers::Redhat::InfraManager::Host"
-        engine_key = conf.credentials[target_provider.data["ssh_creds"]]
-        auth_user = engine_key.username
-        ssh_client = ssh.SSHClient(
-            hostname=target_provider.hostname,
-            username=engine_key.username,
-            password=engine_key.password,
-        )
-        private_key = ssh_client.run_command("cat /etc/pki/ovirt-engine/keys/engine_id_rsa").output
-        try:
-            hosts = [h.name for h in target_provider.hosts.all()]
-        except KeyError:
-            pytest.skip("No conversion host on provider")
+    if target_provider.one_of(RHEVMProvider):
+        if appliance.version < '5.11':
+            resource_type = "ManageIQ::Providers::Redhat::InfraManager::Host"
+            engine_key = conf.credentials[target_provider.data["ssh_creds"]]
+            auth_user = engine_key.username
+            ssh_client = ssh.SSHClient(
+                hostname=target_provider.hostname,
+                username=engine_key.username,
+                password=engine_key.password,
+            )
+            private_key = ssh_client.run_command(
+                "cat /etc/pki/ovirt-engine/keys/engine_id_rsa").output
+            try:
+                hosts = [h.name for h in target_provider.hosts.all()]
+            except KeyError:
+                pytest.skip("No conversion host on provider")
 
-    elif target_provider.one_of(RHEVMProvider) and appliance.version > '5.10':
-        resource_type = "ManageIQ::Providers::Redhat::InfraManager::Vm"
-        vm_key = conf.credentials[
-            target_provider.data["private-keys"]["engine-rsa"]["credentials"]]
-        auth_user = vm_key.username
-        private_key = vm_key.password
-        try:
-            hosts = target_provider.data["conversion_instances"]
-        except KeyError:
-            pytest.skip("No conversion host on provider")
+    elif target_provider.one_of(RHEVMProvider):
+        if appliance.version > '5.10':
+            resource_type = "ManageIQ::Providers::Redhat::InfraManager::Vm"
+            vm_key = conf.credentials[
+                target_provider.data["private-keys"]["engine-rsa"]["credentials"]]
+            auth_user = vm_key.username
+            private_key = vm_key.password
+            try:
+                hosts = target_provider.data["conversion_instances"]
+            except KeyError:
+                pytest.skip("No conversion host on provider")
 
     else:
         resource_type = "ManageIQ::Providers::Openstack::CloudManager::Vm"

--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -230,8 +230,7 @@ def get_conversion_data(appliance, target_provider):
             except KeyError:
                 pytest.skip("No conversion host on provider")
 
-    elif target_provider.one_of(RHEVMProvider):
-        if appliance.version > '5.10':
+        elif appliance.version > '5.10':
             resource_type = "ManageIQ::Providers::Redhat::InfraManager::Vm"
             vm_key = conf.credentials[
                 target_provider.data["private-keys"]["engine-rsa"]["credentials"]]


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{ pytest: cfme/tests/v2v/test_v2v_smoke.py --use-template-cache --provider-limit 2 --use-provider rhv43 --use-provider vsphere67-ims }}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

##Notes:
-The run will fail because this PR needs to be merged 
https://github.com/ManageIQ/integration_tests/pull/9953/
-->

PRT results:
510 - PASS
511 - Currently failing, but would pass once https://github.com/ManageIQ/integration_tests/pull/9953 is merged
