### PR TITLE
[1LP][RFR] Fix test_embedded_ansible_custom_button

### DIFF
--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -219,7 +219,8 @@ def test_ansible_playbook_button_crud(ansible_catalog_item, appliance, request):
 
 @pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
 def test_embedded_ansible_custom_button_localhost(create_vm_modscope, custom_vm_button,
-        appliance, ansible_service_request, ansible_service, ansible_catalog_item):
+        appliance, ansible_service_request_funcscope,
+        ansible_service_funcscope, ansible_catalog_item):
     """
     Polarion:
         assignee: gtalreja
@@ -234,17 +235,19 @@ def test_embedded_ansible_custom_button_localhost(create_vm_modscope, custom_vm_
     order_dialog_view.submit_button.wait_displayed()
     order_dialog_view.fields("credential").fill("CFME Default Credential")
     order_dialog_view.submit_button.click()
-    wait_for(ansible_service_request.exists, num_sec=600)
-    ansible_service_request.wait_for_request()
-    view = navigate_to(ansible_service, "Details")
+    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
+    ansible_service_request_funcscope.wait_for_request()
+    view = navigate_to(ansible_service_funcscope, "Details")
     hosts = view.provisioning.details.get_text_of("Hosts")
     assert hosts == "localhost"
-    assert view.provisioning.results.get_text_of("Status") == "successful"
+    status = "successful" if appliance.version < "5.11" else "Finished"
+    assert view.provisioning.results.get_text_of("Status") == status
 
 
 @pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
 def test_embedded_ansible_custom_button_target_machine(create_vm_modscope, custom_vm_button,
-        ansible_credential, appliance, ansible_service_request, ansible_service):
+        ansible_credential, appliance, ansible_service_request_funcscope,
+        ansible_service_funcscope):
     """
     Polarion:
         assignee: gtalreja
@@ -259,17 +262,19 @@ def test_embedded_ansible_custom_button_target_machine(create_vm_modscope, custo
     order_dialog_view.submit_button.wait_displayed()
     order_dialog_view.fields("credential").fill(ansible_credential.name)
     order_dialog_view.submit_button.click()
-    wait_for(ansible_service_request.exists, num_sec=600)
-    ansible_service_request.wait_for_request()
-    view = navigate_to(ansible_service, "Details")
+    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
+    ansible_service_request_funcscope.wait_for_request()
+    view = navigate_to(ansible_service_funcscope, "Details")
     hosts = view.provisioning.details.get_text_of("Hosts")
     assert hosts == create_vm_modscope.ip_address
-    assert view.provisioning.results.get_text_of("Status") == "successful"
+    status = "successful" if appliance.version < "5.11" else "Finished"
+    assert view.provisioning.results.get_text_of("Status") == status
 
 
 @pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
 def test_embedded_ansible_custom_button_specific_hosts(create_vm_modscope, custom_vm_button,
-        ansible_credential, appliance, ansible_service_request, ansible_service):
+        ansible_credential, appliance, ansible_service_request_funcscope,
+        ansible_service_funcscope):
     """
     Polarion:
         assignee: gtalreja
@@ -285,12 +290,13 @@ def test_embedded_ansible_custom_button_specific_hosts(create_vm_modscope, custo
     order_dialog_view.submit_button.wait_displayed()
     order_dialog_view.fields("credential").fill(ansible_credential.name)
     order_dialog_view.submit_button.click()
-    wait_for(ansible_service_request.exists, num_sec=600)
-    ansible_service_request.wait_for_request()
-    view = navigate_to(ansible_service, "Details")
+    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
+    ansible_service_request_funcscope.wait_for_request()
+    view = navigate_to(ansible_service_funcscope, "Details")
     hosts = view.provisioning.details.get_text_of("Hosts")
     assert hosts == create_vm_modscope.ip_address
-    assert view.provisioning.results.get_text_of("Status") == "successful"
+    status = "successful" if appliance.version < "5.11" else "Finished"
+    assert view.provisioning.results.get_text_of("Status") == status
 
 
 @test_requirements.alert


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{ pytest: cfme/tests/ansible/test_embedded_ansible_automate.py -k "test_embedded_ansible_custom_button_localhost or  test_embedded_ansible_custom_button_target_machine or test_embedded_ansible_custom_button_specific_hosts" --long-running }}