### PR TITLE
[1LP][RFR]Test delete cloud provider dashboard after network provider delete

### DIFF
--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -272,7 +272,7 @@ class NetworkProvider(BaseProvider, Taggable):
         """
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Remove this Network Provider from Inventory',
-                                               handle_alert=True)
+                                               handle_alert=not cancel)
         if not cancel:
             msg = ('Delete initiated for 1 Network Provider from the {} Database'.format(
                 self.appliance.product_name))

--- a/cfme/networks/provider/__init__.py
+++ b/cfme/networks/provider/__init__.py
@@ -272,7 +272,7 @@ class NetworkProvider(BaseProvider, Taggable):
         """
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select('Remove this Network Provider from Inventory',
-                                               handle_alert=not cancel)
+                                               handle_alert=True)
         if not cancel:
             msg = ('Delete initiated for 1 Network Provider from the {} Database'.format(
                 self.appliance.product_name))

--- a/cfme/storage/manager.py
+++ b/cfme/storage/manager.py
@@ -157,12 +157,12 @@ class StorageManager(BaseEntity, CustomButtonEventsMixin, Taggable, PolicyProfil
         if not cancel:
             view.flash.assert_no_error()
 
-    def delete(self):
+    def delete(self, cancel=False):
         """Delete storage manager"""
         view = navigate_to(self, 'Details')
         view.toolbar.configuration.item_select(
             f'Remove this {self.storage_title} from Inventory',
-            handle_alert=True
+            handle_alert=not cancel
         )
 
         view = self.create_view(StorageManagerDetailsView)

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1564,17 +1564,38 @@ def test_provider_compare_ec2_provider_and_backup_regions(appliance):
     assert regions_provider_texts == regions_immediate_backup_texts
 
 
+@test_requirements.cloud
+@pytest.mark.meta(automates=[1632750], blockers=[BZ(1632750,
+                                                 unblock=lambda child_provider: "object_managers"
+                                                 in child_provider)])
 @pytest.mark.uncollectif(lambda child_provider, provider:
                         (provider.one_of(EC2Provider) and "object_managers" in child_provider) or
                         (provider.one_of(AzureProvider) and ("object_managers" or "block_managers"
                                                              in child_provider)),
                         reason="Storage is not supported by AzureProvider "
                                "and Object Storage is not supported by EC2Provider")
-
 @test_requirements.cloud
 @pytest.mark.provider([AzureProvider, EC2Provider, OpenStackProvider], scope="function")
 def test_cloud_provider_dashboard_after_child_provider_remove(
         appliance, provider, request, setup_provider_funcscope, child_provider):
+    """
+        Bugzilla: 1632750
+
+        Polarion:
+        assignee: mmojzis
+        casecomponent: Cloud
+        initialEstimate: 1/6h
+        caseimportance: high
+        casecomponent: Cloud
+        testSteps:
+            1. Have a cloud provider added
+            2. Delete one of its child managers
+            3. Go to cloud provider Dashboard
+        expectedResults:
+            1.
+            2.
+            3. Dashboard should load without any issues
+    """
     child_provider.delete()
 
     @request.addfinalizer
@@ -1584,8 +1605,5 @@ def test_cloud_provider_dashboard_after_child_provider_remove(
 
     view = navigate_to(provider, "Details")
     view.toolbar.view_selector.select('Dashboard View')
-    try:
-        view.flash.wait_displayed(timeout=10)
-    except Exception:
-        pass
+    view.wait_displayed()
     view.flash.assert_no_error()

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1504,7 +1504,9 @@ def test_add_second_provider(setup_provider, provider, request):
 @pytest.mark.ignore_stream("5.10")  # BZ 1710623 was not merged into 5.10
 def test_provider_compare_ec2_provider_and_backup_regions(appliance):
     """
-    Bugzilla: 1710599, 1710623
+    Bugzilla:
+        1710599
+        1710623
     Polarion:
         assignee: mmojzis
         casecomponent: Cloud
@@ -1549,3 +1551,14 @@ def test_provider_compare_ec2_provider_and_backup_regions(appliance):
 
     assert regions_provider_texts == regions_scheduled_backup_texts
     assert regions_provider_texts == regions_immediate_backup_texts
+
+
+@pytest.mark.provider([EC2Provider, OpenStackProvider], scope="function", override=True,
+                      selector=ONE)
+@test_requirements.cloud
+def test_cloud_provider_dashboard_after_block_storage_provider_delete(appliance, provider):
+    storage_manager = appliance.collections.block_managers.filter({'provider': provider}).all()[0]
+    storage_manager.delete()
+    view = navigate_to(provider, "Details")
+    view.toolbar.view_selector.select('Dashboard View')
+    view.flash.assert_no_error

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1569,9 +1569,9 @@ def test_provider_compare_ec2_provider_and_backup_regions(appliance):
                                                  unblock=lambda child_provider: "object_managers"
                                                  in child_provider)])
 @pytest.mark.uncollectif(lambda child_provider, provider:
-                        (provider.one_of(EC2Provider) and "object_managers" in child_provider) or
-                        (provider.one_of(AzureProvider) and ("object_managers" or "block_managers"
-                                                             in child_provider)),
+                        (provider.one_of(EC2Provider) and (child_provider == "object_managers")) or
+                        (provider.one_of(AzureProvider) and (child_provider !=
+                                                             'network_providers')),
                         reason="Storage is not supported by AzureProvider "
                                "and Object Storage is not supported by EC2Provider")
 @test_requirements.cloud
@@ -1596,8 +1596,10 @@ def test_cloud_provider_dashboard_after_child_provider_remove(
             2.
             3. Dashboard should load without any issues
     """
-    child_provider.delete()
+    child_provider.delete(cancel=False)
 
+    # Sometimes provider was not deleted so this preventing to use provider without child providers
+    # to be used in next tests
     @request.addfinalizer
     def _wait_for_delete_provider():
         provider.delete()


### PR DESCRIPTION
Added test coverage for BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1632750
{{ pytest: -k "test_cloud_provider_dashboard_after_child_provider_remove" -v}}