### PR TITLE
[1LP][RFR][NOTEST] Remove pylint comments

### DIFF
--- a/.landscape.yml
+++ b/.landscape.yml
@@ -1,3 +1,0 @@
-pylint:
-  disable:
-    - unused-argument

--- a/cfme/fixtures/xunit_tools.py
+++ b/cfme/fixtures/xunit_tools.py
@@ -1,4 +1,3 @@
-# pylint: disable=broad-except
 import re
 from datetime import datetime
 
@@ -8,7 +7,6 @@ from lxml import etree
 from cfme.utils.conf import cfme_data
 from cfme.utils.conf import xunit
 from cfme.utils.pytest_shortcuts import extract_fixtures_values
-# pylint: disable=no-name-in-module
 
 
 whitelist = [

--- a/cfme/tests/candu/test_candu_manual.py
+++ b/cfme/tests/candu/test_candu_manual.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 """Manual tests"""
 import pytest
 

--- a/cfme/tests/candu/test_nor_rightsize.py
+++ b/cfme/tests/candu/test_nor_rightsize.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 """Manual tests"""
 import pytest
 

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1,5 +1,3 @@
-# pylint: disable=E1101
-# pylint: disable=W0621
 import os
 import uuid
 from urllib.parse import urljoin

--- a/cfme/tests/distributed/test_appliance_manual.py
+++ b/cfme/tests/distributed/test_appliance_manual.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 """Manual tests"""
 import pytest
 

--- a/cfme/tests/intelligence/test_chargeback_manual.py
+++ b/cfme/tests/intelligence/test_chargeback_manual.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 """Manual tests"""
 import pytest
 

--- a/cfme/tests/satellite/test_satellite_manual.py
+++ b/cfme/tests/satellite/test_satellite_manual.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 """Manual tests"""
 import pytest
 

--- a/cfme/tests/services/test_tower_manual.py
+++ b/cfme/tests/services/test_tower_manual.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 """Manual tests"""
 import pytest
 

--- a/cfme/tests/test_server_manual.py
+++ b/cfme/tests/test_server_manual.py
@@ -1,4 +1,3 @@
-# pylint: skip-file
 """Manual tests"""
 import pytest
 


### PR DESCRIPTION
A few test and fixture files have pylint-related comments in them. This PR removes them, as we are not using pylint. No tests or fixtures should be affected.