### PR TITLE
[1LP][RFR] Fix tests

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -488,7 +488,7 @@ class MethodCollection(BaseCollection):
             add_page.validate_button.click()
             add_page.wait_displayed()
             add_page.flash.assert_no_error()
-            add_page.flash.assert_message('Data validated successfully', wait=3)
+            add_page.flash.assert_message('Data validated successfully')
         if cancel:
             add_page.cancel_button.click()
             add_page.flash.assert_no_error()

--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -105,6 +105,8 @@ def _setup_provider_verbose(request, provider, appliance=None):
     if appliance is None:
         appliance = store.current_appliance
     else:
+        # If user wants to add provider to a specific appliance, `appliance` property of
+        # the `provider` must be first changed to that specific appliance.
         provider.appliance = appliance
     try:
         if request.config.option.provider_limit > 0:

--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -104,6 +104,8 @@ def enable_provider_regions(provider):
 def _setup_provider_verbose(request, provider, appliance=None):
     if appliance is None:
         appliance = store.current_appliance
+    else:
+        provider.appliance = appliance
     try:
         if request.config.option.provider_limit > 0:
             existing_providers = [
@@ -147,7 +149,7 @@ def _setup_provider_verbose(request, provider, appliance=None):
         return False
 
 
-def setup_or_skip(request, provider):
+def setup_or_skip(request, provider, appliance=None):
     """ Sets up given provider or skips the test
 
     Note:
@@ -158,7 +160,7 @@ def setup_or_skip(request, provider):
         skip_msg = "Provider {} had been marked as problematic".format(provider.key)
         _artifactor_skip_providers(request, [provider], skip_msg)
 
-    if not _setup_provider_verbose(request, provider):
+    if not _setup_provider_verbose(request, provider, appliance):
         _artifactor_skip_providers(
             request, [provider], "Unable to setup provider {}".format(provider.key))
 
@@ -295,6 +297,19 @@ def setup_provider_clsscope(request, provider):
 def setup_provider_funcscope(request, provider):
     """Function-scoped fixture to set up a provider"""
     return setup_or_skip(request, provider)
+
+
+@pytest.fixture
+def setup_provider_temp_appliance(request, provider, temp_appliance_preconfig_funcscope):
+    """Function-scoped fixture to set up a provider on a temporary appliance"""
+    return setup_or_skip(request, provider, temp_appliance_preconfig_funcscope)
+
+
+@pytest.fixture(scope="module")
+def setup_provider_temp_appliance_modscope(request, provider, temp_appliance_preconfig_modscope):
+    """Module-scoped fixture to set up a provider on a temporary appliance"""
+    return setup_or_skip(request, provider, temp_appliance_preconfig_modscope)
+
 # -----------------------------------------------
 
 

--- a/cfme/intelligence/reports/menus.py
+++ b/cfme/intelligence/reports/menus.py
@@ -152,7 +152,7 @@ class ReportMenu(BaseEntity):
         view.default_button.click()
         view.save_button.click()
         flash_view = self.create_view(AllReportMenusView)
-        assert flash_view.flash.assert_message(
+        flash_view.flash.assert_message(
             'Report Menu for role "{}" was saved'.format(group)
         )
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -818,7 +818,6 @@ def test_display_network_topology(appliance, openstack_provider):
     topology_col = appliance.collections.network_topology_elements
     view = navigate_to(topology_col, 'All')
     assert view.is_displayed
-    view.flash.assert_no_error()
 
 
 @pytest.mark.provider([CloudProvider], scope='class')
@@ -842,6 +841,12 @@ class TestProvidersRESTAPI(object):
         else:
             networks = appliance.rest_api.collections.cloud_networks
         assert_response(appliance)
+        wait_for(
+            lambda: len(networks) != 0,
+            fail_func=provider.refresh_provider_relationships,
+            timeout="40s",
+            silent_failure=True,
+        )
         assert len(networks) > 0, 'No cloud networks found'
         assert networks.name == 'cloud_networks'
         assert len(networks.all) == networks.subcount
@@ -867,6 +872,12 @@ class TestProvidersRESTAPI(object):
             caseimportance: low
             initialEstimate: 1/4h
         """
+        wait_for(
+            lambda: len(provider.rest_api_entity.cloud_networks) != 0,
+            fail_func=provider.refresh_provider_relationships,
+            timeout="40s",
+            silent_failure=True,
+        )
         try:
             network = provider.rest_api_entity.cloud_networks[0]
         except IndexError:

--- a/cfme/tests/configure/test_default_filters.py
+++ b/cfme/tests/configure/test_default_filters.py
@@ -23,7 +23,7 @@ def test_default_filters_reset(appliance):
     node = view.tabs.default_filters.tree.CheckNode(tree_path)
     view.tabs.default_filters.tree.fill(node)
     view.tabs.default_filters.reset.click()
-    assert view.flash.assert_message('All changes have been reset')
+    view.flash.assert_message('All changes have been reset')
 
 
 def test_cloudimage_defaultfilters(appliance):

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -483,7 +483,7 @@ def test_infra_discovery_screen(appliance):
     assert not view.osp_infra.selected
 
     view.start.click()
-    assert view.flash.assert_message("At least 1 item must be selected for discovery")
+    view.flash.assert_message("At least 1 item must be selected for discovery")
 
     view.vmware.click()
     for ips in discovery_ips:

--- a/cfme/tests/infrastructure/test_vm_retirement_rest.py
+++ b/cfme/tests/infrastructure/test_vm_retirement_rest.py
@@ -7,6 +7,7 @@ from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.rest.gen_data import vm as _vm
+from cfme.utils.blockers import BZ
 from cfme.utils.rest import assert_response
 from cfme.utils.wait import wait_for
 
@@ -64,6 +65,7 @@ def vm_retirement_report(appliance, retire_vm):
 @pytest.mark.parametrize(
     "from_collection", [True, False], ids=["from_collection", "from_detail"]
 )
+@pytest.mark.meta(automates=[BZ(1805119)], blockers=[BZ(1805119)])
 def test_retire_vm_now(appliance, vm, from_collection):
     """Test retirement of vm
 
@@ -80,6 +82,9 @@ def test_retire_vm_now(appliance, vm, from_collection):
 
     Metadata:
         test_flag: rest
+
+    Bugzilla:
+        1805119
 
     Polarion:
         assignee: pvala
@@ -111,6 +116,7 @@ def test_retire_vm_now(appliance, vm, from_collection):
 @pytest.mark.parametrize(
     "from_collection", [True, False], ids=["from_collection", "from_detail"]
 )
+@pytest.mark.meta(automates=[BZ(1805119)], blockers=[BZ(1805119)])
 def test_retire_vm_future(appliance, vm, from_collection):
     """Test retirement of vm
 
@@ -127,6 +133,9 @@ def test_retire_vm_future(appliance, vm, from_collection):
 
     Metadata:
         test_flag: rest
+
+    Bugzilla:
+        1805119
 
     Polarion:
         assignee: pvala
@@ -156,6 +165,7 @@ def test_retire_vm_future(appliance, vm, from_collection):
 
 
 @pytest.mark.tier(1)
+@pytest.mark.meta(automates=[BZ(1805119), BZ(1638502)], blockers=[BZ(1805119)])
 def test_check_vm_retirement_requester(
     appliance, request, provider, vm_retirement_report
 ):
@@ -179,6 +189,7 @@ def test_check_vm_retirement_requester(
 
     Bugzilla:
         1638502
+        1805119
     """
     vm_name, report = vm_retirement_report
     saved_report = report.queue(wait_for_finish=True)

--- a/cfme/tests/intelligence/reports/test_reports.py
+++ b/cfme/tests/intelligence/reports/test_reports.py
@@ -181,7 +181,7 @@ def setup_vm(configure_fleecing, appliance, provider):
     vm = appliance.collections.infra_vms.instantiate(
         name=random_vm_name(context="report", max_length=20),
         provider=provider,
-        template_name="env-rhel7-20-percent-full-disk-tpl",
+        template_name="env-rhel7-20-percent-full-disk-pvala-tpl",
     )
     vm.create_on_provider(allow_skip="default", find_in_cfme=True)
     vm.smartstate_scan(wait_for_task_result=True)

--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -1,6 +1,8 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.infrastructure.provider import InfraProvider
+from cfme.markers.env_markers.provider import ONE
 
 pytestmark = [test_requirements.report]
 
@@ -17,7 +19,8 @@ def report(appliance):
 
 
 @pytest.mark.parametrize("filetype", ["txt", "csv", "pdf"])
-def test_download_report(infra_provider, report, filetype):
+@pytest.mark.provider([InfraProvider], selector=ONE, scope="module")
+def test_download_report(setup_provider_modscope, report, filetype):
     """Download the report as a file.
 
     Polarion:

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -590,7 +590,9 @@ def test_infrastructure_provider_left_panel_titles(
 @pytest.mark.ignore_stream("5.10")
 @pytest.mark.parametrize("provider", PROVIDERS)
 @pytest.mark.meta(automates=[1741030, 1783208])
-def test_provider_documentation(temp_appliance_preconfig, provider, request):
+def test_provider_documentation(
+        temp_appliance_preconfig_funcscope, provider, has_no_providers, request
+):
     """
     Bugzilla:
         1741030


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ 
    1. Fix `test_canned_corresponds.py` tests by adding 2 new fixtures `setup_provider_temp_appliance` and `setup_provider_temp_appliance_modscope` to make sure provider is added on the right appliance while using temp appliances in the test.
    2. Fix `test_default_filters_reset` and `test_reset_report_menus` failing because of updates with wt.pf FlashMessages
    3. Block `test_vm_retirement_rest.py` with BZ(1805119)
    4. Fix `test_customization_paginator` by fixing the `AddDialogView::is_displayed`. Also add same fix to `EditDialogView::is_displayed`.
    5. Fix `test_vm_volume_free_space_less_than_20_percent` by restoring the deleted template used by the test.
    6. Fix `TestProvidersRESTAPI` by waiting for the data before testing further.


### PRT Run
{{ pytest: cfme/tests/intelligence/reports/test_canned_corresponds.py cfme/tests/configure/test_default_filters.py::test_default_filters_reset cfme/tests/infrastructure/test_providers.py::test_infra_discovery_screen cfme/tests/infrastructure/test_vm_retirement_rest.py cfme/tests/intelligence/test_download_report.py cfme/tests/webui/test_general_ui.py::test_provider_documentation cfme/tests/intelligence/reports/test_reports.py::test_vm_volume_free_space_less_than_20_percent cfme/tests/cloud/test_providers.py::test_display_network_topology cfme/tests/intelligence/reports/test_menus.py::test_reset_report_menus cfme/tests/cloud/test_providers.py::TestProvidersRESTAPI cfme/tests/automate/test_customization_paginator.py --long-running }}