### PR TITLE
[1LP][RFR] Fix bug in format of output in _setup_provider_verbose

### DIFF
--- a/cfme/fixtures/provider.py
+++ b/cfme/fixtures/provider.py
@@ -117,7 +117,7 @@ def _setup_provider_verbose(request, provider, appliance=None):
             if len(existing_providers) > maximum_current_providers:
                 providers_to_remove = existing_providers[maximum_current_providers:]
                 store.terminalreporter.write_line(
-                    "Removing extra providers: {', '.join([p.key for p in providers_to_remove])}")
+                    f"Removing extra providers: {', '.join([p.key for p in providers_to_remove])}")
                 for p in providers_to_remove:
                     logger.info('removing provider %r', p.key)
                     p.delete_rest()


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ Ouput message in _setup_provider_verbose. 

### PRT Run

{{ pytest: --use-provider rhv43 --use-provider vsphere67-nested --long-running cfme/tests/infrastructure test_vm_power_control.TestVmDetailsPowerControlPerProvider::test_power_on }}

