### PR TITLE
[1LP][RFR] Fix call to set_retirement_date in test_vm_retire_extend

### DIFF
--- a/cfme/tests/automate/test_common_methods.py
+++ b/cfme/tests/automate/test_common_methods.py
@@ -67,7 +67,7 @@ def test_vm_retire_extend(appliance, request, create_vm, soft_assert):
     num_days = 5
     soft_assert(create_vm.retirement_date == 'Never', "The retirement date is not 'Never'!")
     retirement_date = generate_retirement_date(delta=num_days)
-    create_vm.set_retirement_date(retirement_date)
+    create_vm.set_retirement_date(when=retirement_date)
     wait_for(lambda: create_vm.retirement_date != 'Never', message="retirement date set")
     set_date = create_vm.retirement_date
     vm_retire_date_fmt = create_vm.RETIRE_DATE_FMT


### PR DESCRIPTION
Fix for TypeError exceptions in test_vm_retire_extend when setting the retirement date on a VM:

```
>       create_vm.set_retirement_date(retirement_date)
E       TypeError: set_retirement_date() takes 1 positional argument but 2 were given
```

{{ pytest: -vv --long-running --use-provider vsphere67-nested -k test_vm_retire_extend cfme/tests/automate/test_common_methods.py }}
