### PR TITLE
[1LP][RFR] Move distributed and replicated appliance configuration to fixtures

### DIFF
--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -8,7 +8,6 @@ from wait_for import wait_for
 from cfme import test_requirements
 from cfme.cloud.provider.ec2 import EC2Provider
 from cfme.fixtures.cli import provider_app_crud
-from cfme.fixtures.cli import replicated_appliances_with_providers
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.appliance.console import configure_appliances_ha
 from cfme.utils.appliance.console import waiting_for_ha_monitor_started
@@ -348,7 +347,7 @@ def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansi
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream('upstream')
 def test_appliance_console_restore_pg_basebackup_replicated(
-        request, temp_appliances_unconfig_funcscope_rhevm):
+        request, replicated_appliances_with_providers):
     """
     Polarion:
         assignee: jhenner
@@ -357,7 +356,7 @@ def test_appliance_console_restore_pg_basebackup_replicated(
         initialEstimate: 1/2h
         upstream: no
     """
-    appl1, appl2 = replicated_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm)
+    appl1, appl2 = replicated_appliances_with_providers
     appl1.db.backup()
     appl2.db.backup()
 
@@ -435,7 +434,7 @@ def test_appliance_console_restore_db_external(request, get_ext_appliances_with_
 @pytest.mark.tier(2)
 @pytest.mark.ignore_stream('upstream')
 def test_appliance_console_restore_db_replicated(
-        request, temp_appliances_unconfig_funcscope_rhevm):
+        request, replicated_appliances_with_providers):
     """
     Polarion:
         assignee: jhenner
@@ -443,7 +442,7 @@ def test_appliance_console_restore_db_replicated(
         casecomponent: Configuration
         initialEstimate: 1h
     """
-    appl1, appl2 = replicated_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm)
+    appl1, appl2 = replicated_appliances_with_providers
     appl1.db.backup()
     appl2.db.backup()
     providers_before_restore = set(appl1.managed_provider_names)

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -6,7 +6,6 @@ import pytest
 from cfme.fixtures.cli import do_appliance_versions_match
 from cfme.fixtures.cli import provider_app_crud
 from cfme.fixtures.cli import provision_vm
-from cfme.fixtures.cli import replicated_appliances_with_providers
 from cfme.fixtures.cli import update_appliance
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.test_framework.sprout.client import AuthException
@@ -288,8 +287,8 @@ def test_update_distributed_webui(ext_appliances_with_providers, appliance,
 
 
 @pytest.mark.ignore_stream("upstream")
-def test_update_replicated_webui(multiple_preupdate_appliances, appliance, request,
-                                 old_version, soft_assert):
+def test_update_replicated_webui(replicated_appliances_preupdate_with_providers, appliance,
+        request, old_version, soft_assert):
     """ Tests updating an appliance with providers, also confirms that the
             provisioning continues to function correctly after the update has completed
 
@@ -299,7 +298,7 @@ def test_update_replicated_webui(multiple_preupdate_appliances, appliance, reque
         casecomponent: Appliance
         initialEstimate: 1/4h
     """
-    preupdate_appls = replicated_appliances_with_providers(multiple_preupdate_appliances)
+    preupdate_appls = replicated_appliances_preupdate_with_providers
     providers_before_upgrade = set(preupdate_appls[0].managed_provider_names)
     update_appliance(preupdate_appls[0])
     update_appliance(preupdate_appls[1])


### PR DESCRIPTION
The configuration of database replication (global/remote appliances) or distributed (primary/secondary) appliances in cfme/tests/distributed/test_appliance_replication.py has been moved to the replicated_appliances and distributed_appliances fixtures in cfme/fixtures/cli.py.

The existing fixture replicated_appliances_with_providers has uses the new fixture replicated_appliances, and the new fixtures replicated_appliances_preupdate and replicated_appliances_preupdate_with_providers have been added for use by test_appliance_console_restore_db_replicated.

{{ pytest: --long-running -k 'test_appliance_replicate_between_regions or test_external_database_appliance or test_appliance_console_restore_db_replicated or test_update_replicated_webui' cfme/tests/distributed/test_appliance_replication.py cfme/tests/cli/test_appliance_console_db_restore.py cfme/tests/cli/test_appliance_update.py -vv }}