### PR TITLE
[1LP][RFR] Remove deprecated override kwarg from pytest.mark.provider calls.

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1307,7 +1307,7 @@ def test_create_sns_topic(has_no_cloud_providers, provider, request):
 
 
 @test_requirements.ec2
-@pytest.mark.provider([EC2Provider], scope="function", override=True, selector=ONE)
+@pytest.mark.provider([EC2Provider], scope="function", selector=ONE)
 def test_add_delete_add_provider(setup_provider, provider, request):
     """
     Polarion:
@@ -1332,7 +1332,7 @@ def test_add_delete_add_provider(setup_provider, provider, request):
 
 
 @test_requirements.ec2
-@pytest.mark.provider([EC2Provider], scope="function", override=True, selector=ONE)
+@pytest.mark.provider([EC2Provider], scope="function", selector=ONE)
 def test_deploy_instance_with_ssh_addition_template(setup_provider,
                                                     instance_with_ssh_addition_template):
     """


### PR DESCRIPTION
This PR removes the deprecated 'override=True' kwarg passed to pytest.mark.provider for a couple tests. This kwarg is no longer necessary, and was deprecated in https://github.com/ManageIQ/integration_tests/pull/9198 .

{{ pytest: -vv -k 'test_add_delete_add_provider or test_deploy_instance_with_ssh_addition_template' cfme/tests/cloud/test_providers.py }}
