### PR TITLE
[1LP][RFR] Transfer tests to jhenner.

### DIFF
--- a/cfme/test_requirements.py
+++ b/cfme/test_requirements.py
@@ -211,6 +211,12 @@ discovery = pytest.mark.requirement(
     priority='lowest',
 )
 
+ha_proxy = pytest.mark.requirement(
+    "Database HA proxy",
+    description='Database HA proxy and replication',
+    assignee_id='jhenner',
+)
+
 distributed = pytest.mark.requirement(
     "Distributed Appliances",
     description='Distributed Appliance deployment, configuration, and interaction',

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -233,12 +233,13 @@ def test_appliance_console_cli_configure_dedicated_db(unconfigured_appliance, ap
     wait_for(lambda: unconfigured_appliance.db.is_dedicated_active)
 
 
+@test_requirements.ha_proxy
 @pytest.mark.tier(2)
 def test_appliance_console_cli_ha_crud(unconfigured_appliances, app_creds):
     """Tests the configuration of HA with three appliances including failover to standby node
 
     Polarion:
-        assignee: sbulage
+        assignee: jhenner
         caseimportance: high
         casecomponent: Appliance
         initialEstimate: 1h

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -269,6 +269,8 @@ def test_appliance_console_dedicated_db(unconfigured_appliance, app_creds):
     wait_for(lambda: unconfigured_appliance.db.is_dedicated_active)
 
 
+@test_requirements.appliance
+@test_requirements.ha_proxy
 @pytest.mark.tier(2)
 def test_appliance_console_ha_crud(unconfigured_appliances, app_creds):
     """Testing HA configuration with 3 appliances.
@@ -306,9 +308,9 @@ def test_appliance_console_ha_crud(unconfigured_appliances, app_creds):
 
 
     Polarion:
-        assignee: sbulage
+        assignee: jhenner
         caseimportance: high
-        casecomponent: Appliance
+        casecomponent: HAProxy
         initialEstimate: 1h
         testtype: structural
     """
@@ -723,6 +725,7 @@ def test_appliance_console_static_ipv6(unconfigured_appliance, soft_assert):
         "ip -6 r show dev eth0 | grep 'default via 1::f'"))
 
 
+@test_requirements.ha_proxy
 @pytest.mark.manual
 @pytest.mark.tier(2)
 def test_appliance_console_haproxy():
@@ -732,8 +735,8 @@ def test_appliance_console_haproxy():
     tml/high_availability_guide/configuring_haproxy
 
     Polarion:
-        assignee: sbulage
-        casecomponent: Replication
+        assignee: jhenner
+        casecomponent: HAProxy
         caseimportance: medium
         initialEstimate: 1/2h
         setup: setup HA following https://mojo.redhat.com/docs/DOC-1097888
@@ -744,6 +747,7 @@ def test_appliance_console_haproxy():
     pass
 
 
+@test_requirements.ha_proxy
 @pytest.mark.manual
 @pytest.mark.tier(2)
 def test_appliance_console_ha_setup_dc():
@@ -762,8 +766,8 @@ def test_appliance_console_ha_setup_dc():
     majority.
 
     Polarion:
-        assignee: sbulage
-        casecomponent: Replication
+        assignee: jhenner
+        casecomponent: HAProxy
         initialEstimate: 1/2h
         setup: provision 3 appliances
                setup HA following https://mojo.redhat.com/docs/DOC-1097888
@@ -818,6 +822,7 @@ def test_appliance_console_restart(temp_appliance_preconfig_funcscope):
     navigate_to(appliance.server, "LoggedIn")
 
 
+@test_requirements.ha_proxy
 @pytest.mark.manual
 @pytest.mark.tier(2)
 def test_appliance_console_ha_dc_re_establish():
@@ -829,8 +834,8 @@ def test_appliance_console_ha_dc_re_establish():
     tml/high_availability_guide//installation
 
     Polarion:
-        assignee: sbulage
-        casecomponent: Replication
+        assignee: jhenner
+        casecomponent: HAProxy
         initialEstimate: 1/2h
         setup: Restore network connectivity between DC1 and DC2
         startsin: 5.8
@@ -986,6 +991,7 @@ def test_appliance_ssl(appliance):
     assert re.search("hostssl +all +all +all +md5", result.output), "hostssl entry not found"
 
 
+@test_requirements.ha_proxy
 @pytest.mark.manual
 @pytest.mark.tier(2)
 def test_appliance_console_restore_ha_standby_node():
@@ -997,8 +1003,8 @@ def test_appliance_console_restore_ha_standby_node():
     start rh-postgresql95-repmgr` after the restore is finished.
 
     Polarion:
-        assignee: sbulage
-        casecomponent: Replication
+        assignee: jhenner
+        casecomponent: HAProxy
         caseimportance: medium
         initialEstimate: 1/2h
         setup: provision 3 appliances
@@ -1363,6 +1369,7 @@ def test_appliance_console_static_ip_negative(temp_appliance_preconfig_modscope)
         f"old {original_ipv6} IPV6 is not found on console appliance")
 
 
+@test_requirements.ha_proxy
 @pytest.mark.manual
 @pytest.mark.tier(2)
 def test_appliance_console_ha_dc_failover():
@@ -1376,8 +1383,8 @@ def test_appliance_console_ha_dc_failover():
     tml/high_availability_guide//installation
 
     Polarion:
-        assignee: sbulage
-        casecomponent: Replication
+        assignee: jhenner
+        casecomponent: HAProxy
         initialEstimate: 1/2h
         setup: Setup HA
         startsin: 5.8

--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -211,7 +211,7 @@ def test_collect_log_depot(log_depot, appliance, service_request, configured_dep
     Will be extended and improved.
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Configuration
         initialEstimate: 1/4h
         caseimportance: critical
@@ -247,7 +247,7 @@ def test_collect_unconfigured(appliance):
 
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Configuration
         caseimportance: low
         initialEstimate: 1/4h
@@ -279,7 +279,7 @@ def test_collect_multiple_servers(log_depot, temp_appliance_preconfig, depot_mac
 
     """
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Configuration
         initialEstimate: 1/4h
     """
@@ -336,7 +336,7 @@ def test_collect_single_servers(log_depot, appliance, depot_machine_ip, request,
                                 collect_type):
     """
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Configuration
         initialEstimate: 1/4h
     """
@@ -386,7 +386,7 @@ def test_log_collection_over_ipv6(log_depot, depot_machine_ipv4_and_ipv6, applia
     collection succeeds.
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Configuration
         caseimportance: medium
         initialEstimate: 1/4h

--- a/cfme/tests/configure/test_logs.py
+++ b/cfme/tests/configure/test_logs.py
@@ -39,7 +39,7 @@ def test_provider_log_exists(log_exists):
         test_flag: log
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Configuration
         initialEstimate: 1/4h
     """
@@ -58,7 +58,7 @@ def test_provider_log_rotate(appliance, provider, log_exists):
         test_flag: log
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Configuration
     """
@@ -88,7 +88,7 @@ def test_provider_log_updated(appliance, provider, log_exists):
         test_flag: log
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Configuration
     """
@@ -120,7 +120,7 @@ def test_provider_log_level(appliance, provider, log_exists):
         test_flag: log
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Configuration
         testSteps:

--- a/cfme/tests/infrastructure/test_config_management.py
+++ b/cfme/tests/infrastructure/test_config_management.py
@@ -33,7 +33,7 @@ def config_system(provider):
 def test_config_manager_detail_config_btn(provider):
     """
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         caseimportance: medium
         initialEstimate: 1/2h
         casecomponent: Ansible
@@ -45,7 +45,7 @@ def test_config_manager_detail_config_btn(provider):
 def test_config_manager_add(provider):
     """
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         casecomponent: Ansible
         initialEstimate: 1/4h
     """
@@ -56,7 +56,7 @@ def test_config_manager_add(provider):
 def test_config_manager_add_invalid_url(has_no_providers, provider):
     """
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         caseimportance: medium
         initialEstimate: 1/15h
         casecomponent: Ansible
@@ -72,7 +72,7 @@ def test_config_manager_add_invalid_url(has_no_providers, provider):
 def test_config_manager_add_invalid_creds(has_no_providers, provider):
     """
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         caseimportance: medium
         initialEstimate: 1/4h
         casecomponent: Ansible
@@ -92,7 +92,7 @@ def test_config_manager_add_invalid_creds(has_no_providers, provider):
 def test_config_manager_edit(request, provider):
     """
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         caseimportance: medium
         initialEstimate: 1/15h
         casecomponent: Ansible
@@ -110,7 +110,7 @@ def test_config_manager_edit(request, provider):
 def test_config_manager_remove(request, provider):
     """
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         caseimportance: medium
         initialEstimate: 1/15h
         casecomponent: Ansible
@@ -165,7 +165,7 @@ def test_ansible_tower_job_templates_tag(request, provider, tag):
 def test_ansible_tower_service_dialog_creation_from_template(provider, template_type):
     """
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Ansible
         caseimportance: high
@@ -196,7 +196,7 @@ def test_config_manager_add_multiple_times_ansible_tower_243():
     should fail and flash message should be displayed.
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         caseimportance: medium
         caseposneg: negative
         casecomponent: Ansible
@@ -217,7 +217,7 @@ def test_config_manager_job_template_refresh():
     template name was changed.
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         casecomponent: Ansible
         caseimportance: low
         initialEstimate: 1/2h
@@ -237,7 +237,7 @@ def test_config_manager_accordion_tree():
         1560552
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         casecomponent: WebUI
         caseimportance: low
         initialEstimate: 1/4h
@@ -259,7 +259,7 @@ def test_config_manager_remove_objects_ansible_tower_310():
     tower job templates) were left in the UI
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         caseimportance: medium
         casecomponent: Ansible
         initialEstimate: 1/4h
@@ -281,7 +281,7 @@ def test_config_manager_change_zone():
         1353015
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         casecomponent: Provisioning
         caseimportance: medium
         initialEstimate: 1h

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -340,7 +340,7 @@ def test_hosts_not_displayed_several_times(appliance, provider, setup_provider):
     """Tests hosts not displayed several times after removing and adding provider.
 
         Polarion:
-            assignee: anikifor
+            assignee: jhenner
             initialEstimate: 1/20h
             casecomponent: Infra
         """
@@ -527,7 +527,7 @@ def test_add_ipmi_refresh(appliance, setup_provider):
         1669011
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/20h
         caseimportance: medium
         casecomponent: Infra

--- a/cfme/tests/infrastructure/test_iso_datastore.py
+++ b/cfme/tests/infrastructure/test_iso_datastore.py
@@ -32,7 +32,7 @@ def test_iso_datastore_crud(setup_provider, no_iso_dss, provider):
         test_flag: iso
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Infra
         caseimportance: critical

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -346,7 +346,7 @@ def test_provider_rhv_create_delete_tls(request, provider, verify_tls):
 def test_rhv_guest_devices_count(appliance, setup_provider, provider):
     """
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Infra
         caseimportance: high
         initialEstimate: 1/6h
@@ -389,7 +389,7 @@ def test_rhv_custom_attributes_after_refresh(appliance, setup_provider, provider
         1594817
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Infra
         caseimportance: high
         initialEstimate: 1/8h

--- a/cfme/tests/infrastructure/test_publish_vm_to_template.py
+++ b/cfme/tests/infrastructure/test_publish_vm_to_template.py
@@ -57,7 +57,7 @@ def test_publish_vm_to_template(request, vm_crud):
 
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Provisioning
         caseimportance: critical

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -113,7 +113,7 @@ def test_delete_active_vm_snapshot(create_vm):
         1443411
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Infra
         caseimportance: medium
         caseposneg: negative
@@ -136,7 +136,7 @@ def test_create_without_description(create_vm):
         test_flag: snapshot, provision
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Infra
     """

--- a/cfme/tests/infrastructure/test_vm_delete.py
+++ b/cfme/tests/infrastructure/test_vm_delete.py
@@ -33,7 +33,7 @@ def test_delete_vm_on_provider_side(vm_test, provider):
     """ Delete VM on the provider side and refresh relationships in CFME
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Infra
 

--- a/cfme/tests/infrastructure/test_vm_engine_relationship.py
+++ b/cfme/tests/infrastructure/test_vm_engine_relationship.py
@@ -35,7 +35,7 @@ def test_edit_management_relationship(appliance, new_vm):
         1534400
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: WebUI
         caseimportance: high
         initialEstimate: 1/6h

--- a/cfme/tests/networks/test_provision_to_virtual_network.py
+++ b/cfme/tests/networks/test_provision_to_virtual_network.py
@@ -54,7 +54,7 @@ def test_provision_vm_to_virtual_network(appliance, setup_provider, provider,
         test_flag: provision
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         casecomponent: Provisioning
         initialEstimate: 1/4h
     """

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -49,7 +49,7 @@ def test_tower_workflow_item(appliance, ansible_workflow_catitem, workflow_type,
         test_flag: provision
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Services
         caseimportance: high
@@ -77,7 +77,7 @@ def test_retire_ansible_workflow(appliance, ansible_workflow_catitem, workflow_t
         test_flag: provision
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         casecomponent: Services
         caseimportance: medium
         initialEstimate: 1/4h

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -52,7 +52,7 @@ def test_order_tower_catalog_item(appliance, provider, catalog_item, request, jo
         1717500
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Services
         caseimportance: high
@@ -84,7 +84,7 @@ def test_retire_ansible_service(appliance, catalog_item, request, job_type,
         test_flag: provision
 
     Polarion:
-        assignee: nachandr
+        assignee: jhenner
         casecomponent: Services
         caseimportance: medium
         initialEstimate: 1/4h

--- a/cfme/tests/services/test_iso_service_catalogs.py
+++ b/cfme/tests/services/test_iso_service_catalogs.py
@@ -103,7 +103,7 @@ def test_rhev_iso_servicecatalog(appliance, provider, setup_provider, setup_iso_
         test_flag: iso, provision
 
     Polarion:
-        assignee: anikifor
+        assignee: jhenner
         initialEstimate: 1/4h
         casecomponent: Services
     """

--- a/conf/polarion_tools.yaml
+++ b/conf/polarion_tools.yaml
@@ -132,6 +132,7 @@ docstrings:
             - Provisioning
             - Quota
             - Replication
+            - HAProxy
             - Reporting
             - Rest
             - SelfServiceUI


### PR DESCRIPTION
There is naming clash of centralized control (at the moment also
often called Replication) with HA tests, marked as Replication as well.
I belive these are very different features. So I've:

 * Created new polarion marker for the Ha proxy tests.
 * Set polarion markers have been set on the tests.
 * Set the casecomponent to HAProxy on HA proxy related tests.