### PR TITLE
[1LP][RFR] Remove local vm fixtures so common create_vm is used.

### DIFF
--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -7,7 +7,6 @@ from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import providers
 from cfme.utils.blockers import BZ
-from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
 
 

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -33,20 +33,6 @@ def clone_vm_name():
     return clone_vm_name
 
 
-@pytest.fixture
-def create_vm(appliance, provider, request):
-    """Fixture to provision vm to the provider being tested"""
-    vm_name = fauxfactory.gen_alphanumeric(15, start="test_clone_")
-    vm = appliance.collections.infra_vms.instantiate(vm_name, provider)
-    logger.info("provider_key: %s", provider.key)
-
-    if not provider.mgmt.does_vm_exist(vm.name):
-        logger.info("deploying %s on provider %s", vm.name, provider.key)
-        vm.create_on_provider(allow_skip="default", find_in_cfme=True)
-    yield vm
-    vm.cleanup_on_provider()
-
-
 @pytest.mark.provider([VMwareProvider], **filter_fields)
 @pytest.mark.meta(blockers=[BZ(1685201)])
 @test_requirements.provision

--- a/cfme/tests/infrastructure/test_vm_delete.py
+++ b/cfme/tests/infrastructure/test_vm_delete.py
@@ -14,21 +14,8 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
-def vm_test(provider):
-    collection = provider.appliance.provider_based_collection(provider)
-    vm_name = random_vm_name(context="del-test")
-    vm = collection.instantiate(vm_name, provider)
-    vm.create_on_provider(allow_skip="default", find_in_cfme=True)
-    vm.wait_to_appear(timeout=900, load_details=False)
-    yield vm
-
-    if vm.exists:
-        vm.cleanup_on_provider()
-
-
 @pytest.mark.meta(automates=[1592430])
-def test_delete_vm_on_provider_side(vm_test, provider):
+def test_delete_vm_on_provider_side(create_vm, provider):
     """ Delete VM on the provider side and refresh relationships in CFME
 
     Polarion:
@@ -41,7 +28,7 @@ def test_delete_vm_on_provider_side(vm_test, provider):
     """
     logs = LogValidator("/var/www/miq/vmdb/log/evm.log", failure_patterns=[".*ERROR.*"])
     logs.start_monitoring()
-    vm_test.cleanup_on_provider()
+    create_vm.cleanup_on_provider()
     provider.refresh_provider_relationships()
     try:
         wait_for(provider.is_refreshed, func_kwargs={'refresh_delta': 10}, timeout=600)

--- a/cfme/tests/infrastructure/test_vm_delete.py
+++ b/cfme/tests/infrastructure/test_vm_delete.py
@@ -2,7 +2,6 @@ import pytest
 
 from cfme import test_requirements
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
-from cfme.utils.generators import random_vm_name
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for

--- a/cfme/tests/infrastructure/test_vm_engine_relationship.py
+++ b/cfme/tests/infrastructure/test_vm_engine_relationship.py
@@ -4,7 +4,6 @@ from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.virtual_machines import InfraVm
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
-from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [
     pytest.mark.tier(2),
@@ -14,17 +13,6 @@ pytestmark = [
     test_requirements.general_ui
 ]
 
-'''
-@pytest.fixture
-def new_vm(provider, appliance):
-    """Get a random vm to mark relationship"""
-    view = navigate_to(provider, 'ProviderVms')
-    all_names = view.entities.all_entity_names
-    try:
-        return appliance.collections.infra_vms.instantiate(name=all_names[0], provider=provider)
-    except IndexError:
-        pytest.skip(f"No VMs found on provider {provider.name}")
-'''
 
 @pytest.mark.meta(automates=[1534400])
 def test_edit_management_relationship(appliance, create_vm):

--- a/cfme/tests/infrastructure/test_vm_engine_relationship.py
+++ b/cfme/tests/infrastructure/test_vm_engine_relationship.py
@@ -14,7 +14,7 @@ pytestmark = [
     test_requirements.general_ui
 ]
 
-
+'''
 @pytest.fixture
 def new_vm(provider, appliance):
     """Get a random vm to mark relationship"""
@@ -24,10 +24,10 @@ def new_vm(provider, appliance):
         return appliance.collections.infra_vms.instantiate(name=all_names[0], provider=provider)
     except IndexError:
         pytest.skip(f"No VMs found on provider {provider.name}")
-
+'''
 
 @pytest.mark.meta(automates=[1534400])
-def test_edit_management_relationship(appliance, new_vm):
+def test_edit_management_relationship(appliance, create_vm):
     """
     check that Edit Management Relationship works for the VM
 
@@ -40,7 +40,7 @@ def test_edit_management_relationship(appliance, new_vm):
         caseimportance: high
         initialEstimate: 1/6h
     """
-    vm_relationship = InfraVm.CfmeRelationship(new_vm)
+    vm_relationship = InfraVm.CfmeRelationship(create_vm)
 
     for i in range(2):  # do it 2 times and leave the vm w/o relationship
         # set relationship


### PR DESCRIPTION

## Purpose or Intent

- __Updating tests__ to use a common create_vm fixture instead of local ones to create  vms used in tests. Tasos recently wrote a common create_vm fixture and this PR updates vm tests to use it.

### PRT Run
