### PR TITLE
[1LP][RFR] Update docker-py 1.10 to docker 4.2

### DIFF
--- a/cfme/utils/dockerbot/pytestbase/Dockerfile
+++ b/cfme/utils/dockerbot/pytestbase/Dockerfile
@@ -1,10 +1,12 @@
 FROM fedora:30
 
+#TODO rewrite this to use quickstart
+
 RUN dnf install -y gcc postgresql-devel libxml2-devel libxslt-devel zeromq-devel git nano python3-devel gnupg gnupg2 libcurl-devel redhat-rpm-config findutils libffi-devel openssl-devel tesseract freetype-devel gcc-c++ python3-pip python3 libjpeg-devel iputils && dnf clean all
 ARG CFME_REPO=https://github.com/ManageIQ/integration_tests.git
 ARG CFME_BRANCH=master
 RUN git clone -b $CFME_BRANCH $CFME_REPO /cfme_tests
-RUN cd /cfme_tests && PYCURL_SSL_LIBRARY=openssl pip3 install -U -r /cfme_tests/requirements/frozen.py3.txt --no-cache-dir
+RUN cd /cfme_tests && PYCURL_SSL_LIBRARY=openssl pip3 install --user -U -r /cfme_tests/requirements/frozen.txt --no-cache-dir
 RUN python3 -c 'import pycurl'
 ADD setup.sh /setup.sh
 ADD post_result.py /post_result.py

--- a/cfme/utils/dockerbot/sel_container.py
+++ b/cfme/utils/dockerbot/sel_container.py
@@ -33,7 +33,7 @@ def vnc_ready(addr, port):
 @click.option('--image', help='Chooses selenium container image',
               default=docker_conf.get('selff', 'cfmeqe/sel_ff_chrome'))
 @click.option('--vncviewer', help='Chooses VNC viewer command',
-              default=docker_conf.get('vncviewer', 'vinagre'))
+              default=docker_conf.get('vncviewer', 'vncviewer'))
 @click.option('--random-ports', is_flag=True, default=False,
               help='Choose random ports for VNC, webdriver, (overrides --webdriver and --vnc)')
 def main(watch, vnc, webdriver, image, vncviewer, random_ports):

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -126,7 +126,7 @@ Deprecated==1.2.5
 diaper==1.3
 dictdiffer==0.8.0
 distro==1.5.0
-docker-py==1.10.6
+docker==4.2.0
 docker-pycreds==0.4.0
 docutils==0.15.2
 dogpile.cache==0.7.1

--- a/requirements/frozen_docs.py3.txt
+++ b/requirements/frozen_docs.py3.txt
@@ -118,7 +118,7 @@ deepdiff==3.3.0
 diaper==1.3
 dictdiffer==0.8.0
 distro==1.4.0
-docker-py==1.10.6
+docker==4.2.0
 docker-pycreds==0.4.0
 docutils==0.15.2
 dogpile.cache==0.7.1

--- a/requirements/template_scanned_imports.txt
+++ b/requirements/template_scanned_imports.txt
@@ -15,7 +15,7 @@ dateparser
 debtcollector
 deepdiff
 diaper
-docker-py
+docker
 fauxfactory
 gevent
 humanfriendly


### PR DESCRIPTION
The structure of the library changed significantly, thus dockerbot needed significant changes

We no longer need to process info from inspect, and the interface for creating an running containers has completely changed.

I moved some of the logging around, and changed the logic to accommodate the docker API changes.


NOTE: 
I stopped short of updating the dockerfile for the pytest container.  It needs to be rewritten to use quickstart, but that is out of scope of trying to update our docker dependency.

The DockerInstance changes can be verified by running `miq-selenium-container`