### PR TITLE
[1LP][RFR] Fix provider fixture scope

### DIFF
--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -357,7 +357,8 @@ def pytest_fixture_setup(fixturedef, request):
                 fixturefunc = getimfunc(fixturedef.func)
                 if fixturefunc != fixturedef.func:
                     fixturefunc = fixturefunc.__get__(request.instance)
-            my_cache_key = request.param_index
+            # Use the DataProvider instance as the cache key.
+            my_cache_key = request.param
             try:
                 provider_data = call_fixture_func(fixturefunc, request, kwargs)
             except TEST_OUTCOME:
@@ -365,9 +366,10 @@ def pytest_fixture_setup(fixturedef, request):
                 raise
             from cfme.utils.providers import get_crud
             provider = get_crud(provider_data.key)
-            fixturedef.cached_result = (provider, my_cache_key, None)
             request.param = provider
             yield provider
+            # Store the cached_result after we have yielded to other pytest_fixture_setup methods.
+            fixturedef.cached_result = (provider, my_cache_key, None)
             break
     else:
         yield


### PR DESCRIPTION
When the provider marker has scope='module' (or anything other than function) set, the provider fixture was not properly scoped. The fixture, and any other fixtures depending on it, would teardown and setup between each test. This PR fixes that behavior with the following changes:

1.) De-duplicate the DataProvider instances created during test collection / parametrization, so that the same instance is always used for the same combination of provider category, type, and version. This is implemented by using a new class method in DataProvider, get_instance(), which stores previously-created instances in a private class-level attribute, _instances. This is a dictionary where the key is the tuple (category, type, version), and the value is the corresponding instance. In a sample test collection run, this drastically cut down the number of DataProvider instances created from 24,605 to 19.

2.) Use the DataProvider instance as the provider fixture's cache key. Previously, the BaseProvider subclass instance was stored here, but this instance is created for a test only *after* pytest checks whether the cache key of the test's fixture request matches the cached result from the previous fixture execution. Because the DataProvider instances have been de-duplicated and are created during test collection, using them as the key will guarantee that this check succeeds.

Before this fix, a pytest run with the --setup-show option would show teardown/setup of module-scoped fixtures between tests in the same module. With the fix, lines like the following between tests will no longer appear:

```
    TEARDOWN M provider[vSphere 6.5 (nested)]
    SETUP          M provider[vSphere 6.5 (nested)]
```
{{ pytest: -v --setup-show -m smoke }}