### PR TITLE
[1LP][RFR] - Service Dialog test

### DIFF
--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -55,6 +55,7 @@ class ElementForm(AddBoxView):
         )
         field_required = DialogBootstrapSwitch(label='Required')
         default_value = DialogBootstrapSwitch(label='Default value')
+        load_values_on_init = DialogBootstrapSwitch(label='Load values on init')
         default_value_dropdown = BootstrapSelect(
             locator='//label[contains(normalize-space(.), '
                     '"Default value")]/following-sibling::div/span/div'

--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -703,10 +703,9 @@ def test_access_child_services_from_the_my_service():
     pass
 
 
-@pytest.mark.meta(coverage=[1684575])
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_load_values_on_init_option_service_dialog_element():
+@pytest.mark.ignore_stream("5.10")
+@pytest.mark.meta(automates=[1684575])
+def test_catalog_load_values_on_init(appliance, request):
     """
 
     Bugzilla:
@@ -718,13 +717,36 @@ def test_load_values_on_init_option_service_dialog_element():
         casecomponent: Services
         initialEstimate: 1/16h
         testSteps:
-            1. create a service dialog
+            1. create a service dialog with option dynamic to True
             2. In service dialog element option page
         expectedResults:
             1.
             2. Load_values_on_init button should always be enabled
     """
-    pass
+    element_data = {
+        "element_information": {
+            "ele_label": fauxfactory.gen_alphanumeric(start="label_"),
+            "ele_name": fauxfactory.gen_alphanumeric(start="name_"),
+            "ele_desc": fauxfactory.gen_alphanumeric(start="desc_"),
+            "choose_type": "Text Box",
+            "dynamic_chkbox": True
+        },
+        "options": {"field_required": True}
+    }
+    service_dialog = appliance.collections.service_dialogs
+    sd = service_dialog.create(label=fauxfactory.gen_alphanumeric(15, start="label_"),
+                               description="my dialog")
+    tab = sd.tabs.create(tab_label=fauxfactory.gen_alphanumeric(start="tab_"),
+                         tab_desc="my tab desc")
+    box = tab.boxes.create(box_label=fauxfactory.gen_alphanumeric(start="box_"),
+                           box_desc="my box desc")
+    box.elements.create(element_data=[element_data])
+    request.addfinalizer(sd.delete_if_exists)
+    view = appliance.browser.create_view(EditElementView)
+    view.element.edit_element(element_data['element_information']['ele_label'])
+    assert view.element_information.dynamic_chkbox.is_enabled
+    view.options.click()
+    assert view.options.load_values_on_init.is_enabled
 
 
 @pytest.mark.meta(coverage=[1677724])


### PR DESCRIPTION
**Adding new test -** Test to check `Load values on init` option in service dialog when `Dynamix` box enable
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_catalog_load_values_on_init  --long-running -v}}