### PR TITLE
[1LP][RFR] Fix OpenStack volume tests

### DIFF
--- a/cfme/tests/openstack/cloud/test_instances.py
+++ b/cfme/tests/openstack/cloud/test_instances.py
@@ -67,11 +67,13 @@ def new_instance(provider):
 @pytest.fixture(scope='function')
 def volume(appliance, provider):
     collection = appliance.collections.volumes
-    storage_manager = f'{provider.name} Cinder Manager'
+    az = None if appliance.version < '5.11' else provider.data['provisioning']['availability_zone']
     volume = collection.create(name=fauxfactory.gen_alpha(start="vol_"),
-                               storage_manager=storage_manager,
+                               # TODO (jhenner) Not sure what to set this to.
+                               from_manager=False,
+                               az=az,
                                tenant=provider.data['provisioning']['cloud_tenant'],
-                               size=VOLUME_SIZE,
+                               volume_size=VOLUME_SIZE,
                                provider=provider)
     yield volume
 
@@ -83,6 +85,7 @@ def volume(appliance, provider):
 def volume_with_type(appliance, provider):
     vol_type = provider.mgmt.capi.volume_types.create(name=fauxfactory.gen_alpha(start="type_"))
     volume_type = appliance.collections.volume_types.instantiate(vol_type.name, provider)
+    az = None if appliance.version < '5.11' else provider.data['provisioning']['availability_zone']
 
     @wait_for_decorator(delay=10, timeout=300,
                         message="Waiting for volume type to appear")
@@ -91,12 +94,13 @@ def volume_with_type(appliance, provider):
         return volume_type.exists
 
     collection = appliance.collections.volumes
-    storage_manager = f'{provider.name} Cinder Manager'
     volume = collection.create(name=fauxfactory.gen_alpha(start="vol_"),
-                               storage_manager=storage_manager,
+                               # TODO (jhenner) Not sure what to set this to.
+                               from_manager=False,
+                               az=az,
                                tenant=provider.data['provisioning']['cloud_tenant'],
                                volume_type=volume_type.name,
-                               size=VOLUME_SIZE,
+                               volume_size=VOLUME_SIZE,
                                provider=provider)
     yield volume
 

--- a/cfme/tests/openstack/cloud/test_volume_backup.py
+++ b/cfme/tests/openstack/cloud/test_volume_backup.py
@@ -20,14 +20,16 @@ VOLUME_SIZE = 1
 @pytest.fixture(scope='function')
 def volume_backup(appliance, provider):
     volume_collection = appliance.collections.volumes
-    storage_manager = f'{provider.name} Cinder Manager'
     backup_collection = appliance.collections.volume_backups.filter({'provider': provider})
+    az = None if appliance.version < '5.11' else provider.data['provisioning']['availability_zone']
 
     # create new volume
     volume = volume_collection.create(name=fauxfactory.gen_alpha(start="vol_"),
-                                      storage_manager=storage_manager,
+                                      # TODO (jhenner) Not sure what to set this to.
+                                      from_manager=False,
+                                      az=az,
                                       tenant=provider.data['provisioning']['cloud_tenant'],
-                                      size=VOLUME_SIZE,
+                                      volume_size=VOLUME_SIZE,
                                       provider=provider)
 
     # create new backup for crated volume
@@ -60,15 +62,17 @@ def volume_backup_with_type(appliance, provider):
         return volume_type.exists
 
     volume_collection = appliance.collections.volumes
-    storage_manager = f'{provider.name} Cinder Manager'
     backup_collection = appliance.collections.volume_backups.filter({'provider': provider})
+    az = None if appliance.version < '5.11' else provider.data['provisioning']['availability_zone']
 
     # create new volume
     volume = volume_collection.create(name=fauxfactory.gen_alpha(start="vol_"),
-                                      storage_manager=storage_manager,
+                                      # TODO (jhenner) Not sure what to set this to.
+                                      from_manager=False,
+                                      az=az,
                                       tenant=provider.data['provisioning']['cloud_tenant'],
                                       volume_type=volume_type.name,
-                                      size=VOLUME_SIZE,
+                                      volume_size=VOLUME_SIZE,
                                       provider=provider)
 
     # create new backup for crated volume

--- a/cfme/tests/openstack/cloud/test_volumes.py
+++ b/cfme/tests/openstack/cloud/test_volumes.py
@@ -21,11 +21,14 @@ VOLUME_SIZE = 1
 @pytest.fixture(scope='function')
 def volume(appliance, provider):
     collection = appliance.collections.volumes
-    storage_manager = f'{provider.name} Cinder Manager'
+    az = None if appliance.version < '5.11' else provider.data['provisioning']['availability_zone']
+
     volume = collection.create(name=fauxfactory.gen_alpha(start="vol_"),
-                               storage_manager=storage_manager,
+                               # TODO (jhenner) Not sure what to set this to.
+                               from_manager=False,
+                               az=az,
                                tenant=provider.data['provisioning']['cloud_tenant'],
-                               size=VOLUME_SIZE,
+                               volume_size=VOLUME_SIZE,
                                provider=provider)
     yield volume
 
@@ -41,6 +44,7 @@ def volume(appliance, provider):
 def volume_with_type(appliance, provider):
     vol_type = provider.mgmt.capi.volume_types.create(name=fauxfactory.gen_alpha(start="type_"))
     volume_type = appliance.collections.volume_types.instantiate(vol_type.name, provider)
+    az = None if appliance.version < '5.11' else provider.data['provisioning']['availability_zone']
 
     @wait_for_decorator(delay=10, timeout=300,
                         message="Waiting for volume type to appear")
@@ -49,12 +53,14 @@ def volume_with_type(appliance, provider):
         return volume_type.exists
 
     collection = appliance.collections.volumes
-    storage_manager = f'{provider.name} Cinder Manager'
+
     volume = collection.create(name=fauxfactory.gen_alpha(start="vol_"),
-                               storage_manager=storage_manager,
+                               # TODO (jhenner) Not sure what to set this to.
+                               from_manager=False,
+                               az=az,
                                tenant=provider.data['provisioning']['cloud_tenant'],
                                volume_type=volume_type.name,
-                               size=VOLUME_SIZE,
+                               volume_size=VOLUME_SIZE,
                                provider=provider)
     yield volume
 


### PR DESCRIPTION
## Purpose or Intent
__Fixing__ volume tests. It seems the `storage_manager` attribute was removed without changing the tests. Also the `size` attribute was changed to `volume_size`.

As can be currently seen on trackerbot, all tests executed in this PR were failing like this:
```
>                                         provider=provider)
E       TypeError: create() got an unexpected keyword argument 'storage_manager'

cfme/tests/openstack/cloud/test_volume_backup.py:31: TypeError
TypeError
b"create() got an unexpected keyword argument 'storage_manager'"
```

Many of them started working with these changes.

{{pytest: cfme/tests/openstack/cloud/test_instances.py::test_instance_attach_detach_volume_with_type[openstack-13] cfme/tests/openstack/cloud/test_instances.py::test_instance_attach_volume[openstack-13] cfme/tests/openstack/cloud/test_volume_backup.py::test_create_backup_of_volume_with_type[openstack-13] cfme/tests/openstack/cloud/test_volume_backup.py::test_create_volume_backup[openstack-13] cfme/tests/openstack/cloud/test_volume_backup.py::test_create_volume_incremental_backup[openstack-13] cfme/tests/openstack/cloud/test_volume_backup.py::test_incr_backup_of_attached_volume_crud[openstack-13] cfme/tests/openstack/cloud/test_volume_backup.py::test_restore_incremental_backup[openstack-13] cfme/tests/openstack/cloud/test_volume_backup.py::test_restore_volume_backup[openstack-13] cfme/tests/openstack/cloud/test_volumes.py::test_create_volume[openstack-13] cfme/tests/openstack/cloud/test_volumes.py::test_create_volume_with_type[openstack-13] cfme/tests/openstack/cloud/test_volumes.py::test_delete_volume[openstack-13] cfme/tests/openstack/cloud/test_volumes.py::test_delete_volume_with_type[openstack-13] cfme/tests/openstack/cloud/test_volumes.py::test_edit_volume[openstack-13] cfme/tests/openstack/cloud/test_volumes.py::test_edit_volume_with_type[openstack-13] cfme/tests/openstack/cloud/test_volumes.py::test_volume_attach_detach_instance[openstack-13]
--long-running -v --use-provider complete }}