### PR TITLE
[1LP][RFR] Parametrize correct fixture on transformation_method for v2v

### DIFF
--- a/cfme/tests/v2v/test_v2v_smoke.py
+++ b/cfme/tests/v2v/test_v2v_smoke.py
@@ -31,7 +31,7 @@ pytestmark = [
 ]
 
 
-@pytest.mark.parametrize("mapping_data_vm_obj_single_datastore",
+@pytest.mark.parametrize("v2v_provider_setup",
                          ['SSH', 'VDDK'], indirect=True)
 @pytest.mark.parametrize(
     "source_type, dest_type, template_type",

--- a/cfme/tests/v2v/test_v2v_smoke.py
+++ b/cfme/tests/v2v/test_v2v_smoke.py
@@ -39,12 +39,13 @@ pytestmark = [
         ["nfs", "nfs", Templates.RHEL7_MINIMAL]
     ]
 )
+@pytest.mark.meta(automates=[1815046])
 def test_single_vm_migration_with_ssh_and_vddk(request, appliance, provider,
                                                source_type, dest_type, template_type,
                                                mapping_data_vm_obj_single_datastore):
     """
     Polarion:
-        assignee: sshveta
+        assignee: nachandr
         caseimportance: high
         caseposneg: positive
         testtype: functional


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
In the smoke test,the transportation method parameter is currently being passed to the wrong fixture. That issue has been fixed through this PR and the parameter is passed to the right fixture so that the test be could run once for each of the transportation methods.
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{ pytest: cfme/tests/v2v/test_v2v_smoke.py --use-template-cache --provider-limit 2 --use-provider rhv43 --use-provider vsphere67-ims -k test_single_vm_migration_with_ssh_and_vddk }}
-->
### PRT Results
510 - PASS
511 - PASS
