### PR TITLE
[1LP][RFR] Adding service dialog multi drop test

### DIFF
--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -62,7 +62,7 @@ class ElementForm(AddBoxView):
         field_past_dates = DialogBootstrapSwitch(label='Show Past Dates')
         field_category = Select(
             locator='.//select[../../../../label[normalize-space(text())="Category"]]')
-
+        multi_select = DialogBootstrapSwitch(label='Multiselect')
         validation_switch = DialogBootstrapSwitch(label='Validation')
         validation = Input(name='validator_rule')
         visible = DialogBootstrapSwitch(label='Visible')

--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -404,23 +404,6 @@ def test_in_dynamic_dropdown_list_the_default_value_should_not_contain_all_the_v
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_saving_service_dialog_with_multi_select_drop_down_populated_by_expression_method():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1559030
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_cui_should_check_dialog_field_associations():
     """


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_save_dynamic_multi_drop_down_dialog }}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
