### PR TITLE
[1LP][RFR] Update setting of pytest.TerminalReporter.writer attribute

### DIFF
--- a/cfme/fixtures/pytest_store.py
+++ b/cfme/fixtures/pytest_store.py
@@ -37,7 +37,7 @@ class FlexibleTerminalReporter(TerminalReporter):
         if file is None:
             file = sys.stdout
 
-        self._tw = self.writer = TerminalWriter(file)
+        self._tw = TerminalWriter(file)
         self.hasmarkup = self._tw.hasmarkup
         self.reportchars = ''
         self.currentfspath = None


### PR DESCRIPTION
Rrecent package updates put us on a version of pytest where the attribute can no longer be set.

Following the pytest suggestion, using `_tw` attribute directly, for our case of a TerminalReporter that works outside of a pytest session.