### PR TITLE
[1LP][RFR] Automating default non required value drop dialog

### DIFF
--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -1180,3 +1180,33 @@ def test_save_dynamic_multi_drop_down_dialog(appliance, import_datastore, import
     # no error should be displayed
     view = sd.create_view(DetailsDialogView, wait="60s")
     view.flash.assert_success_message(f'{sd.label} was saved')
+
+
+@pytest.mark.meta(automates=[1783375])
+@pytest.mark.customer_scenario
+@pytest.mark.parametrize("file_name", ["bz_1783375.yml"], ids=["sample_dialog"],)
+def test_dialog_not_required_default_value(appliance, generic_catalog_item_with_imported_dialog,
+                                           file_name):
+    """
+    Bugzilla:
+        1783375
+    Polarion:
+        assignee: nansari
+        casecomponent: Services
+        initialEstimate: 1/16h
+        startsin: 5.10
+    """
+    catalog_item, _, ele_label = generic_catalog_item_with_imported_dialog
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+
+    # download yaml file
+    fs = FTPClientWrapper(cfme_data.ftpserver.entities.dialogs)
+    file_path = fs.download(file_name)
+    with open(file_path, "r") as stream:
+        dialog_data = yaml.load(stream, Loader=yaml.BaseLoader)
+        default_drop = dialog_data[0]["dialog_tabs"][0]["dialog_groups"][0]["dialog_fields"][0][
+            "default_value"
+        ]
+
+    view = navigate_to(service_catalogs, "Order")
+    assert view.fields("dropdown_list_1").read() == default_drop


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_dialog_not_required_default_value }}

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
