### PR TITLE
[1LP][RFR] Fix test_embedded_ansible_actions

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -6,6 +6,7 @@ from cfme.control.explorer.policies import VMControlPolicy
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.conf import credentials
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
@@ -26,10 +27,8 @@ def ansible_action(appliance, ansible_catalog_item):
         fauxfactory.gen_alphanumeric(15, start="action_"),
         action_type="Run Ansible Playbook",
         action_values={
-            "run_ansible_playbook": {
-                "playbook_catalog_item": ansible_catalog_item.name
-            }
-        }
+            "run_ansible_playbook": {"playbook_catalog_item": ansible_catalog_item.name}
+        },
     )
     yield action
 
@@ -42,11 +41,12 @@ def policy_for_testing(appliance, create_vm_modscope, provider, ansible_action):
     policy = appliance.collections.policies.create(
         VMControlPolicy,
         fauxfactory.gen_alpha(15, start="policy_"),
-        scope=f"fill_field(VM and Instance : Name, INCLUDES, {vm.name})"
+        scope=f"fill_field(VM and Instance : Name, INCLUDES, {vm.name})",
     )
     policy.assign_actions_to_event("Tag Complete", [ansible_action.description])
     policy_profile = appliance.collections.policy_profiles.create(
-        fauxfactory.gen_alpha(15, start="profile_"), policies=[policy])
+        fauxfactory.gen_alpha(15, start="profile_"), policies=[policy]
+    )
     provider.assign_policy_profiles(policy_profile.description)
     yield
 
@@ -63,7 +63,7 @@ def ansible_credential(wait_for_ansible, appliance, full_template_modscope):
         fauxfactory.gen_alpha(start="cred_"),
         "Machine",
         username=credentials[full_template_modscope.creds]["username"],
-        password=credentials[full_template_modscope.creds]["password"]
+        password=credentials[full_template_modscope.creds]["password"],
     )
     yield credential
 
@@ -71,10 +71,18 @@ def ansible_credential(wait_for_ansible, appliance, full_template_modscope):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
-def test_action_run_ansible_playbook_localhost(request, ansible_catalog_item, ansible_action,
-        policy_for_testing, create_vm_modscope, ansible_credential, ansible_service_request,
-        ansible_service):
+@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+def test_action_run_ansible_playbook_localhost(
+    request,
+    ansible_catalog_item,
+    ansible_action,
+    policy_for_testing,
+    create_vm_modscope,
+    ansible_credential,
+    ansible_service_request_funcscope,
+    ansible_service_funcscope,
+    appliance,
+):
     """Tests a policy with ansible playbook action against localhost.
 
     Polarion:
@@ -86,18 +94,28 @@ def test_action_run_ansible_playbook_localhost(request, ansible_catalog_item, an
         ansible_action.run_ansible_playbook = {"inventory": {"localhost": True}}
     added_tag = create_vm_modscope.add_tag()
     request.addfinalizer(lambda: create_vm_modscope.remove_tag(added_tag))
-    wait_for(ansible_service_request.exists, num_sec=600)
-    ansible_service_request.wait_for_request()
-    view = navigate_to(ansible_service, "Details")
+    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
+    ansible_service_request_funcscope.wait_for_request()
+    view = navigate_to(ansible_service_funcscope, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == "localhost"
-    assert view.provisioning.results.get_text_of("Status") == "successful"
+    status = "successful" if appliance.version < "5.11" else "Finished"
+    assert view.provisioning.results.get_text_of("Status") == status
 
 
+@pytest.mark.meta(blockers=[BZ(1822533, forced_streams=["5.11", "5.10"])])
 @pytest.mark.tier(3)
-@pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
-def test_action_run_ansible_playbook_manual_address(request, ansible_catalog_item, ansible_action,
-        policy_for_testing, create_vm_modscope, ansible_credential, ansible_service_request,
-        ansible_service):
+@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+def test_action_run_ansible_playbook_manual_address(
+    request,
+    ansible_catalog_item,
+    ansible_action,
+    policy_for_testing,
+    create_vm_modscope,
+    ansible_credential,
+    ansible_service_request_funcscope,
+    ansible_service_funcscope,
+    appliance,
+):
     """Tests a policy with ansible playbook action against manual address.
 
     Polarion:
@@ -110,25 +128,32 @@ def test_action_run_ansible_playbook_manual_address(request, ansible_catalog_ite
         ansible_catalog_item.provisioning = {"machine_credential": ansible_credential.name}
     with update(ansible_action):
         ansible_action.run_ansible_playbook = {
-            "inventory": {
-                "specific_hosts": True,
-                "hosts": vm.ip_address
-            }
+            "inventory": {"specific_hosts": True, "hosts": vm.ip_address}
         }
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    wait_for(ansible_service_request.exists, num_sec=600)
-    ansible_service_request.wait_for_request()
-    view = navigate_to(ansible_service, "Details")
+    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
+    ansible_service_request_funcscope.wait_for_request()
+    view = navigate_to(ansible_service_funcscope, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == vm.ip_address
-    assert view.provisioning.results.get_text_of("Status") == "successful"
+    status = "successful" if appliance.version < "5.11" else "Finished"
+    assert view.provisioning.results.get_text_of("Status") == status
 
 
+@pytest.mark.meta(blockers=[BZ(1822533, forced_streams=["5.11", "5.10"])])
 @pytest.mark.tier(3)
-@pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
-def test_action_run_ansible_playbook_target_machine(request, ansible_catalog_item, ansible_action,
-        policy_for_testing, create_vm_modscope, ansible_credential, ansible_service_request,
-        ansible_service):
+@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+def test_action_run_ansible_playbook_target_machine(
+    request,
+    ansible_catalog_item,
+    ansible_action,
+    policy_for_testing,
+    create_vm_modscope,
+    ansible_credential,
+    ansible_service_request_funcscope,
+    ansible_service_funcscope,
+    appliance,
+):
     """Tests a policy with ansible playbook action against target machine.
 
     Polarion:
@@ -141,18 +166,27 @@ def test_action_run_ansible_playbook_target_machine(request, ansible_catalog_ite
         ansible_action.run_ansible_playbook = {"inventory": {"target_machine": True}}
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    wait_for(ansible_service_request.exists, num_sec=600)
-    ansible_service_request.wait_for_request()
-    view = navigate_to(ansible_service, "Details")
+    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
+    ansible_service_request_funcscope.wait_for_request()
+    view = navigate_to(ansible_service_funcscope, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == vm.ip_address
-    assert view.provisioning.results.get_text_of("Status") == "successful"
+    status = "successful" if appliance.version < "5.11" else "Finished"
+    assert view.provisioning.results.get_text_of("Status") == status
 
 
 @pytest.mark.tier(3)
-@pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
-def test_action_run_ansible_playbook_unavailable_address(request, ansible_catalog_item,
-        create_vm_modscope, ansible_action, policy_for_testing, ansible_credential,
-        ansible_service_request, ansible_service):
+@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+def test_action_run_ansible_playbook_unavailable_address(
+    request,
+    ansible_catalog_item,
+    create_vm_modscope,
+    ansible_action,
+    policy_for_testing,
+    ansible_credential,
+    ansible_service_request_funcscope,
+    ansible_service_funcscope,
+    appliance,
+):
     """Tests a policy with ansible playbook action against unavailable address.
 
     Polarion:
@@ -165,24 +199,23 @@ def test_action_run_ansible_playbook_unavailable_address(request, ansible_catalo
         ansible_catalog_item.provisioning = {"machine_credential": ansible_credential.name}
     with update(ansible_action):
         ansible_action.run_ansible_playbook = {
-            "inventory": {
-                "specific_hosts": True,
-                "hosts": "unavailable_address"
-            }
+            "inventory": {"specific_hosts": True, "hosts": "unavailable_address"}
         }
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    wait_for(ansible_service_request.exists, num_sec=600)
-    ansible_service_request.wait_for_request()
-    view = navigate_to(ansible_service, "Details")
+    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
+    ansible_service_request_funcscope.wait_for_request()
+    view = navigate_to(ansible_service_funcscope, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == "unavailable_address"
-    assert view.provisioning.results.get_text_of("Status") == "failed"
+    status = "failed" if appliance.version < "5.11" else "Finished"
+    assert view.provisioning.results.get_text_of("Status") == status
 
 
 @pytest.mark.tier(3)
-@pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
-def test_control_action_run_ansible_playbook_in_requests(request,
-        create_vm_modscope, policy_for_testing, ansible_service_request):
+@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+def test_control_action_run_ansible_playbook_in_requests(
+    request, create_vm_modscope, policy_for_testing, ansible_service_request_funcscope
+):
     """Checks if execution of the Action result in a Task/Request being created.
 
     Polarion:
@@ -193,4 +226,4 @@ def test_control_action_run_ansible_playbook_in_requests(request,
     vm = create_vm_modscope
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    assert ansible_service_request.exists
+    assert ansible_service_request_funcscope.exists


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/ansible/test_embedded_ansible_actions.py --long-running }}

