### PR TITLE
[1LP][RFR] - Fix for SCAP testcase

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -595,11 +595,8 @@ def test_appliance_console_scap(temp_appliance_preconfig, soft_assert):
         initialEstimate: 1/3h
     """
 
-    command_set = ('ap', RETURN, '15', RETURN, RETURN)
-    temp_appliance_preconfig.appliance_console.run_commands(command_set, timeout=30)
-
-    rules_failures = temp_appliance_preconfig.appliance_console.scap_check_rules()
-    assert not rules_failures, "Some rules have failed, check log"
+    temp_appliance_preconfig.appliance_console.scap_harden_appliance()
+    assert not temp_appliance_preconfig.appliance_console.scap_failures()
 
 
 @pytest.mark.tier(1)

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -197,7 +197,7 @@ def test_update_scap_webui(appliance_with_providers, appliance, request, old_ver
         initialEstimate: 1/4h
     """
     appliance_with_providers.appliance_console.scap_harden_appliance()
-    rules_failures = appliance_with_providers.appliance_console.scap_check_rules()
+    rules_failures = appliance_with_providers.appliance_console.scap_failures()
     assert not rules_failures, "Some rules have failed, check log"
     update_appliance(appliance_with_providers)
 
@@ -205,7 +205,7 @@ def test_update_scap_webui(appliance_with_providers, appliance, request, old_ver
              num_sec=900, delay=20, handle_exception=True,
              message='Waiting for appliance to update')
     # Re-harden appliance and confirm rules are applied.
-    rules_failures = appliance_with_providers.appliance_console.scap_check_rules()
+    rules_failures = appliance_with_providers.appliance_console.scap_failures()
     assert not rules_failures, "Some rules have failed, check log"
     # Verify that existing provider can detect new VMs on the second appliance
     virtual_crud = provider_app_crud(VMwareProvider, appliance_with_providers)

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -80,8 +80,8 @@ class ApplianceConsole(AppliancePlugin):
             }))
             interaction.answer('Press any key to continue.', '', timeout=AP_WELCOME_SCREEN_TIMEOUT)
 
-    def scap_check_rules(self):
-        """Check that rules have been applied correctly."""
+    def scap_failures(self):
+        """Return applied scap rules failure list."""
         rules_failures = []
 
         self.appliance.ssh_client.put_file(scripts_path.join('scap.rb'), '/tmp/scap.rb')


### PR DESCRIPTION
Fixed SCAP testcase 
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: ./cfme/tests/cli/test_appliance_console.py::test_appliance_console_scap ./cfme/tests/cli/test_appliance_update.py::test_update_scap_webui  -v}}
