### PR TITLE
[1LP][RFR] Update widgetastic.patternfly to fix FlashMessages exception handling

### DIFF
--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -337,7 +337,7 @@ webencodings==0.5.1
 websocket-client==0.40.0
 Werkzeug==0.16.0
 widgetastic.core==0.51
-widgetastic.patternfly==1.3.0
+widgetastic.patternfly==1.3.1
 widgetsnbextension==3.4.2
 wrapanapi==3.5.6
 wrapt==1.11.1


### PR DESCRIPTION
This PR updates widgetastic.patternfly to include the changes in:

Add NoSuchElementException handling back into FlashMessages.
https://github.com/RedHatQE/widgetastic.patternfly/pull/118

This will resolve the test failures caused by NoSuchElementException errors in recent SSUI tests, such as the following:

```
        with appliance.context.use(context):
            dashboard = Dashboard(appliance)
>           assert dashboard.retired_services() == dashboard.results()

cfme/tests/ssui/test_ssui_dashboard.py:218: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
[...]
cfme/base/ssui.py:185: in step
    self.obj.login()
.cfme_venv/lib64/python3.7/site-packages/sentaku/context.py:131: in __call__
    return bound_method(*k, **kw)
cfme/base/ssui.py:156: in login
    login_view.flash.assert_no_error()
.cfme_venv/lib64/python3.7/site-packages/widgetastic/widget/base.py:67: in wrapped
    return method(self, *new_args, **new_kwargs)
.cfme_venv/lib64/python3.7/site-packages/widgetastic_patternfly/__init__.py:2916: in assert_no_error
    for msg in self.messages(**msg_filter):
.cfme_venv/lib64/python3.7/site-packages/widgetastic_patternfly/__init__.py:2876: in messages
    stop = self.msg_count + 1
.cfme_venv/lib64/python3.7/site-packages/widgetastic_patternfly/__init__.py:2821: in msg_count
    return len(self.browser.elements(self.MSG_LOCATOR, parent=self))
[...]
E           selenium.common.exceptions.NoSuchElementException: Message: Could not find an element Locator(by='xpath', locator='.//div[@id="flash_msg_div"]')

.cfme_venv/lib64/python3.7/site-packages/widgetastic/browser.py:352: NoSuchElementException (cfme/fixtures/log.py:84)
```
It appears that although cfme.base.ssui.LoginPage includes a nested FlashMessages view, the corresponding div element does not actually exist when viewing the page in the browser. A future PR should clean up this and other view classes that include FlashMessages but shouldn't.

{{ pytest: cfme/tests/ssui/test_ssui_dashboard.py -v }}
