### PR TITLE
[RFR] v2v : Add alert attribute to InfrastructureMappingView

### DIFF
--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -523,7 +523,7 @@ def test_duplicate_plan_name(appliance, mapping_data_vm_obj_mini, provider, requ
     view.general.infra_map.fill(mapping_data_vm_obj_mini.infra_mapping_data.get("name"))
     view.general.name.fill(name)
     view.general.description.fill("description")
-    assert view.general.alert.read() == "Name {name} already exists".format(name=name)
+    assert view.general.alert.read() == f"Name {name} already exists"
     view.cancel_btn.click()
 
 
@@ -551,7 +551,7 @@ def test_duplicate_mapping_name(appliance, mapping_data_vm_obj_mini):
     view = navigate_to(infrastructure_mapping_collection, "Add")
     view.general.name.fill(name)
     view.general.description.fill("description")
-    view.general.flash.assert_message(f"Infrastructure mapping {name} already exists")
+    assert view.general.alert.read() == f"Infrastructure mapping {name} already exists"
     view.general.cancel_btn.click()
 
 

--- a/cfme/v2v/infrastructure_mapping.py
+++ b/cfme/v2v/infrastructure_mapping.py
@@ -54,6 +54,7 @@ class InfraMappingCommonButtons(InfrastructureMappingView):
     remove_mapping = Button("Remove Selected")
     remove_all_mappings = Button("Remove All")
     mappings_tree = InfraMappingTreeView(tree_class="treeview")
+    alert = Text('.//div[contains(@class, "alert")]')
 
 
 class ComponentView(View):


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{ pytest: cfme/tests/v2v/test_v2v_migrations_ui.py --use-template-cache --provider-limit 2 --use-provider={osp13-ims,rhv43} --use-provider vsphere67-ims -k duplicate}}

