### PR TITLE
[1LP][RFR] Fix- Group creation

### DIFF
--- a/cfme/tests/integration/test_cfme_auth.py
+++ b/cfme/tests/integration/test_cfme_auth.py
@@ -343,11 +343,13 @@ def test_login_local_group(temp_appliance_preconfig_long, local_user, local_grou
 
 @pytest.mark.tier(1)
 @pytest.mark.ignore_stream('5.8')
-@pytest.mark.uncollectif(lambda auth_mode, auth_user:
+@pytest.mark.uncollectif(lambda prov_key, auth_mode, auth_user:
                          auth_mode == 'amazon' or
-                         len(auth_user.groups or []) < 2,
+                         len(auth_user.groups or []) < 2 or
+                         prov_key == 'cfme_openldap',
                          reason='Amazon auth_data needed for group switch testing or'
-                         'user does not have multiple groups')
+                         'user does not have multiple groups or CFME_OPENLDAP provider'
+                                ' needs some fixes for this test to work on it.')
 @pytest.mark.meta(blockers=[BZ(1759291)], automates=[1759291])
 def test_user_group_switching(
         temp_appliance_preconfig_long, auth_user, auth_mode, auth_provider,
@@ -373,7 +375,8 @@ def test_user_group_switching(
                                                    auth_mode,
                                                    auth_user.username,
                                                    group,
-                                                   auth_provider))
+                                                   auth_provider,
+                                                   "My Company"))
     else:
         logger.info('All user groups for group switching are evm built-in: {}'
                     .format(auth_user.groups))


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->
Adding fix for group creation

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->

{{pytest: ./cfme/tests/integration/test_cfme_auth.py::test_user_group_switching --long-running -v}}
