### PR TITLE
[1LP][RFR] Continue swapping EC2 with OpenStack and fix HTTP 503 issues.

### DIFF
--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -6,7 +6,7 @@ import pytest
 from wait_for import wait_for
 
 from cfme import test_requirements
-from cfme.cloud.provider.ec2 import EC2Provider
+from cfme.cloud.provider.openstack import OpenStackProvider
 from cfme.fixtures.cli import provider_app_crud
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.appliance.console import configure_appliances_ha
@@ -59,7 +59,7 @@ def get_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm):
     appl2.wait_for_web_ui()
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl1).setup()
-    provider_app_crud(EC2Provider, appl1).setup()
+    provider_app_crud(OpenStackProvider, appl1).setup()
     appl1.db.backup()
     return temp_appliances_unconfig_funcscope_rhevm
 
@@ -95,7 +95,7 @@ def get_ext_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm, 
     appl2.wait_for_web_ui()
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl1).setup()
-    provider_app_crud(EC2Provider, appl1).setup()
+    provider_app_crud(OpenStackProvider, appl1).setup()
     appl1.db.backup()
     return temp_appliances_unconfig_funcscope_rhevm
 
@@ -164,7 +164,7 @@ def get_ha_appliances_with_providers(unconfigured_appliances, app_creds):
 
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl3).setup()
-    provider_app_crud(EC2Provider, appl3).setup()
+    provider_app_crud(OpenStackProvider, appl3).setup()
     appl1.db.backup()
 
     return unconfigured_appliances
@@ -194,7 +194,7 @@ def two_appliances_one_with_providers(temp_appliances_preconfig_funcscope):
 
     # Add infra/cloud providers
     provider_app_crud(VMwareProvider, appl1).setup()
-    provider_app_crud(EC2Provider, appl1).setup()
+    provider_app_crud(OpenStackProvider, appl1).setup()
     return appl1, appl2
 
 
@@ -509,7 +509,7 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
 
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl3).setup()
-    provider_app_crud(EC2Provider, appl3).setup()
+    provider_app_crud(OpenStackProvider, appl3).setup()
     appl1.db.backup()
 
     providers_before_restore = set(appl3.managed_provider_names)

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -48,19 +48,23 @@ def provision_vm(request, provider):
 @pytest.fixture
 def get_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm):
     """Returns two database-owning appliances, configures first appliance with providers and
-    takes a backup prior to running tests.
-
+    takes a backup on the first one prior to running tests.
     """
     appl1, appl2 = temp_appliances_unconfig_funcscope_rhevm
     # configure appliances
     appl1.configure(region=0)
-    appl1.wait_for_web_ui()
     appl2.configure(region=0)
-    appl2.wait_for_web_ui()
+
+    for app in temp_appliances_unconfig_funcscope_rhevm:
+        app.wait_for_web_ui()
+        app.wait_for_api_available()
+
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl1).setup()
     provider_app_crud(OpenStackProvider, appl1).setup()
     appl1.db.backup()
+    appl1.wait_for_web_ui()
+    appl1.wait_for_api_available()
     return temp_appliances_unconfig_funcscope_rhevm
 
 
@@ -75,6 +79,8 @@ def get_appliance_with_ansible(temp_appliance_preconfig_funcscope):
     appl1.enable_embedded_ansible_role()
     appl1.wait_for_embedded_ansible()
     appl1.db.backup()
+    appl1.wait_for_web_ui()
+    appl1.wait_for_api_available()
     return temp_appliance_preconfig_funcscope
 
 
@@ -89,6 +95,8 @@ def get_ext_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm, 
     # configure appliances
     appl1.configure(region=0)
     appl1.wait_for_web_ui()
+    appl1.wait_for_api_available()
+
     appl2.appliance_console_cli.configure_appliance_external_join(
         app_ip, app_creds_modscope['username'], app_creds_modscope['password'], 'vmdb_production',
         app_ip, app_creds_modscope['sshlogin'], app_creds_modscope['sshpass'])
@@ -240,6 +248,8 @@ def test_appliance_console_dump_restore_db_local(request, get_appliances_with_pr
     restore_db(appl2)
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
+    appl2.wait_for_api_available()
+
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == set(appl1.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -264,8 +274,9 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
         initialEstimate: 1/2h
     """
     appl1, appl2 = two_appliances_one_with_providers
-    backup_file_name = f'/tmp/backup.{fauxfactory.gen_alphanumeric()}.dump'
+    appl1_provider_names = set(appl1.managed_provider_names)
 
+    backup_file_name = f'/tmp/backup.{fauxfactory.gen_alphanumeric()}.dump'
     appl1.db.backup(backup_file_name)
 
     # Transfer v2_key and db backup from first appliance to second appliance
@@ -297,8 +308,9 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
+    appl2.wait_for_api_available()
     # Assert providers on the second appliance
-    assert set(appl2.managed_provider_names) == set(appl1.managed_provider_names), (
+    assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'
     )
     # Verify that existing provider can detect new VMs on the second appliance
@@ -325,6 +337,7 @@ def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansi
     manager.quit()
     appl1.evmserverd.start()
     appl1.wait_for_web_ui()
+    appl1.wait_for_api_available()
     appl1.wait_for_embedded_ansible()
     repositories = appl1.collections.ansible_repositories
     try:
@@ -374,6 +387,8 @@ def test_appliance_console_restore_pg_basebackup_replicated(
     appl2.evmserverd.start()
     appl1.wait_for_web_ui()
     appl2.wait_for_web_ui()
+    appl1.wait_for_api_available()
+    appl2.wait_for_api_available()
     # Assert providers exist after restore and replicated to second appliances
     assert providers_before_restore == set(appl1.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -461,6 +476,8 @@ def test_appliance_console_restore_db_replicated(
     appl2.evmserverd.start()
     appl1.wait_for_web_ui()
     appl2.wait_for_web_ui()
+    appl1.wait_for_api_available()
+    appl2.wait_for_api_available()
 
     # reconfigure replication between appliances which switches to "disabled"
     # during restore
@@ -530,6 +547,7 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
 
     appl3.evmserverd.start()
     appl3.wait_for_web_ui()
+    appl3.wait_for_api_available()
     # Assert providers still exist after restore
     assert providers_before_restore == set(appl3.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -543,6 +561,7 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
 
     appl3.evmserverd.wait_for_running()
     appl3.wait_for_web_ui()
+    appl3.wait_for_api_available()
     # Assert providers still exist after ha failover
     assert providers_before_restore == set(appl3.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -623,6 +642,7 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
+    appl2.wait_for_api_available()
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'
@@ -709,6 +729,7 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
+    appl2.wait_for_api_available()
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -518,6 +518,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             # restarted:
             restart_evm = False
             self.wait_for_web_ui(log_callback=log_callback)
+            self.wait_for_api_available()
             if self.version < '5.11':
                 self.configure_vm_console_cert(log_callback=log_callback)
                 restart_evm = True
@@ -529,6 +530,7 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             if restart_evm:
                 self.evmserverd.restart(log_callback=log_callback)
                 self.wait_for_web_ui(timeout=1800, log_callback=log_callback)
+                self.wait_for_api_available()
 
     def configure_gce(self, log_callback=None):
         # Force use of IPAppliance's configure method

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1532,9 +1532,11 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
                     pass
                 api = self.rest_api
 
-                # Make sure we really make a new request.
+                # Make sure we really make a new request. Perhaps accessing the
+                # rest_api property just creates a client object but no network
+                # communicatin is done until we access some property of the
+                # client.
                 assert api.server_info['server_href']
-
                 self.log.info("Appliance REST API ready")
                 return api
             except APIException as exc:

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1538,8 +1538,8 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
                 self.log.info("Appliance REST API ready")
                 return api
             except APIException as exc:
-                self.log.warning('Appliance rest API not ready: %s', exc)
-                return None
+                self.log.warning('Appliance RESTAPI not ready: %s', exc)
+                return False
 
         api, _ = wait_for(func=_check_appliance_api_ready, num_sec=num_sec, delay=10)
         return api

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1521,6 +1521,10 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
 
         def _check_appliance_api_ready():
             try:
+                # There are 2 hard problems in computer science: cache
+                # invalidation, naming things, and off-by-1 errors.
+                # -- Leon Bambrick
+                #
                 # Try invalidating stale cached api object if exists
                 try:
                     del self.__dict__['rest_api']
@@ -1682,6 +1686,9 @@ ExecStartPre=/usr/bin/bash -c "ipcs -s|grep apache|cut -d\  -f2|while read line;
             assert result.success, 'Failed to generate UUID'
         log_callback('Updated UUID: {}'.format(str(result)))
         try:
+            # There are 2 hard problems in computer science: cache
+            # invalidation, naming things, and off-by-1 errors.
+            # -- Leon Bambrick
             del self.__dict__['guid']  # invalidate cached_property
         except KeyError:
             logger.exception('Exception clearing cached_property "guid"')


### PR DESCRIPTION
Another piece to saga about stabilization of the db restore tests.

 * There was a PR 9959, but more has to be done to see more tests running in release runs as EC2 is disabled on these. 
 * Also, some tests were still quite flaky. The problem is that the API is probably handled by other process/thread then the web-ui and we may get HTTP 503 while the web UI might be already loaded and responding with HTTP 2xx.

I believe this PR, greatly reduces the problem by blocking until the API responds with some OK result. The API client object cached in the appliance had to be invalidated.

The errors currently on the PRT are not related. Related issue is an exception saying HTTP 503.