### PR TITLE
[1LP][RFR] Automating dynamic refresh dialog test

### DIFF
--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -562,36 +562,6 @@ def test_request_details_page_tagcontrol_field(request, appliance, import_dialog
     assert details_view.is_displayed
 
 
-@pytest.mark.meta(coverage=[1694737])
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_regex_validation_should_work():
-    """
-
-    Bugzilla:
-        1694737
-
-    Polarion:
-        assignee: nansari
-        startsin: 5.10
-        casecomponent: Services
-        initialEstimate: 1/6h
-        testSteps:
-            1. Import DataStore and Dynamic Dialog
-            2. Add catalog item with above dialog
-            3. Navigate to order page of service
-            4. In service Order page
-            5. Add values
-        expectedResults:
-            1.
-            2.
-            3.
-            4.
-            5. Regex validation should work
-    """
-    pass
-
-
 @pytest.mark.tier(2)
 @pytest.mark.meta(automates=[1696474])
 @pytest.mark.customer_scenario

--- a/cfme/tests/services/test_dynamicdd_dialogelement.py
+++ b/cfme/tests/services/test_dynamicdd_dialogelement.py
@@ -462,21 +462,46 @@ def test_dynamic_dropdown_values_should_load_correctly():
     pass
 
 
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_child_dialog_should_update_with_new_options_based_on_option_of_parent_dialog_upon_ref():
+@pytest.mark.customer_scenario
+@pytest.mark.meta(automates=[1580535, 1694737])
+@pytest.mark.tier(2)
+@pytest.mark.parametrize("import_data", [DatastoreImport("bz_1580535.zip", "bz_1580535", None)],
+                         ids=["datastore"])
+@pytest.mark.parametrize("file_name", ["bz_1580535.yml"], ids=["refresh_dialog"])
+def test_dynamic_field_update_on_refresh(appliance, import_datastore, import_data, file_name,
+                                         generic_catalog_item_with_imported_dialog):
     """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: service
     Bugzilla:
         1580535
+        1694737
+
+    Polarion:
+        assignee: nansari
+        startsin: 5.10
+        casecomponent: Services
+        initialEstimate: 1/16h
+        testSteps:
+            1. Import Datastore and dialog
+            2. Add service catalog with above created dialog
+            3. Navigate to order page of service
+            4. In service Order page
+        expectedResults:
+            1.
+            2.
+            3.
+            4. dynamic field should update correctly
     """
-    pass
+    catalog_item, sd, ele_label = generic_catalog_item_with_imported_dialog
+
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+    view = navigate_to(service_catalogs, "Order")
+    view.fields("Menu").refresh.click()
+    menu = view.fields("menu").read()
+    topping = view.fields("dropdown_list_1").read()
+
+    data = {"Burger": "Black Bean", "Fries": "Sweet Potato", "Shake": "Vanilla",
+            "Empty Set": "Nothing selected for parent dialog"}
+    assert topping == data[menu]
 
 
 @pytest.mark.customer_scenario

--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -144,23 +144,6 @@ def test_custom_image_on_item_bundle_crud():
 
 @pytest.mark.manual
 @pytest.mark.tier(3)
-def test_catalog_item_changing_the_provider_template_after_filling_all_tabs():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.5
-        tags: service
-    Bugzilla:
-        1240443
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
 def test_request_filter_on_request_page():
     """
     Polarion:
@@ -172,21 +155,6 @@ def test_request_filter_on_request_page():
         tags: service
     Bugzilla:
         1498237
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_check_all_availability_zones_for_amazon_provider():
-    """ Check if all availability zones can be selected while creating catalog item.
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/8h
-        startsin: 5.5
-        tags: service
     """
     pass
 
@@ -213,23 +181,6 @@ def test_edit_catalog_item_after_remove_resource_pool():
             2.
             3.
             4. Validation message should be shown
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_generic_object_details_displayed_from_a_service_do_not_include_associations():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Automate
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1576828
     """
     pass
 
@@ -354,39 +305,6 @@ def test_cui_should_check_dialog_field_associations():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_generic_object_should_be_visible_in_service_view():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        initialEstimate: 1/4h
-        testtype: functional
-        startsin: 5.8
-        tags: service
-    Bugzilla:
-        1515945
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_reconfigure_service_for_dialogs_with_timeout_values():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.7
-    Bugzilla:
-        1442920
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(2)
 def test_timepicker_should_pass_correct_timing_on_service_order():
     """
@@ -397,23 +315,6 @@ def test_timepicker_should_pass_correct_timing_on_service_order():
         initialEstimate: 1/4h
         startsin: 5.9
         tags: service
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_should_be_able_to_see_requests_if_our_users_are_in_groups_with_managed_tags():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        initialEstimate: 1/4h
-        testtype: functional
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1596738
     """
     pass
 
@@ -465,20 +366,5 @@ def test_entries_shouldnt_be_mislabeled_for_dropdown_element_in_dialog_editor():
         tags: service
     Bugzilla:
         1597802
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_reconfigure_existing_duplicate_orders():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: service
     """
     pass


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dynamicdd_dialogelement.py::test_dynamic_field_update_on_refresh -vvvv --long-running }}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
- `test_regex_validation_should_work`  this is also covered in this PR
- removed `test_reconfigure_service_for_dialogs_with_timeout_values`, we already have automation -> `test_reconfigure_service`
- removed few nonrequired tests which no need to test.
- remove `test_should_be_able_to_see_requests_if_our_users...`, we already have related test `test_service_rbac_request`