### PR TITLE
[1LP][RFR] Remove test_info for test_docs.py

### DIFF
--- a/cfme/tests/configure/test_docs.py
+++ b/cfme/tests/configure/test_docs.py
@@ -116,40 +116,6 @@ def test_contents(appliance, soft_assert):
                                                            .format(exp_str, pdf_titlepage_text_low))
 
 
-@pytest.mark.tier(3)
-@pytest.mark.sauce
-@pytest.mark.ignore_stream("upstream")
-def test_info(appliance, soft_assert):
-    """
-    Test the alt/title and href attributes.
-    Each doc link is an anchor with image child element, and then the link text anchor
-    Verify anchor title matches alt in anchor image
-    Verify image anchor href matches link text href
-
-    Polarion:
-        assignee: pvala
-        initialEstimate: 1/4h
-        casecomponent: WebUI
-
-    """
-    view = navigate_to(appliance.server, 'Documentation')
-    for link_widget in view.links.sub_widgets:
-        if not (hasattr(link_widget, 'img_anchor') or hasattr(link_widget, 'img')):
-            # This check only applies to the PDF links, essentially factors out customer portal link
-            continue
-        # Check img_anchor title attribute against img alt attribute
-        title = view.browser.get_attribute(attr='title', locator=link_widget.img_anchor.locator)
-        alt = view.browser.get_attribute(attr='alt', locator=link_widget.img.locator)
-        soft_assert(title == alt, 'Image title/alt check failed for documentation link: {}'
-                                  .format(link_widget.TEXT))
-
-        # Check img_anchor href matches link text href
-        img_href = view.browser.get_attribute(attr='href', locator=link_widget.img_anchor.locator)
-        text_href = view.browser.get_attribute(attr='href', locator=link_widget.link.locator)
-        soft_assert(img_href == text_href, 'href attributes check failed for documentation link: {}'
-                                           .format(link_widget.TEXT))
-
-
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream("upstream")
 def test_all_docs_present(appliance):


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:
- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
Remove test test_info, As this functionality has been removed, there are no alt or image anchor to be tested against and every other functionality is accounted.

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/configure/test_docs.py  --long-running }}