### PR TITLE
[1LP][RFR] Fixing conversion host api for OSP

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -287,9 +287,9 @@ def set_conversion_host_api(
 
     for host in conversion_data["hosts"]:
         conversion_entity = (
-            "vms"
-            if target_provider.one_of(RHEVMProvider) and appliance.version >= '5.11.5'
-            else "hosts"
+            "hosts"
+            if target_provider.one_of(RHEVMProvider) and appliance.version < '5.11.5'
+            else "vms"
         )
         host_id = (
             getattr(appliance.rest_api.collections, conversion_entity).filter(


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

Correcting conversion_entity value, the conversion_entity is always 'vms' for Openstack provider and it is true for all cfme version, however for RHV provider it is "hosts" till 5.11.4.X version and "vms" from 5.11.5 version.

At the moment the conversion_entity is set to "hosts" which breaks OSP related all tests, This PR will correct the same.

    conversion_entity = (
            "hosts"
            if target_provider.one_of(RHEVMProvider) and appliance.version < '5.11.5'
            else "vms"
        )

{{ pytest: cfme/tests/v2v/test_conversion_host_ui.py  -k "test_add_conversion_host_ui_crud" --use-template-cache --provider-limit 2 --use-provider osp13-ims  --use-provider vsphere67-ims }}

The above PRT failing due to issue fixed in this #PR https://github.com/ManageIQ/integration_tests/pull/9979/files
