### PR TITLE
[1LP][RFR] Cover provisioning issues

### DIFF
--- a/cfme/cloud/provider/__init__.py
+++ b/cfme/cloud/provider/__init__.py
@@ -139,6 +139,8 @@ class CloudProvider(BaseProvider, CloudInfraProviderMixin, Pretty, PolicyProfile
     db_types = ["CloudManager"]
     template_class = Image
     collection_name = 'cloud_providers'
+    provisioning_dialog_widget_names = BaseProvider.provisioning_dialog_widget_names.union({
+        'properties', 'volumes', 'customize'})
 
     name = attr.ib(default=None)
     key = attr.ib(default=None)

--- a/cfme/cloud/provider/ec2.py
+++ b/cfme/cloud/provider/ec2.py
@@ -93,6 +93,9 @@ class EC2Provider(CloudProvider):
     region = attr.ib(default=None)
     region_name = attr.ib(default=None)
 
+    provisioning_dialog_widget_names = CloudProvider.provisioning_dialog_widget_names.difference(
+        {'volumes'})
+
     @property
     def view_value_mapping(self):
         """Maps values to view attrs"""

--- a/cfme/common/provider.py
+++ b/cfme/common/provider.py
@@ -101,6 +101,7 @@ class BaseProvider(Taggable, Updateable, Navigatable, BaseEntity, CustomButtonEv
     _param_name = ParamClassName('name')
     STATS_TO_MATCH = []
     db_types = ["Providers"]
+    provisioning_dialog_widget_names = {'request', 'purpose', 'catalog', 'environment', 'schedule'}
     ems_events = []
     settings_key = None
     vm_class = None  # Set on type specific provider classes for VM/instance class

--- a/cfme/infrastructure/provider/__init__.py
+++ b/cfme/infrastructure/provider/__init__.py
@@ -96,6 +96,8 @@ class InfraProvider(BaseProvider, CloudInfraProviderMixin, Pretty, Fillable,
     hosts_menu_item = "Hosts"
     vm_name = "Virtual Machines"
     collection_name = 'infra_providers'
+    provisioning_dialog_widget_names = BaseProvider.provisioning_dialog_widget_names.union(
+        {'hardware', 'network', 'customize'})
 
     name = attr.ib(default=None)
     key = attr.ib(default=None)

--- a/cfme/infrastructure/provider/scvmm.py
+++ b/cfme/infrastructure/provider/scvmm.py
@@ -40,6 +40,8 @@ class SCVMMProvider(InfraProvider):
     settings_key = 'ems_scvmm'
     ui_prov_type = 'Microsoft System Center VMM'
     log_name = 'scvmm'
+    provisioning_dialog_widget_names = (InfraProvider.provisioning_dialog_widget_names
+        - {'environment'} | {'customize'})
 
     @property
     def view_value_mapping(self):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -948,26 +948,7 @@ class InfraVm(VM):
     def clone_vm(self, email=None, first_name=None, last_name=None,
                  vm_name=None, provision_type=None):
         view = navigate_to(self, 'Clone')
-        first_name = first_name or fauxfactory.gen_alphanumeric()
-        last_name = last_name or fauxfactory.gen_alphanumeric()
-        email = email or f"{first_name}@{last_name}.test"
-        try:
-            prov_data = cfme_data["management_systems"][self.provider.key]["provisioning"]
-        except (KeyError, IndexError):
-            raise ValueError("You have to specify the correct options in cfme_data.yaml")
-
-        provisioning_data = {
-            'catalog': {'vm_name': vm_name,
-                        'provision_type': provision_type},
-            'request': {
-                'email': email,
-                'first_name': first_name,
-                'last_name': last_name},
-            'environment': {"host_name": {'name': prov_data.get("host")},
-                            "datastore_name": {"name": prov_data.get("datastore")}},
-            'network': {'vlan': partial_match(prov_data.get("vlan"))},
-        }
-        view.form.fill_with(provisioning_data, on_change=view.form.submit_button)
+        self._fill_clone_form(view, email, first_name, last_name, vm_name, provision_type)
 
     def publish_to_template(self, template_name, email=None, first_name=None, last_name=None):
         view = navigate_to(self, 'Publish')
@@ -1734,6 +1715,15 @@ class SetOwnership(CFMENavigateStep):
     # No am_i_here because the page only indicates name and not provider
     def step(self, *args, **kwargs):
         self.prerequisite_view.toolbar.configuration.item_select('Set Ownership')
+
+
+@navigator.register(InfraTemplate, 'CloneTemplate')
+class TemplateClone(CFMENavigateStep):
+    VIEW = CloneVmView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.toolbar.lifecycle.item_select("Clone this Template")
 
 
 @navigator.register(InfraVm, 'Rename')

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -407,8 +407,6 @@ class RequestDetailsView(RequestsView):
 
     @View.nested
     class properties(WaitTab):  # noqa
-        # Cloud providers only?
-
         instance_type = SummaryFormItem('Properties', 'Instance Type')
         boot_disk_size = SummaryFormItem('Properties', 'Boot Disk Size ')
         is_preemptible = Checkbox(name='hardware__is_preemptible')

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -407,6 +407,8 @@ class RequestDetailsView(RequestsView):
 
     @View.nested
     class properties(WaitTab):  # noqa
+        # Cloud providers only?
+
         instance_type = SummaryFormItem('Properties', 'Instance Type')
         boot_disk_size = SummaryFormItem('Properties', 'Boot Disk Size ')
         is_preemptible = Checkbox(name='hardware__is_preemptible')
@@ -430,6 +432,12 @@ class RequestDetailsView(RequestsView):
         power_on = SummaryFormItem('Lifespan', 'Power on virtual machines after creation')
         retirement = SummaryFormItem('Lifespan', 'Time until Retirement')
         retirement_warning = SummaryFormItem('Lifespan', 'Retirement Warning')
+
+    @View.nested
+    class volumes(WaitTab):  # noqa
+        volume_name = SummaryFormItem('Volumes', 'Volume Name')
+        volume_size = SummaryFormItem('Volumes', 'Size (gigabytes)')
+        delete_on_terminate = Checkbox(name='volumes__delete_on_terminate_1')
 
     @property
     def is_displayed(self):

--- a/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
@@ -14,6 +14,7 @@ from cfme.infrastructure.pxe import get_template_from_config
 from cfme.markers.env_markers.provider import providers
 from cfme.tests.infrastructure.test_provisioning_dialog import check_all_tabs
 from cfme.utils import ssh
+from cfme.utils.blockers import BZ
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
@@ -60,6 +61,7 @@ def vm_name():
 
 @pytest.mark.tier(3)
 @test_requirements.provision
+@pytest.mark.meta(automates=[BZ(1797706)])
 def test_provision_cloud_init(appliance, request, setup_provider, provider, provisioning,
                         setup_ci_template, vm_name):
     """ Tests provisioning from a template with cloud_init
@@ -69,6 +71,7 @@ def test_provision_cloud_init(appliance, request, setup_provider, provider, prov
 
     Bugzilla:
         1619744
+        1797706
 
     Polarion:
         assignee: jhenner

--- a/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
@@ -89,6 +89,7 @@ def test_provision_cloud_init(appliance, request, setup_provider, provider, prov
     # for image selection in before_fill
     inst_args['template_name'] = image
 
+    # TODO Perhaps merge this with stuff in test_provisioning_dialog.prov_data
     if provider.one_of(AzureProvider):
         inst_args['environment'] = {'public_ip_address': "New"}
     if provider.one_of(OpenStackProvider):
@@ -98,6 +99,7 @@ def test_provision_cloud_init(appliance, request, setup_provider, provider, prov
         inst_args['environment'] = {'public_ip_address': floating_ip}
         inst_arg_props = inst_args.setdefault('properties', {})
         inst_arg_props['instance_type'] = partial_match(provisioning['ci-flavor-name'])
+
     if provider.one_of(InfraProvider) and appliance.version > '5.9':
         inst_args['customize']['customize_type'] = 'Specification'
 

--- a/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
@@ -127,7 +127,7 @@ def test_provision_cloud_init(appliance, request, setup_provider, provider, prov
 
 @test_requirements.provision
 @pytest.mark.provider([RHEVMProvider])
-@pytest.mark.meta(automates=[1670327])
+@pytest.mark.meta(automates=[1797706])
 def test_provision_cloud_init_payload(appliance, request, setup_provider, provider, provisioning,
                                       vm_name):
     """

--- a/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py
@@ -12,6 +12,7 @@ from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.infrastructure.pxe import get_template_from_config
 from cfme.markers.env_markers.provider import providers
+from cfme.tests.infrastructure.test_provisioning_dialog import check_all_tabs
 from cfme.utils import ssh
 from cfme.utils.generators import random_vm_name
 from cfme.utils.log import logger
@@ -104,9 +105,11 @@ def test_provision_cloud_init(appliance, request, setup_provider, provider, prov
 
     collection = appliance.provider_based_collection(provider)
     instance = collection.create(vm_name, provider, form_values=inst_args)
+
     request.addfinalizer(instance.cleanup_on_provider)
     provision_request = provider.appliance.collections.requests.instantiate(vm_name,
                                                                    partial_check=True)
+    check_all_tabs(provision_request, provider)
     provision_request.wait_for_request()
     wait_for(lambda: instance.ip_address is not None, num_sec=600)
     connect_ip = instance.ip_address
@@ -122,6 +125,7 @@ def test_provision_cloud_init(appliance, request, setup_provider, provider, prov
 
 @test_requirements.provision
 @pytest.mark.provider([RHEVMProvider])
+@pytest.mark.meta(automates=[1670327])
 def test_provision_cloud_init_payload(appliance, request, setup_provider, provider, provisioning,
                                       vm_name):
     """
@@ -170,6 +174,7 @@ def test_provision_cloud_init_payload(appliance, request, setup_provider, provid
     request.addfinalizer(instance.cleanup_on_provider)
     provision_request = provider.appliance.collections.requests.instantiate(vm_name,
                                                                             partial_check=True)
+    check_all_tabs(provision_request, provider)
     provision_request.wait_for_request()
 
     connect_ip = wait_for(find_global_ipv6, func_args=[instance], num_sec=600, delay=20).out

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -275,7 +275,7 @@ def test_disk_format_select(provisioner, disk_format, provider, prov_data, vm_na
 
 
 @pytest.mark.parametrize("started", [True, False])
-@pytest.mark.meta(automates=[1670327])
+@pytest.mark.meta(automates=[1797706])
 @pytest.mark.provider(gen_func=providers, filters=[all_infra], scope="module")
 def test_power_on_or_off_after_provision(provisioner, prov_data, provider, started, vm_name):
     """ Tests setting the desired power state after provisioning.

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -11,7 +11,6 @@ from widgetastic_patternfly import CheckableBootstrapTreeview as CbTree
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
 from cfme.cloud.provider.azure import AzureProvider
-from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.common import BaseLoggedInPage
 from cfme.infrastructure.provider import InfraProvider
@@ -145,23 +144,7 @@ def provisioner(appliance, request, setup_provider, provider, vm_name):
 def check_all_tabs(provision_request, provider):
     view = navigate_to(provision_request, "Details")
 
-    widget_names = 'request', 'purpose', 'catalog', 'environment', 'schedule'
-    # Note the order of these branch checks is important as, for example,
-    # EC2Provider is subclass of CloudProvider and thus incorrect branch may
-    # get executed.
-    if provider.one_of(EC2Provider):
-        widget_names += 'properties', 'customize'
-    elif provider.one_of(CloudProvider):
-        widget_names += 'properties', 'volumes', 'customize'
-    elif provider.one_of(SCVMMProvider):
-        widget_names += 'environment', 'hardware', 'network'
-    elif provider.one_of(InfraProvider):
-        widget_names += 'hardware', 'network', 'customize'
-    else:
-        raise NotImplementedError(f"Couldn't determine which tabs to check for "
-                                  "this provider: {provider}")
-
-    for name in widget_names:
+    for name in provider.provisioning_dialog_widget_names:
         widget = getattr(view, name)
         widget.click()
         if BZ(1797706).blocks and provider.one_of(RHEVMProvider):

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -144,24 +144,27 @@ def provisioner(appliance, request, setup_provider, provider, vm_name):
 
 def check_all_tabs(provision_request, provider):
     view = navigate_to(provision_request, "Details")
-    widgets_names = 'request', 'purpose', 'catalog', 'environment', 'schedule'
+
+    widget_names = 'request', 'purpose', 'catalog', 'environment', 'schedule'
+    # Note the order of these branch checks is important as, for example,
+    # EC2Provider is subclass of CloudProvider and thus incorrect branch may
+    # get executed.
     if provider.one_of(EC2Provider):
-        widgets_names += 'properties', 'customize'
+        widget_names += 'properties', 'customize'
     elif provider.one_of(CloudProvider):
-        widgets_names += 'properties', 'volumes', 'customize'
+        widget_names += 'properties', 'volumes', 'customize'
     elif provider.one_of(SCVMMProvider):
-        widgets_names += 'environment', 'hardware', 'network'
+        widget_names += 'environment', 'hardware', 'network'
     elif provider.one_of(InfraProvider):
-        widgets_names += 'hardware', 'network', 'customize'
+        widget_names += 'hardware', 'network', 'customize'
     else:
         raise NotImplementedError(f"Couldn't determine which tabs to check for "
                                   "this provider: {provider}")
 
-    for name in widgets_names:
+    for name in widget_names:
         widget = getattr(view, name)
         widget.click()
-        bz_1726590_in_effect = BZ(1797706).blocks and provider.one_of(RHEVMProvider)
-        if bz_1726590_in_effect:
+        if BZ(1797706).blocks and provider.one_of(RHEVMProvider):
             pytest.skip('Skipping as this fails due to BZ 1797706')
         assert widget.is_displayed
 

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -10,6 +10,9 @@ from widgetastic_patternfly import CheckableBootstrapTreeview as CbTree
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
+from cfme.cloud.provider.azure import AzureProvider
+from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.common import BaseLoggedInPage
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
@@ -41,6 +44,13 @@ pytestmark = [
 ]
 
 
+def prov_source(provider):
+    if provider.one_of(CloudProvider):
+        return provider.data['provisioning']['image']['name']
+    else:
+        return provider.data['provisioning']['template']
+
+
 @pytest.fixture(scope="function")
 def vm_name():
     vm_name = random_vm_name('provd')
@@ -49,23 +59,35 @@ def vm_name():
 
 @pytest.fixture(scope="function")
 def prov_data(provisioning, provider):
-    data = {
+    # TODO Perhaps merge this with stuff with test_cloud_init_provisioning.test_provision_cloud_init
+    data = dict(provisioning, **{
         'request': {
             'email': fauxfactory.gen_email(),
             'first_name': fauxfactory.gen_alphanumeric(),
             'last_name': fauxfactory.gen_alphanumeric(),
             'manager_name': fauxfactory.gen_alphanumeric(20, start="manager ")},
-        'network': {'vlan': partial_match(provisioning.get('vlan'))},
         'catalog': {},
         'hardware': {},
         'schedule': {},
         'purpose': {},
-    }
+    })
+
+    mgmt_system = provider.mgmt
 
     if provider.one_of(InfraProvider):
+        data['network'] = {'vlan': partial_match(provisioning.get('vlan'))}
         data['environment'] = {
             'datastore_name': {'name': provisioning['datastore']},
             'host_name': {'name': provisioning['host']}}
+    elif provider.one_of(AzureProvider):
+        data['environment'] = {'public_ip_address': "New"}
+    elif provider.one_of(OpenStackProvider):
+        ip_pool = provider.data['public_network']
+        floating_ip = mgmt_system.get_first_floating_ip(pool=ip_pool)
+        provider.refresh_provider_relationships()
+        data['environment'] = {'public_ip_address': floating_ip}
+        props = data.setdefault('properties', {})
+        props['instance_type'] = partial_match(provisioning['ci-flavor-name'])
 
     if provider.one_of(RHEVMProvider):
         data['catalog']['provision_type'] = 'Native Clone'
@@ -80,12 +102,10 @@ def provisioner(appliance, request, setup_provider, provider, vm_name):
 
     def _provisioner(template, provisioning_data, delayed=None):
         collection = appliance.provider_based_collection(provider)
-        vm = collection.instantiate(name=vm_name, provider=provider, template_name=template)
-
         provisioning_data['template_name'] = template
         provisioning_data['provider_name'] = provider.name
-        view = navigate_to(vm.parent, 'Provision')
-        view.form.fill_with(provisioning_data, on_change=view.form.submit_button)
+        vm = collection.create(vm_name, provider, form_values=provisioning_data)
+
         base_view = vm.appliance.browser.create_view(BaseLoggedInPage)
         base_view.flash.assert_no_error()
 
@@ -125,7 +145,9 @@ def provisioner(appliance, request, setup_provider, provider, vm_name):
 def check_all_tabs(provision_request, provider):
     view = navigate_to(provision_request, "Details")
     widgets_names = 'request', 'purpose', 'catalog', 'environment', 'schedule'
-    if provider.one_of(CloudProvider):
+    if provider.one_of(EC2Provider):
+        widgets_names += 'properties', 'customize'
+    elif provider.one_of(CloudProvider):
         widgets_names += 'properties', 'volumes', 'customize'
     elif provider.one_of(SCVMMProvider):
         widgets_names += 'environment', 'hardware', 'network'
@@ -141,6 +163,7 @@ def check_all_tabs(provision_request, provider):
 
 
 @pytest.mark.meta(blockers=[BZ(1627673, forced_streams=['5.10'])])
+@pytest.mark.provider(gen_func=providers, filters=[all_infra], scope="module")
 def test_change_cpu_ram(provisioner, soft_assert, provider, prov_data, vm_name):
     """ Tests change RAM and CPU in provisioning dialog.
 
@@ -166,12 +189,8 @@ def test_change_cpu_ram(provisioner, soft_assert, provider, prov_data, vm_name):
     prov_data['hardware']["num_sockets"] = "4"
     prov_data['hardware']["cores_per_socket"] = "1" if not provider.one_of(SCVMMProvider) else None
     prov_data['hardware']["memory"] = "2048"
-    if provider.one_of(CloudProvider):
-        template_name = provider.data['provisioning']['image']['name']
-    else:
-        template_name = provider.data['provisioning']['template']
 
-    vm = provisioner(template_name, prov_data)
+    vm = provisioner(prov_source(provider), prov_data)
 
     # Go to the VM info
     view = navigate_to(vm, "Details")
@@ -241,9 +260,8 @@ def test_disk_format_select(provisioner, disk_format, provider, prov_data, vm_na
 
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['hardware']["disk_format"] = disk_format
-    template_name = provider.data['provisioning']['template']
 
-    vm = provisioner(template_name, prov_data)
+    vm = provisioner(prov_source(provider), prov_data)
 
     # Go to the VM info
     view = navigate_to(vm, 'Details')
@@ -258,6 +276,7 @@ def test_disk_format_select(provisioner, disk_format, provider, prov_data, vm_na
 
 @pytest.mark.parametrize("started", [True, False])
 @pytest.mark.meta(automates=[1670327])
+@pytest.mark.provider(gen_func=providers, filters=[all_infra], scope="module")
 def test_power_on_or_off_after_provision(provisioner, prov_data, provider, started, vm_name):
     """ Tests setting the desired power state after provisioning.
 
@@ -282,9 +301,8 @@ def test_power_on_or_off_after_provision(provisioner, prov_data, provider, start
     """
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['schedule']["power_on"] = started
-    template_name = provider.data['provisioning']['template']
 
-    vm = provisioner(template_name, prov_data)
+    vm = provisioner(prov_source(provider), prov_data)
 
     wait_for(
         lambda: vm.exists_on_provider and
@@ -317,9 +335,8 @@ def test_tag(provisioner, prov_data, provider, vm_name):
     """
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['purpose']["apply_tags"] = CbTree.CheckNode(path=("Service Level *", "Gold"))
-    template_name = provider.data['provisioning']['template']
 
-    vm = provisioner(template_name, prov_data)
+    vm = provisioner(prov_source(provider), prov_data)
 
     tags = vm.get_tags()
     assert any(
@@ -363,9 +380,7 @@ def test_provisioning_schedule(provisioner, provider, prov_data, vm_name):
     prov_data['schedule']["provision_start_hour"] = str(provision_time.hour)
     prov_data['schedule']["provision_start_min"] = str(provision_time.minute)
 
-    template_name = provider.data['provisioning']['template']
-
-    provisioner(template_name, prov_data, delayed=provision_time)
+    provisioner(prov_source(provider), prov_data, delayed=provision_time)
 
 
 @pytest.mark.provider([RHEVMProvider],
@@ -399,9 +414,8 @@ def test_provisioning_vnic_profiles(provisioner, provider, prov_data, vm_name, v
     """
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['network'] = {'vlan': vnic_profile}
-    template_name = provider.data['provisioning']['template']
 
-    vm = provisioner(template_name, prov_data)
+    vm = provisioner(prov_source(provider), prov_data)
 
     wait_for(
         lambda: vm.exists_on_provider,
@@ -481,11 +495,10 @@ def test_vmware_default_placement(provisioner, prov_data, provider, setup_provid
         casecomponent: Provisioning
         initialEstimate: 1/4h
     """
-    template_name = provider.data['provisioning']['template']
     prov_data['catalog']['vm_name'] = vm_name
     prov_data['environment'] = {'automatic_placement': True}
 
-    vm = provisioner(template_name, prov_data)
+    vm = provisioner(prov_source(provider), prov_data)
 
     wait_for(
         lambda: vm.exists_on_provider,

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -160,6 +160,9 @@ def check_all_tabs(provision_request, provider):
     for name in widgets_names:
         widget = getattr(view, name)
         widget.click()
+        bz_1726590_in_effect = BZ(1797706).blocks and provider.one_of(RHEVMProvider)
+        if bz_1726590_in_effect:
+            pytest.skip('Skipping as this fails due to BZ 1797706')
         assert widget.is_displayed
 
 

--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -160,6 +160,7 @@ def check_all_tabs(provision_request, provider):
     for name in widgets_names:
         widget = getattr(view, name)
         widget.click()
+        assert widget.is_displayed
 
 
 @pytest.mark.meta(blockers=[BZ(1627673, forced_streams=['5.10'])])

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -91,7 +91,7 @@ def test_template_clone(request, appliance, provider, clone_vm_name):
         provision_type = 'Native Clone'
 
     @request.addfinalizer
-    def template_clone_deltion():
+    def template_clone_cleanup():
         collections = appliance.collections
         if BZ(1797733).blocks:
             cloned_template = collections.infra_vms.instantiate(clone_vm_name, provider)


### PR DESCRIPTION
We got some bugs related to nil deference on provisioning request dialog.

This PR is adding checks to existing tests. These checks are doing clicking trough the request tabs to verify they do display fine.

{pytest: cfme/tests/test_foo_file.py -v cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py cfme/tests/infrastructure/test_provisioning_dialog.py cfme/tests/infrastructure/test_vm_clone.py}

### Local runs and test failures advocacy
cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py::test_provision_cloud_init[openstack-13] PASSED

The cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py/test_provision_cloud_init[ec2] seems to be failing because Fedora image is not present on the EC2. It can be fixed in yamls.