### PR TITLE
[WIPTEST] Fix schema tc

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -43,6 +43,7 @@ from widgetastic.widget import Text
 from widgetastic.widget import TextInput
 from widgetastic.widget import View
 from widgetastic.widget import Widget
+from widgetastic.widget.base import ParametrizedViewRequest
 from widgetastic.xpath import quote
 from widgetastic_patternfly import Accordion as PFAccordion
 from widgetastic_patternfly import AggregateStatusCard
@@ -4224,7 +4225,11 @@ class WaitTab(Tab):
                 if _tries >= _to_try:  # raise the TimedOutError if we've tried enough times
                     raise
         try:
-            widget.wait_displayed(timeout=2)
+
+            if isinstance(widget, ParametrizedViewRequest):
+                pass
+            else:
+                widget.wait_displayed(timeout=2)
         except TimedOutError:
             self.logger.warning("Tab widget not displayed, continuing...")
 


### PR DESCRIPTION
Fixed below error:
```
>           'parameters of the view.'.format(self.view_class.__name__))
E       AttributeError: This is not an instance of fields. You need to call this object and pass the required parameters of the view.

/var/ci/cfme_venv3/lib64/python3.7/site-packages/widgetastic/widget/base.py:1199: AttributeError
AttributeError
b'This is not an instance of fields. You need to call this object and pass the required parameters of the view.'
```

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{ pytest: cfme/tests/automate/test_class.py -k 'test_schema_crud' --use-template-cache -qsvvv }}


