### PR TITLE
[1LP][RFR] UCI code for RHV shouldn't be executed for <=5.11.4

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -215,7 +215,6 @@ def vddk_url():
 def get_conversion_data(appliance, target_provider):
     if target_provider.one_of(RHEVMProvider):
         # Support for UCI hosts for RHV would be added in 5.11.5.
-        # So, this if block should be disabled until then.
         if appliance.version >= '5.11.5':
             resource_type = "ManageIQ::Providers::Redhat::InfraManager::Vm"
             vm_key = conf.credentials[
@@ -267,7 +266,7 @@ def set_conversion_host_api(
     """
     Setting conversion host for RHV and OSP provider via REST
 
-    Note: Support for using VM as UCI conversion hosts will be added for RHV in 5.11.5.
+    Note: Support for using VMs as UCI conversion hosts will be added for RHV in 5.11.5.
     """
     vmware_ssh_private_key = None
     vmware_vddk_package_url = None


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
UCI support for RHV would be pushed to 5.11.5.

I'm reverting changes made through PR#9954 while making sure that minimal to no change would be required whenever 5.11.5 lands( with support for RHV UCI hosts).
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{ pytest: cfme/tests/v2v/test_v2v_smoke.py --use-template-cache --provider-limit 2 --use-provider rhv43 --use-provider vsphere67-ims }}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->

### PRT Results
5.10 - PASS
5.11 - FAILED, like expected