### PR TITLE
[1LP][RFR] Assign generic_objects tests to tpapaioa + small fix

### DIFF
--- a/cfme/tests/automate/generic_objects/test_definitions.py
+++ b/cfme/tests/automate/generic_objects/test_definitions.py
@@ -34,7 +34,7 @@ def gen_obj_def_import_export(appliance):
 def test_generic_object_definition_crud(appliance, context, soft_assert):
     """
     Polarion:
-        assignee: jdupuy
+        assignee: tpapaioa
         casecomponent: GenericObjects
         caseimportance: high
         initialEstimate: 1/12h
@@ -81,7 +81,7 @@ def test_generic_object_definition_crud(appliance, context, soft_assert):
 def test_generic_objects_class_accordion_should_display_when_locale_is_french():
     """ Generic objects class accordion should display when locale is french
     Polarion:
-        assignee: nansari
+        assignee: tpapaioa
         casecomponent: Services
         testtype: functional
         initialEstimate: 1/6h
@@ -101,7 +101,7 @@ def test_upload_image_generic_object_definition(appliance):
         1650104
 
     Polarion:
-        assignee: jdupuy
+        assignee: tpapaioa
         initialEstimate: 1/30h
         caseimportance: medium
         caseposneg: negative
@@ -127,7 +127,7 @@ def test_import_export_generic_object_definition(request, appliance, gen_obj_def
         1595259
 
     Polarion:
-        assignee: jdupuy
+        assignee: tpapaioa
         initialEstimate: 1/6h
         caseimportance: high
         caseposneg: positive

--- a/cfme/tests/automate/generic_objects/test_instances.py
+++ b/cfme/tests/automate/generic_objects/test_instances.py
@@ -51,7 +51,7 @@ def button_with_dialog(appliance, generic_object, dialog):
 def test_generic_objects_crud(appliance, context, request):
     """
     Polarion:
-        assignee: jdupuy
+        assignee: tpapaioa
         initialEstimate: 1/4h
         tags: 5.9
         casecomponent: GenericObjects
@@ -114,19 +114,19 @@ def test_generic_objects_tag_ui(appliance, generic_object, tag_place):
             test_flag: ui
 
     Polarion:
-        assignee: anikifor
+        assignee: tpapaioa
         initialEstimate: 1/4h
         casecomponent: GenericObjects
     """
     with appliance.context.use(ViaUI):
         assigned_tag = generic_object.add_tag(details=tag_place)
-        # TODO uncomment when tags aria added to details
+        # TODO uncomment when tags are added to details
         # tag_available = instance.get_tags()
         # assert any(tag.category.display_name == assigned_tag.category.display_name and
         #            tag.display_name == assigned_tag.display_name
         #            for tag in tag_available), 'Assigned tag was not found on the details page'
         generic_object.remove_tag(assigned_tag, details=tag_place)
-        # TODO uncomment when tags aria added to details
+        # TODO uncomment when tags are added to details
         # assert not(tag.category.display_name == assigned_tag.category.display_name and
         #            tag.display_name == assigned_tag.display_name
         #            for tag in tag_available), 'Assigned tag was not removed from the details page'
@@ -141,7 +141,7 @@ def test_generic_objects_tag_rest(appliance, generic_object, tags):
 
     Polarion:
         initialEstimate: 1/4h
-        assignee: pvala
+        assignee: tpapaioa
         casecomponent: Tagging
         caseimportance: high
     """
@@ -164,7 +164,7 @@ def test_generic_object_with_service_button(appliance, generic_object, button_wi
         1743266
 
     Polarion:
-        assignee: jdupuy
+        assignee: tpapaioa
         initialEstimate: 1/6h
         caseimportance: high
         caseposneg: positive
@@ -199,7 +199,7 @@ def test_generic_object_on_service_breadcrumb(appliance, generic_object):
         1741050
 
     Polarion:
-        assignee: jdupuy
+        assignee: tpapaioa
         initialEstimate: 1/6h
         casecomponent: GenericObjects
         testSteps:
@@ -224,7 +224,7 @@ def test_generic_object_on_service_breadcrumb(appliance, generic_object):
     # now navigate to the details of the generic_object
     with appliance.context.use(ViaUI):
         view = navigate_to(generic_object, "MyServiceDetails")
-        view.breadcrumb.click_location("Active Services")
+        view.breadcrumb.click_location(myservice.name)
         assert not view.is_displayed
         view = myservice.create_view(MyServicesView)
         assert view.is_displayed


### PR DESCRIPTION
Assigned additional generic-objects-related tests to tpapaioa. Also included a small fix to the breadcrumb location expected in test_generic_object_on_service_breadcrumb.

{{ pytest: -v -k test_generic_object_on_service_breadcrumb cfme/tests/automate/generic_objects/test_instances.py }}