### PR TITLE
[1LP][RFR] Adding multi_drop down service dialog test

### DIFF
--- a/cfme/services/service_catalogs/__init__.py
+++ b/cfme/services/service_catalogs/__init__.py
@@ -63,6 +63,8 @@ class BaseOrderForm(View):
             ".//div[contains(@class, 'bootstrap-select')]/select[@id={key|quote}]/.."))
         param_dropdown = BootstrapSelect(locator=ParametrizedLocator(
             ".//div[contains(@class, 'bootstrap-select')]/select[@id='param_{key}']/.."))
+        multi_drop = BootstrapSelect(locator=ParametrizedLocator(
+            ".//div[contains(@class, 'bootstrap-select')]/select[@input-id={key|quote}]/.."))
         checkbox = Checkbox(id=Parameter("key"))
         refresh = Text(
             locator=ParametrizedLocator(

--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -990,10 +990,10 @@ def test_datepicker_in_service_request():
     pass
 
 
-@pytest.mark.meta(coverage=[1740823])
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_dialog_dropdown_integer_required():
+@pytest.mark.meta(automates=[1740823])
+@pytest.mark.customer_scenario
+@pytest.mark.parametrize("file_name", ["bz_1740823.yml"], ids=["sample_dialog"],)
+def test_multi_dropdown_dialog_value(appliance, generic_catalog_item_with_imported_dialog):
     """
     Bugzilla:
         1740823
@@ -1003,20 +1003,27 @@ def test_dialog_dropdown_integer_required():
         casecomponent: Services
         initialEstimate: 1/16h
         startsin: 5.10
-        testSteps:
-            1. Create a multi select dropdown using the default "One, Two, Three" values.
-            2. Add dialog to catalog item
-            3. Order the new item
-            4. Go to your multi select dropdown and choose the value "<None>"
-            5. Select additional options, notice that displayed list of choices includes "<None>"
+    testSteps:
+            1. Create a multi select dropdown with values "One, Two, Three"
+            2. Add catalog item
+            3. Go to service order page
+            4. Check the values in dropdown
+            5. Check the "<None>" in multi drop down list
         expectedResults:
             1.
             2.
             3.
-            4.
-            5. "<None>" should not be displayed in the list of selected options
+            4. "One, Two, Three" should be present in list
+            5. "<None>" should not be displayed in the list
     """
-    pass
+    catalog_item, sd, ele_label = generic_catalog_item_with_imported_dialog
+
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    view = navigate_to(service_catalogs, "Order")
+
+    options_list = [option.text for option in view.fields(ele_label).multi_drop.all_options]
+    assert all([opt in options_list for opt in ["One", "Two", "Three"]])
+    assert "<None>" not in options_list
 
 
 @pytest.mark.tier(2)


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run

{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_multi_dropdown_dialog_value  }}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
