### PR TITLE
[1LP][RFR] Add end version of 5.10 for test_configure_vmdb_last_start_time

### DIFF
--- a/cfme/tests/configure/test_database_ui.py
+++ b/cfme/tests/configure/test_database_ui.py
@@ -6,6 +6,7 @@ from cfme.utils.log_validator import LogValidator
 
 
 @pytest.mark.tier(2)
+@pytest.mark.ignore_stream('5.11')
 def test_configure_vmdb_last_start_time(appliance):
     """
         Go to Settings -> Configure -> Database
@@ -16,6 +17,7 @@ def test_configure_vmdb_last_start_time(appliance):
         assignee: tpapaioa
         casecomponent: Configuration
         caseimportance: medium
+        endsin: 5.10
         initialEstimate: 1/12h
     """
     db_last_start_time = (


### PR DESCRIPTION
As of 5.11.1, the Configuration -> Database page is disabled by default:

Bug 1767645 - [RFE] Hide the Configuration -> Database screen
https://bugzilla.redhat.com/show_bug.cgi?id=1767645

This PR removes the test for 5.11.

{{ pytest: cfme/tests/configure/test_database_ui.py -k test_configure_vmdb_last_start_time -vv }}