### PR TITLE
[1LP][RFR] Adding stack bundle retire test

### DIFF
--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -491,35 +491,6 @@ def test_service_dd_dialog_load_values_on_init(appliance, import_datastore, impo
     assert not view.fields("text_box").read()
 
 
-@pytest.mark.meta(coverage=[1684092])
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_retire_catalog_bundle_service_orchestration_item():
-    """
-
-    Bugzilla:
-        1684092
-
-    Polarion:
-        assignee: nansari
-        startsin: 5.10
-        casecomponent: Services
-        initialEstimate: 1/6h
-        testSteps:
-            1. Add ec2 provider
-            2. Provisioned the catalog bundle with ServiceOrchestration item
-            3. Navigate to My service page
-            4. Retired the bundle
-        expectedResults:
-            1.
-            2.
-            3.
-            4. Catalog bundle should retire with no error
-
-    """
-    pass
-
-
 @pytest.mark.meta(coverage=[1656351])
 @pytest.mark.manual
 @pytest.mark.tier(2)


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_provision_stack.py::test_retire_catalog_bundle_service_orchestration_item --long-running   --use-provider ec2west -vvvv }}

It fails on 5.11. we have open bz: 1754543
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
