### PR TITLE
[1LP][RFR] Adding dropdown descending value test

### DIFF
--- a/cfme/tests/services/test_dynamicdd_dialogelement.py
+++ b/cfme/tests/services/test_dynamicdd_dialogelement.py
@@ -208,21 +208,40 @@ def test_dynamic_submit_cancel_button_service(request, appliance, generic_servic
     wait_for(lambda: not (view.submit.disabled and view.cancel.disabled), timeout=120)
 
 
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_drop_down_dialog_should_honor_the_order_of_values_as_they_are_inputted():
+@pytest.mark.meta(automates=[1593874])
+@pytest.mark.customer_scenario
+@pytest.mark.parametrize("file_name", ["bz_1594268.yml"], ids=["sample_dialog"],)
+def test_dropdown_dialog_descending_values(appliance, generic_catalog_item_with_imported_dialog):
     """
+    Bugzilla:
+        1593874
+
     Polarion:
         assignee: nansari
         casecomponent: Services
         initialEstimate: 1/16h
-        testtype: functional
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1593874
+        startsin: 5.10
+    testSteps:
+            1. Create a dropdown dialog with values 'X', 'S', 'A', 'B'
+            2. 'Sort by' is set to 'None'
+            3. Add catalog item
+            4. Go to service order page
+            5. Check the values in dropdown
+    expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5. Drop down list should not be sorted
     """
-    pass
+    catalog_item, sd, ele_label = generic_catalog_item_with_imported_dialog
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    value = ['<None>', 'X', 'S', 'A', 'B']
+
+    view = navigate_to(service_catalogs, "Order")
+    options_list = [option.text for option in view.fields(ele_label).dropdown.all_options]
+
+    assert options_list == value
 
 
 @pytest.mark.manual


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dynamicdd_dialogelement.py::test_dropdown_dialog_descending_values  -vvvv --long-running  }}


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
