### PR TITLE
[RFR] v2v: Fix parametrization of test_migrations_different_os_templates

### DIFF
--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -51,7 +51,7 @@ def test_single_datastore_single_vm_migration(request, appliance, provider,
     """
     Test VM migration with single datastore
     Polarion:
-        assignee: sshveta
+        assignee: nachandr
         caseimportance: medium
         caseposneg: positive
         testtype: functional
@@ -106,7 +106,7 @@ def test_single_network_single_vm_migration(request, appliance, provider,
                                             mapping_data_vm_obj_single_network):
     """
     Polarion:
-        assignee: sshveta
+        assignee: nachandr
         caseimportance: high
         caseposneg: positive
         testtype: functional
@@ -150,7 +150,7 @@ def test_dual_datastore_dual_vm_migration(request, appliance, provider,
                                           soft_assert):
     """
     Polarion:
-        assignee: sshveta
+        assignee: nachandr
         caseimportance: high
         caseposneg: positive
         testtype: functional
@@ -196,7 +196,7 @@ def test_dual_nics_migration(request, appliance, provider,
                              mapping_data_vm_obj_dual_nics):
     """
     Polarion:
-        assignee: sshveta
+        assignee: nachandr
         caseimportance: medium
         caseposneg: positive
         testtype: functional
@@ -240,7 +240,7 @@ def test_dual_disk_vm_migration(request, appliance, provider,
                                 mapping_data_vm_obj_single_datastore):
     """
     Polarion:
-        assignee: sshveta
+        assignee: nachandr
         caseimportance: high
         caseposneg: positive
         testtype: functional

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -280,12 +280,12 @@ def test_dual_disk_vm_migration(request, appliance, provider,
 @pytest.mark.parametrize(
     "source_type, dest_type, template_type",
     [
-        ["nfs", "nfs", Templates.WIN7_TEMPLATE],
-        ["nfs", "nfs", Templates.WIN10_TEMPLATE],
-        ["nfs", "nfs", Templates.WIN2016_TEMPLATE],
-        ["nfs", "nfs", Templates.RHEL69_TEMPLATE],
-        ["nfs", "nfs", Templates.WIN2012_TEMPLATE],
-        ["nfs", "nfs", Templates.UBUNTU16_TEMPLATE],
+        ["nfs", "nfs", [Templates.WIN7_TEMPLATE]],
+        ["nfs", "nfs", [Templates.WIN10_TEMPLATE]],
+        ["nfs", "nfs", [Templates.WIN2016_TEMPLATE]],
+        ["nfs", "nfs", [Templates.RHEL69_TEMPLATE]],
+        ["nfs", "nfs", [Templates.WIN2012_TEMPLATE]],
+        ["nfs", "nfs", [Templates.UBUNTU16_TEMPLATE]],
     ]
 )
 def test_migrations_different_os_templates(request, appliance, provider,
@@ -294,7 +294,7 @@ def test_migrations_different_os_templates(request, appliance, provider,
                                            soft_assert):
     """
     Polarion:
-        assignee: sshveta
+        assignee: nachandr
         caseimportance: high
         caseposneg: positive
         testtype: functional

--- a/cfme/tests/v2v/test_v2v_migrations.py
+++ b/cfme/tests/v2v/test_v2v_migrations.py
@@ -286,7 +286,9 @@ def test_dual_disk_vm_migration(request, appliance, provider,
         ["nfs", "nfs", [Templates.RHEL69_TEMPLATE]],
         ["nfs", "nfs", [Templates.WIN2012_TEMPLATE]],
         ["nfs", "nfs", [Templates.UBUNTU16_TEMPLATE]],
-    ]
+    ],
+    ids=[Templates.WIN7_TEMPLATE, Templates.WIN10_TEMPLATE, Templates.WIN2016_TEMPLATE,
+         Templates.RHEL69_TEMPLATE, Templates.WIN2012_TEMPLATE, Templates.UBUNTU16_TEMPLATE]
 )
 def test_migrations_different_os_templates(request, appliance, provider,
                                            source_type, dest_type, template_type,


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{ pytest: cfme/tests/v2v/test_v2v_migrations.py --use-template-cache --provider-limit 2 --use-provider=rhv43 --use-provider vsphere67-ims -k test_migrations_different_os_templates}}
-->
### PRT Results:
511 - PASS
510 - few tests failed because of an Error at teardown while deleting Infra mapping. This failure happens intermittently.