### PR TITLE
[1LP][RFR] Change assignee from sbulage to gtalreja in ansible tests

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -78,7 +78,7 @@ def test_action_run_ansible_playbook_localhost(request, ansible_catalog_item, an
     """Tests a policy with ansible playbook action against localhost.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         initialEstimate: 1/6h
         casecomponent: Ansible
     """
@@ -101,7 +101,7 @@ def test_action_run_ansible_playbook_manual_address(request, ansible_catalog_ite
     """Tests a policy with ansible playbook action against manual address.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         initialEstimate: 1/6h
         casecomponent: Ansible
     """
@@ -132,7 +132,7 @@ def test_action_run_ansible_playbook_target_machine(request, ansible_catalog_ite
     """Tests a policy with ansible playbook action against target machine.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         initialEstimate: 1/6h
         casecomponent: Ansible
     """
@@ -156,7 +156,7 @@ def test_action_run_ansible_playbook_unavailable_address(request, ansible_catalo
     """Tests a policy with ansible playbook action against unavailable address.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         initialEstimate: 1/6h
         casecomponent: Ansible
     """
@@ -186,7 +186,7 @@ def test_control_action_run_ansible_playbook_in_requests(request,
     """Checks if execution of the Action result in a Task/Request being created.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         initialEstimate: 1/6h
         casecomponent: Ansible
     """

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -185,7 +185,7 @@ def test_automate_ansible_playbook_method_type(request, appliance, ansible_repos
 def test_ansible_playbook_button_crud(ansible_catalog_item, appliance, request):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -222,7 +222,7 @@ def test_embedded_ansible_custom_button_localhost(create_vm_modscope, custom_vm_
         appliance, ansible_service_request, ansible_service, ansible_catalog_item):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/4h
     """
@@ -247,7 +247,7 @@ def test_embedded_ansible_custom_button_target_machine(create_vm_modscope, custo
         ansible_credential, appliance, ansible_service_request, ansible_service):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/4h
     """
@@ -272,7 +272,7 @@ def test_embedded_ansible_custom_button_specific_hosts(create_vm_modscope, custo
         ansible_credential, appliance, ansible_service_request, ansible_service):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/4h
     """

--- a/cfme/tests/ansible/test_embedded_ansible_basic.py
+++ b/cfme/tests/ansible/test_embedded_ansible_basic.py
@@ -157,7 +157,7 @@ def new_zone(appliance):
 def test_embedded_ansible_repository_crud(ansible_repository, wait_for_ansible):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/12h
@@ -178,7 +178,7 @@ def test_embedded_ansible_repository_branch_crud(appliance, request, wait_for_an
     Ability to add repo with branch (without SCM credentials).
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/12h
@@ -214,7 +214,7 @@ def test_embedded_ansible_repository_branch_crud(appliance, request, wait_for_an
 def test_embedded_ansible_repository_invalid_url_crud(request, appliance, wait_for_ansible):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/6h
@@ -242,7 +242,7 @@ def test_embedded_ansible_private_repository_crud(request, ansible_private_repos
     Add Private Repository by using SCM credentials. Check repository gets added successfully.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/6h
@@ -261,7 +261,7 @@ def test_embedded_ansible_credential_crud(credentials_collection, wait_for_ansib
         credentials, appliance):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/6h
@@ -305,7 +305,7 @@ def test_embedded_ansible_credential_crud(credentials_collection, wait_for_ansib
 def test_embed_tower_playbooks_list_changed(appliance, wait_for_ansible):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/6h
         tags: ansible_embed
@@ -422,7 +422,7 @@ def test_embedded_ansible_credential_with_private_key(request, wait_for_ansible,
         1439589
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -446,7 +446,7 @@ def test_embedded_ansible_repository_playbook_link(ansible_repository):
     check it will navigate to the Playbooks area.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/6h
         tags: ansible_embed
@@ -464,7 +464,7 @@ def test_embedded_ansible_repository_playbook_sub_dir(ansible_repository):
     The Embedded Ansible role should find playbooks in sub folders.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/6h
         tags: ansible_embed
@@ -488,7 +488,7 @@ def test_embed_tower_repo_add_new_zone(appliance, ansible_repository, new_zone, 
         1656308
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/2h
         testSteps:
@@ -542,7 +542,7 @@ def test_embedded_ansible_repository_refresh(ansible_repository):
     Repository"
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/6h

--- a/cfme/tests/ansible/test_embedded_ansible_crud.py
+++ b/cfme/tests/ansible/test_embedded_ansible_crud.py
@@ -23,7 +23,7 @@ def test_embedded_ansible_enable(embedded_appliance):
     """Tests whether the embedded ansible role and all workers have started correctly
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/6h
@@ -47,7 +47,7 @@ def test_embedded_ansible_disable(embedded_appliance):
     """Tests whether the embedded ansible role and all workers have stopped correctly
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/6h
@@ -82,7 +82,7 @@ def test_embedded_ansible_event_catcher_process(embedded_appliance):
     evm:status)
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/4h
@@ -114,7 +114,7 @@ def test_embedded_ansible_logs(embedded_appliance):
     p1 (/var/log/tower)
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/4h

--- a/cfme/tests/ansible/test_embedded_ansible_manual.py
+++ b/cfme/tests/ansible/test_embedded_ansible_manual.py
@@ -15,7 +15,7 @@ def test_embed_tower_retire_service_with_instances_ec2():
     Retire Service+instances which were deployed by playbook from CFME UI.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1h
@@ -38,7 +38,7 @@ def test_embed_tower_exec_play_against_machine_multi_appliance():
     Playbook should be executed successfully.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1h
@@ -53,7 +53,7 @@ def test_embed_tower_failover():
     Check that ansible fails over to new region correctly
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1h
@@ -71,7 +71,7 @@ def test_embed_ansible_next_gen():
         1511126
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/2h
         tags: ansible_embed
@@ -88,7 +88,7 @@ def test_embed_tower_exec_play_with_creds(appliance, provider):
     and can execute it against provider type with provider type credentials.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1h
@@ -107,7 +107,7 @@ def test_embed_ansible_catalog_items():
         1449696
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Configuration
         caseimportance: medium
         caseposneg: negative
@@ -123,7 +123,7 @@ def test_embed_tower_add_private_repo():
     Ability to add private repo with SCM credentials.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/6h
@@ -142,7 +142,7 @@ def test_embed_tower_repo_url_validation():
         1478958
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/6h
         tags: ansible_embed
@@ -159,7 +159,7 @@ def test_embed_tower_order_service_extra_vars():
     Execute playbook with extra variables which will be passed to Tower.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/4h
         tags: ansible_embed
@@ -174,7 +174,7 @@ def test_service_ansible_playbook_with_already_existing_catalog_item_name():
         1509809
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -191,7 +191,7 @@ def test_service_ansible_playbook_order_credentials_usecredsfromservicedialog():
     creation)
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/4h
@@ -210,7 +210,7 @@ def test_service_ansible_playbook_machine_credentials_service_details_sui():
     machine credentials were attached to the service.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/2h
@@ -229,7 +229,7 @@ def test_service_ansible_overridden_extra_vars():
     be overridden at "ordering" time. Check if the overridden parameters are passed.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -247,7 +247,7 @@ def test_service_ansible_playbook_standard_output_non_ascii_hostname():
         1534039
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -262,7 +262,7 @@ def test_service_ansible_playbook_retire_non_ascii():
     Retire ansible playbook service with non_ascii host
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -283,7 +283,7 @@ def test_automate_ansible_playbook_method_type_verbosity():
     levels.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/4h
@@ -300,7 +300,7 @@ def test_embed_tower_playbook_with_retry_interval():
         1626152
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/2h
         testSteps:
@@ -336,7 +336,7 @@ def test_embed_tower_playbook_with_retry_method():
         1625047
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/2h
         testSteps:

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -242,7 +242,7 @@ def custom_service_button(appliance, local_ansible_catalog_item):
 def test_service_ansible_playbook_available(appliance):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: high
         initialEstimate: 1/6h
@@ -256,7 +256,7 @@ def test_service_ansible_playbook_available(appliance):
 def test_service_ansible_playbook_crud(appliance, ansible_repository):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/6h
@@ -292,7 +292,7 @@ def test_service_ansible_playbook_tagging(ansible_catalog_item):
     """ Tests ansible_playbook tag addition, check added tag and removal
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: high
         initialEstimate: 1/2h
@@ -313,7 +313,7 @@ def test_service_ansible_playbook_tagging(ansible_catalog_item):
 def test_service_ansible_playbook_negative(appliance):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         caseposneg: negative
@@ -336,7 +336,7 @@ def test_service_ansible_playbook_bundle(appliance, ansible_catalog_item):
     """Ansible playbooks are not designed to be part of a cloudforms service bundle.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         caseposneg: negative
@@ -356,7 +356,7 @@ def test_service_ansible_playbook_provision_in_requests(
     """Tests if ansible playbook service provisioning is shown in service requests.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -388,7 +388,7 @@ def test_service_ansible_playbook_confirm(appliance, soft_assert):
     possible.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -421,7 +421,7 @@ def test_service_ansible_retirement_remove_resources(
 ):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: critical
         initialEstimate: 1/4h
@@ -492,7 +492,7 @@ def test_service_ansible_playbook_order_retire(
     unavailable host.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         initialEstimate: 1/4h
         casecomponent: Ansible
         caseimportance: medium
@@ -529,7 +529,7 @@ def test_service_ansible_playbook_plays_table(
     """Plays table in provisioned and retired service should contain at least one row.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: low
         initialEstimate: 1/6h
@@ -551,7 +551,7 @@ def test_service_ansible_playbook_order_credentials(
     screen.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -575,7 +575,7 @@ def test_service_ansible_playbook_pass_extra_vars(
     retirement.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/4h
@@ -611,7 +611,7 @@ def test_service_ansible_execution_ttl(
     than 100 minutes and set max ttl greater than ansible playbook running time.
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 2h
@@ -656,7 +656,7 @@ def test_custom_button_ansible_credential_list(
         1448918
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Automate
         caseimportance: medium
         initialEstimate: 1/3h
@@ -692,7 +692,7 @@ def test_ansible_group_id_in_payload(
         1480019
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -736,7 +736,7 @@ def test_embed_tower_exec_play_against(
 ):
     """
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/4h
@@ -803,7 +803,7 @@ def test_service_ansible_verbosity(
     Bugzilla:
         1460788
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/6h
@@ -868,7 +868,7 @@ def test_ansible_service_linked_vm(
         1448918
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/3h
         tags: ansible_embed
@@ -894,7 +894,7 @@ def test_ansible_service_order_vault_credentials(
     Add vault password and test in the playbook that encrypted yml can be
     decrypted.
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/2h
         tags: ansible_embed
@@ -940,7 +940,7 @@ ansible_service_catalog, ansible_service_funcscope, ansible_service_request_func
         1734904
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/3h
         tags: ansible_embed
@@ -977,7 +977,7 @@ ansible_service_catalog, ansible_service_funcscope, ansible_service_request_func
     Bugzilla:
         1742839
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/3h
         tags: ansible_embed
@@ -1014,7 +1014,7 @@ ansible_service_request_funcscope):
         1515561
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         initialEstimate: 1/4h
         tags: ansible_embed
@@ -1054,7 +1054,7 @@ def test_service_ansible_service_name(request, appliance, dialog_with_catalog_it
         1505929
 
     Polarion:
-        assignee: sbulage
+        assignee: gtalreja
         casecomponent: Ansible
         caseimportance: medium
         initialEstimate: 1/2h


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
