### PR TITLE
[1LP][RFR] Fix VM retirement tests and test cleanup

### DIFF
--- a/cfme/tests/infrastructure/test_vm_retirement_rest.py
+++ b/cfme/tests/infrastructure/test_vm_retirement_rest.py
@@ -20,11 +20,6 @@ pytestmark = [
 ]
 
 
-@pytest.fixture
-def retire_action(appliance):
-    return VersionPicker({Version.lowest(): 'retire', '5.11': 'request_retire'}).pick()
-
-
 @pytest.fixture(scope="function")
 def vm(request, provider, appliance):
     return _vm(request, provider, appliance)
@@ -73,7 +68,7 @@ def vm_retirement_report(appliance, retire_vm):
     "from_collection", [True, False], ids=["from_collection", "from_detail"]
 )
 @pytest.mark.meta(automates=[BZ(1805119)], blockers=[BZ(1805119, forced_streams=["5.10"])])
-def test_retire_vm_now(appliance, vm, from_collection, retire_action):
+def test_retire_vm_now(appliance, vm, from_collection):
     """Test retirement of vm
 
     Prerequisities:
@@ -99,6 +94,7 @@ def test_retire_vm_now(appliance, vm, from_collection, retire_action):
         caseimportance: high
         initialEstimate: 1/3h
     """
+    retire_action = VersionPicker({Version.lowest(): 'retire', '5.11': 'request_retire'}).pick()
     retire_vm = appliance.rest_api.collections.vms.get(name=vm)
     if from_collection:
         getattr(appliance.rest_api.collections.vms.action, retire_action)(retire_vm)
@@ -126,7 +122,7 @@ def test_retire_vm_now(appliance, vm, from_collection, retire_action):
 @pytest.mark.meta(
     automates=[BZ(1805119), BZ(1827787)], blockers=[BZ(1827787, forced_streams=["5.10", "5.11"])]
 )
-def test_retire_vm_future(appliance, vm, from_collection, retire_action):
+def test_retire_vm_future(appliance, vm, from_collection):
     """Test retirement of vm
 
     Prerequisities:
@@ -153,6 +149,7 @@ def test_retire_vm_future(appliance, vm, from_collection, retire_action):
         caseimportance: high
         initialEstimate: 1/3h
     """
+    retire_action = VersionPicker({Version.lowest(): 'retire', '5.11': 'request_retire'}).pick()
     retire_vm = appliance.rest_api.collections.vms.get(name=vm)
     date = (datetime.datetime.now() + datetime.timedelta(days=5)).strftime("%Y/%m/%d")
     future = {"date": date, "warn": "4"}

--- a/cfme/tests/intelligence/reports/test_import_export_reports_widgets.py
+++ b/cfme/tests/intelligence/reports/test_import_export_reports_widgets.py
@@ -182,9 +182,9 @@ def test_reports_invalid_file(appliance, yaml_name):
             2. Import `invalid_yaml` yaml that has no yaml data.
     """
     if yaml_name == "invalid_yaml":
-        message = "Error during 'upload': undefined method `keys' for \"i\":String"
+        message = r".*Error during.*upload.*: undefined method `keys.* for.*i.*:String.*"
     else:
-        message = "Error during 'upload': Invalid YAML file"
+        message = r".*Error during.*upload.*: Invalid YAML file"
 
     with pytest.raises(AssertionError, match=message):
         appliance.collections.reports.import_report(yaml_path(yaml_name))

--- a/cfme/tests/intelligence/reports/test_import_export_reports_widgets.py
+++ b/cfme/tests/intelligence/reports/test_import_export_reports_widgets.py
@@ -182,9 +182,9 @@ def test_reports_invalid_file(appliance, yaml_name):
             2. Import `invalid_yaml` yaml that has no yaml data.
     """
     if yaml_name == "invalid_yaml":
-        message = r".*Error during.*upload.*: undefined method `keys.* for.*i.*:String.*"
+        message = r".*Error during .*'upload.*': undefined method `keys.*' for.*i.*:String"
     else:
-        message = r".*Error during.*upload.*: Invalid YAML file"
+        message = r".*Error during 'upload': Invalid YAML file"
 
     with pytest.raises(AssertionError, match=message):
         appliance.collections.reports.import_report(yaml_path(yaml_name))

--- a/cfme/tests/webui/test_general_ui.py
+++ b/cfme/tests/webui/test_general_ui.py
@@ -487,7 +487,7 @@ def test_compliance_column_header(appliance, setup_provider, provider):
 
 @pytest.mark.ignore_stream("5.10")
 @pytest.mark.meta(blockers=[BZ(1741310)], automates=[1741310])
-@pytest.mark.provider([AnsibleTowerProvider, SatelliteProvider])
+@pytest.mark.provider([AnsibleTowerProvider, SatelliteProvider], selector=ONE_PER_TYPE)
 def test_add_provider_button_accordion(has_no_providers, provider):
     """
     Test that add_provider button is visible after clicking accordion on
@@ -687,51 +687,6 @@ def test_compare_vm_from_datastore_relationships(appliance, setup_provider, prov
     view.toolbar.configuration.item_select("Compare Selected items")
     compare_view = datastore.create_view(DatastoresCompareView)
     assert compare_view.is_displayed
-
-
-@pytest.mark.manual("manualonly")
-@pytest.mark.tier(1)
-def test_ui_pinning_after_relog():
-    """
-    Polarion:
-        assignee: pvala
-        casecomponent: WebUI
-        caseimportance: medium
-        caseposneg: negative
-        initialEstimate: 1/12h
-        testSteps:
-            1. Go to Automate -> Explorer
-            2. Pin this menu
-            3. Logout
-            4. Log in
-            5. No menu should be pinned
-    """
-    pass
-
-
-@pytest.mark.manual
-def test_ui_notification_icon():
-    """
-    Bugzilla:
-        1489798
-
-    Polarion:
-        assignee: pvala
-        casecomponent: WebUI
-        caseimportance: low
-        initialEstimate: 1/6h
-        startsin: 5.9
-        testSteps:
-            1. Go to rails console and type:
-            Notification.create(:type => :automate_user_error, :initiator =>
-            User.first, :options => { :message => "test" })
-            2. Check in UI whether notification icon was displayed
-            3. Go to rails console and type:
-            Notification.create(:type => :automate_global_error, :initiator =>
-            User.first, :options => { :message => "test" })
-            4. Check in UI whether notification icon was displayed
-    """
-    pass
 
 
 @pytest.mark.tier(1)


### PR DESCRIPTION
## Purpose or Intent
- __Fixing__ 
    1. Tests related to VM retirement
    2. Adding `selector` to `test_add_provider_button_accordion` so that it doesn't extra tests.
    3. `test_reports_invalid_file` which was failing because error message changed.
- __Removing__
    1. Blockers from BZs
    2. test_ui_pinning_after_relog and test_ui_notification_icon

### PRT Run
{{ pytest: cfme/tests/infrastructure/test_vm_retirement_rest.py cfme/tests/intelligence/reports/test_import_export_reports_widgets.py::test_reports_invalid_file -vvv }}