### PR TITLE
[1LP][RFR] Removed test test_bundles_in_bundle

### DIFF
--- a/cfme/tests/services/test_generic_service_catalogs.py
+++ b/cfme/tests/services/test_generic_service_catalogs.py
@@ -66,32 +66,6 @@ def test_delete_catalog_item_deletes_service(appliance, catalog_item):
         service_catalogs.order()
 
 
-@pytest.mark.ignore_stream("5.10")
-def test_service_circular_reference(appliance, catalog_item):
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        caseimportance: medium
-        initialEstimate: 1/8h
-        tags: service
-    """
-    bundle_name = fauxfactory.gen_alphanumeric(start="first_")
-    catalog_bundle = appliance.collections.catalog_bundles.create(
-        bundle_name, description="catalog_bundle",
-        display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
-        catalog_items=[catalog_item.name])
-    sec_bundle_name = fauxfactory.gen_alphanumeric(start="sec_")
-    sec_catalog_bundle = appliance.collections.catalog_bundles.create(
-        sec_bundle_name, description="catalog_bundle",
-        display_in=True, catalog=catalog_item.catalog,
-        dialog=catalog_item.dialog, catalog_items=[bundle_name])
-    msg = ("Error during 'Resource Add': Adding resource <{}> to Service <{}> "
-           "will create a circular reference".format(sec_bundle_name, bundle_name))
-    with pytest.raises(Exception, match=msg):
-        catalog_bundle.update({'catalog_items': sec_catalog_bundle.name})
-
-
 def test_service_generic_catalog_bundle(appliance, catalog_item):
     """
     Polarion:
@@ -110,42 +84,6 @@ def test_service_generic_catalog_bundle(appliance, catalog_item):
     service_catalogs.order()
     logger.info('Waiting for cfme provision request for service %s', bundle_name)
     request_description = bundle_name
-    provision_request = appliance.collections.requests.instantiate(request_description,
-                                                                   partial_check=True)
-    provision_request.wait_for_request()
-    msg = "Request failed with the message {}".format(provision_request.rest.message)
-    assert provision_request.is_succeeded(), msg
-
-
-@pytest.mark.ignore_stream("5.10")
-def test_bundles_in_bundle(appliance, catalog_item):
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        caseimportance: low
-        initialEstimate: 1/8h
-        tags: service
-    """
-    bundle_name = fauxfactory.gen_alphanumeric(start="first_")
-    appliance.collections.catalog_bundles.create(
-        bundle_name, description="catalog_bundle",
-        display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
-        catalog_items=[catalog_item.name])
-    sec_bundle_name = fauxfactory.gen_alphanumeric(start="sec_")
-    appliance.collections.catalog_bundles.create(
-        sec_bundle_name, description="catalog_bundle",
-        display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
-        catalog_items=[bundle_name])
-    third_bundle_name = fauxfactory.gen_alphanumeric(start="third_")
-    third_catalog_bundle = appliance.collections.catalog_bundles.create(
-        third_bundle_name, description="catalog_bundle",
-        display_in=True, catalog=catalog_item.catalog, dialog=catalog_item.dialog,
-        catalog_items=[bundle_name, sec_bundle_name])
-    service_catalogs = ServiceCatalogs(appliance, third_catalog_bundle.catalog, third_bundle_name)
-    service_catalogs.order()
-    logger.info('Waiting for cfme provision request for service %s', bundle_name)
-    request_description = third_bundle_name
     provision_request = appliance.collections.requests.instantiate(request_description,
                                                                    partial_check=True)
     provision_request.wait_for_request()


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
Adding bundle in bundle not supported any more in 5.11 as well
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
