### PR TITLE
[1LP][RFR] Add support for create and nav_away to Host.update() and test_infrastructure_hosts_crud

### DIFF
--- a/cfme/common/host_views.py
+++ b/cfme/common/host_views.py
@@ -307,7 +307,7 @@ class HostEditView(HostFormView):
     @property
     def is_displayed(self):
         return (
-            self.logged_in_as_current_user and self.navigation.currently_selected == [
+            self.in_compute_infrastructure_hosts and self.navigation.currently_selected == [
                 'Compute', 'Infrastructure', 'Hosts'] and self.title.text == 'Info/Settings')
 
 

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -101,7 +101,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
         Args:
            updates (dict): fields that are changing.
            action (str): denotes additional functionality. Expecting edit_from_details,
-           edit_from_hosts, delete, cancel, or nav_away.
+           edit_from_hosts, cancel, or nav_away.
         """
         if 'from_hosts' not in action:
             view = navigate_to(self, "Edit")

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -94,7 +94,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
             super(Host.Credential, self).__init__(**kwargs)
             self.ipmi = kwargs.get('ipmi')
 
-    def update(self, updates, validate_credentials=False, from_details=False):
+    def update(self, updates, validate_credentials=False, from_details=True):
         """Updates a host in the UI. Better to use utils.update.update context manager than call
         this directly.
 
@@ -102,10 +102,12 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
            updates (dict): fields that are changing.
         """
         if from_details:
-            view = navigate_to(self, "Details")
+            view = navigate_to(self, "Edit")
         else:
             view = navigate_to(self.parent, "All")
-        view = navigate_to(self, "Edit")
+            view.entities.get_entity(name=self.name, surf_pages=True).ensure_checked()
+            view.toolbar.configuration.item_select('Edit Selected items')
+            view = self.create_view(HostEditView)
         changed = view.fill({
             "name": updates.get("name"),
             "hostname": updates.get("hostname") or updates.get("ip_address"),

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -108,6 +108,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
             view.entities.get_entity(name=self.name, surf_pages=True).ensure_checked()
             view.toolbar.configuration.item_select('Edit Selected items')
             view = self.create_view(HostEditView)
+            assert view.is_displayed
         changed = view.fill({
             "name": updates.get("name"),
             "hostname": updates.get("hostname") or updates.get("ip_address"),

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -100,9 +100,13 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
         this directly.
 
         Args:
-           updates (dict): fields that are changing.
-           action (str): denotes additional functionality. Expecting edit_from_details,
-           edit_from_hosts, cancel, or nav_away.
+            updates (dict): fields that are changing.
+            validate_credentials (bool): if True, validate host credentials
+            from_details (bool): if True, select 'Edit Selected items' from details view
+                else,  select 'Edit Selected items' from hosts view
+            cancel (bool): click cancel button to cancel the edit if True
+            nav_away (bool): navigate away from edit view before saving if True
+            changes (bool): expecting saved changes if True
         """
         if from_details:
             view = navigate_to(self, "Edit")
@@ -113,6 +117,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
             view = self.create_view(HostEditView)
             assert view.is_displayed
         if nav_away and not changes:
+            # navigate away before any changes have been made in the edit view
             view.navigation.select('Compute', 'Infrastructure', 'Hosts',
                                   handle_alert=False)
             view = self.create_view(HostsView)
@@ -146,6 +151,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
                 view.endpoints.ipmi.validate_button.click()
         view.flash.assert_no_error()
         if nav_away and changes:
+            # navigate away here after changes have been made in the edit view
             view = navigate_to(self.parent, "All")
             assert view.is_displayed
             return

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -1,8 +1,8 @@
 """A model of an Infrastructure Host in CFME."""
 import json
-import pytest
 
 import attr
+import pytest
 from manageiq_client.api import APIException
 from navmazing import NavigateToAttribute
 from navmazing import NavigateToSibling

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -94,7 +94,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
             super(Host.Credential, self).__init__(**kwargs)
             self.ipmi = kwargs.get('ipmi')
 
-    def update(self, updates, validate_credentials=False, from_details=False, cancel=False):
+    def update(self, updates, validate_credentials=False, from_details=True, cancel=False):
         """Updates a host in the UI. Better to use utils.update.update context manager than call
         this directly.
 

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -103,6 +103,8 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
         """
         if from_details:
             view = navigate_to(self, "Details")
+        else:
+            view = navigate_to(self.parent, "All")
         view = navigate_to(self, "Edit")
         changed = view.fill({
             "name": updates.get("name"),

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -94,7 +94,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
             super(Host.Credential, self).__init__(**kwargs)
             self.ipmi = kwargs.get('ipmi')
 
-    def update(self, updates, validate_credentials=False, from_details=True,
+    def update(self, updates, validate_credentials=False, from_hosts=False,
                cancel=False, nav_away=False, changes=True):
         """Updates a host in the UI. Better to use utils.update.update context manager than call
         this directly.
@@ -102,20 +102,20 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
         Args:
             updates (dict): fields that are changing.
             validate_credentials (bool): if True, validate host credentials
-            from_details (bool): if True, select 'Edit Selected items' from details view
-                else,  select 'Edit Selected items' from hosts view
+            from_hosts (bool): if True, select 'Edit Selected items' from hosts view
+                else, select 'Edit Selected items' from details view
             cancel (bool): click cancel button to cancel the edit if True
             nav_away (bool): navigate away from edit view before saving if True
             changes (bool): expecting saved changes if True
         """
-        if from_details:
-            view = navigate_to(self, "Edit")
-        else:
+        if from_hosts:
             view = navigate_to(self.parent, "All")
             view.entities.get_entity(name=self.name, surf_pages=True).ensure_checked()
             view.toolbar.configuration.item_select('Edit Selected items')
             view = self.create_view(HostEditView)
             assert view.is_displayed
+        else:
+            view = navigate_to(self, "Edit")
         if nav_away and not changes:
             # navigate away before any changes have been made in the edit view
             view.navigation.select('Compute', 'Infrastructure', 'Hosts',

--- a/cfme/infrastructure/host.py
+++ b/cfme/infrastructure/host.py
@@ -94,7 +94,7 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
             super(Host.Credential, self).__init__(**kwargs)
             self.ipmi = kwargs.get('ipmi')
 
-    def update(self, updates, validate_credentials=False, from_details=True):
+    def update(self, updates, validate_credentials=False, from_details=False):
         """Updates a host in the UI. Better to use utils.update.update context manager than call
         this directly.
 
@@ -102,13 +102,8 @@ class Host(BaseEntity, Updateable, Pretty, PolicyProfileAssignable, Taggable,
            updates (dict): fields that are changing.
         """
         if from_details:
-            view = navigate_to(self, "Edit")
-        else:
-            view = navigate_to(self.parent, "All")
-            view.entities.get_entity(name=self.name, surf_pages=True).ensure_checked()
-            view.toolbar.configuration.item_select('Edit Selected items')
-            view = self.create_view(HostEditView)
-            assert view.is_displayed
+            view = navigate_to(self, "Details")
+        view = navigate_to(self, "Edit")
         changed = view.fill({
             "name": updates.get("name"),
             "hostname": updates.get("hostname") or updates.get("ip_address"),

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -1,5 +1,6 @@
 import random
 import socket
+from datetime import datetime
 
 import fauxfactory
 import pytest
@@ -8,10 +9,10 @@ from widgetastic.exceptions import UnexpectedAlertPresentException
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
+from cfme.common.host_views import HostDetailsView
+from cfme.common.host_views import HostEditView
 from cfme.common.host_views import HostsCompareView
 from cfme.common.host_views import HostsEditView
-from cfme.common.host_views import ProviderHostsCompareView
-from cfme.common.host_views import HostsEditView, HostEditView, HostsView, HostDetailsView
 from cfme.common.provider_views import InfraProviderDetailsView
 from cfme.common.provider_views import InfraProvidersView
 from cfme.common.provider_views import ProviderNodesView

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -558,7 +558,12 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
     if crud_action != 'remove':
         new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
         try:
-            with update(host, action=crud_action):
+            with update(host,
+                        from_details=(crud_action == 'edit_from_details'),
+                        cancel=(crud_action == 'cancel'),
+                        nav_away=(crud_action == 'nav_away'),
+                        changes=(crud_action == 'changes')
+                        ):
                 host.custom_ident = new_custom_id
         except UnexpectedAlertPresentException as e:
             if crud_action in ['cancel', 'nav_away_no_changes'] and "Abandon changes" in e.msg:
@@ -566,8 +571,6 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
             else:
                 raise
         if crud_action not in ['cancel', 'nav_away_changes', 'nav_away_no_changes']:
-            assert host.custom_ident == new_custom_id  # is this actually doing anything here
-            # different from the line below ?
             assert navigate_to(host, 'Details').entities.summary("Properties").get_text_of(
                 "Custom Identifier") == new_custom_id
         else:

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -556,8 +556,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
         except NameError:
             existing_custom_id = None
     if crud_action != 'remove':
-        stamp = fauxfactory.gen_alphanumeric()
-        new_custom_id = f'Edit host data. {stamp}'
+        new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
         try:
             with update(host, action=crud_action):
                 host.custom_ident = new_custom_id
@@ -579,5 +578,5 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
                 if existing_custom_id:
                     raise
     else:
-        host.delete()
+        host.delete(cancel=True)
         host.delete(cancel=False)

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -494,6 +494,7 @@ def test_infrastructure_hosts_navigation_after_download_from_compare(
         initialEstimate: 1/3h
     Bugzilla:
         1747545
+
     """
     h_coll = locals()[hosts_collection].collections.hosts
     hosts_view = h_coll.compare_entities(provider, entities_list=h_coll.all()[:num_hosts])
@@ -541,6 +542,8 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
         casecomponent: Infra
         caseimportance: low
         initialEstimate: 1/6h
+    Bugzilla:
+        1634794
     """
     host = appliance.collections.hosts.all()[0]
     if crud_action != 'remove':

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -566,7 +566,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
         new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
         try:
             with update(host,
-                        from_details=(crud_action == 'edit_from_details'),
+                        from_hosts=(crud_action == 'edit_from_hosts'),
                         cancel=(crud_action == 'cancel'),
                         nav_away=(crud_action in ['nav_away_changes', 'nav_away_no_changes']),
                         changes=(crud_action == 'nav_away_changes')

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -540,6 +540,13 @@ def test_add_ipmi_refresh(appliance, setup_provider):
                                          'nav_away_changes', 'nav_away_no_changes', 'remove'])
 def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
     """
+    crud_action: (All are edit actions except for 'remove')
+        'edit_from_hosts'  : select host and click edit dropdown from the hosts view
+        'edit_from_details' : click edit dropdown from the details view of host to edit
+        'cancel' : click the cancel button before saving edits
+        'nav_away_changes' : navigate away from the edit view after making changes (not saved)
+        'nav_away_no_changes' : navigate away from the edit view without having made changes
+        'remove' : remove the host
     Polarion:
         assignee: prichard
         casecomponent: Infra
@@ -567,7 +574,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
                 host.custom_ident = new_custom_id
         except UnexpectedAlertPresentException as e:
             if crud_action in ['cancel', 'nav_away_no_changes'] and "Abandon changes" in e.msg:
-                pytest.fail("Abandon changes alert displayed, but no changes made.")
+                pytest.fail("Abandon changes alert displayed, but no changes made. BZ1634794")
             else:
                 raise
         if crud_action not in ['cancel', 'nav_away_changes', 'nav_away_no_changes']:

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -575,7 +575,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
     # start edit and cancel
     new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
     with update(host,
-                from_details=False,
+                from_details=True,
                 cancel=True,
                 ):
         host.custom_ident = new_custom_id

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -545,9 +545,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
 
     # Case1 - edit from Hosts
     new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
-    with update(host,
-                from_details=False,
-                ):
+    with update(host, from_details=False):
         host.custom_ident = new_custom_id
     # verify edit
     assert navigate_to(host, 'Details').entities.summary("Properties").get_text_of(
@@ -555,9 +553,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
 
     # Case2 - edit from Details
     new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
-    with update(host,
-                from_details=True,
-                ):
+    with update(host, from_details=True):
         host.custom_ident = new_custom_id
     # verify edit
     assert navigate_to(host, 'Details').entities.summary("Properties").get_text_of(
@@ -572,10 +568,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
         existing_custom_id = None
     # start edit and cancel
     new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
-    with update(host,
-                from_details=True,
-                cancel=True,
-                ):
+    with update(host, from_details=True, cancel=True):
         host.custom_ident = new_custom_id
     # verify edit
     # No changes are expected. Comparing to existing value captured above.
@@ -590,8 +583,7 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
     view = navigate_to(host, "Edit")
     # navigate away before any changes have been made in the edit view
     try:
-        view.navigation.select('Compute', 'Infrastructure', 'Hosts',
-                               handle_alert=False)
+        view.navigation.select('Compute', 'Infrastructure', 'Hosts', handle_alert=False)
     except UnexpectedAlertPresentException as e:
         if "Abandon changes" in e.msg:
             pytest.fail("Abandon changes alert displayed, but no changes made. BZ1634794")

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -4,11 +4,16 @@ import socket
 import fauxfactory
 import pytest
 from wait_for import TimedOutError
+from widgetastic.exceptions import UnexpectedAlertPresentException
 
 from cfme import test_requirements
 from cfme.base.credential import Credential
+from cfme.common.host_views import HostsCompareView
 from cfme.common.host_views import HostsEditView
+from cfme.common.host_views import ProviderHostsCompareView
+from cfme.common.host_views import HostsEditView, HostEditView, HostsView, HostDetailsView
 from cfme.common.provider_views import InfraProviderDetailsView
+from cfme.common.provider_views import InfraProvidersView
 from cfme.common.provider_views import ProviderNodesView
 from cfme.fixtures.provider import setup_or_skip
 from cfme.infrastructure.provider import InfraProvider
@@ -86,7 +91,6 @@ def navigate_and_select_quads(provider):
 
     Returns:
         view: the provider nodes view, quadicons already selected"""
-    # TODO: prichard navigate instead of creating views and consider creaing EditableMixin
     hosts_view = navigate_to(provider, 'ProviderNodes')
     assert hosts_view.is_displayed
     [h.ensure_checked() for h in hosts_view.entities.get_all()]
@@ -462,6 +466,9 @@ def test_infrastructure_hosts_compare(appliance, setup_provider_min_hosts, provi
         casecomponent: Infra
         caseimportance: high
         initialEstimate: 1/6h
+    Bugzilla:
+        1746214
+
     """
 
     h_coll = locals()[hosts_collection].collections.hosts

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -547,7 +547,6 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
     new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
     with update(host,
                 from_details=False,
-                cancel=False,
                 ):
         host.custom_ident = new_custom_id
     # verify edit
@@ -558,7 +557,6 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
     new_custom_id = f'Edit host data. {fauxfactory.gen_alphanumeric()}'
     with update(host,
                 from_details=True,
-                cancel=False,
                 ):
         host.custom_ident = new_custom_id
     # verify edit
@@ -626,4 +624,4 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
 
     # Case6 - lastly do the delete. First try is canceled.
     host.delete(cancel=True)
-    host.delete(cancel=False)
+    host.delete

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -469,7 +469,6 @@ def test_infrastructure_hosts_compare(appliance, setup_provider_min_hosts, provi
         initialEstimate: 1/6h
     Bugzilla:
         1746214
-
     """
 
     h_coll = locals()[hosts_collection].collections.hosts

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -537,7 +537,7 @@ def test_add_ipmi_refresh(appliance, setup_provider):
 @test_requirements.infra_hosts
 @pytest.mark.meta(automates=[1634794])
 @pytest.mark.parametrize("crud_action", ['edit_from_hosts', 'edit_from_details', 'cancel',
-                                         'nav_away_changes, nav_away_no_changes', 'remove'])
+                                         'nav_away_changes', 'nav_away_no_changes', 'remove'])
 def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
     """
     Polarion:

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -561,8 +561,8 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
             with update(host,
                         from_details=(crud_action == 'edit_from_details'),
                         cancel=(crud_action == 'cancel'),
-                        nav_away=(crud_action == 'nav_away'),
-                        changes=(crud_action == 'changes')
+                        nav_away=('nav_away' in crud_action),
+                        changes=('changes' in crud_action and 'no' not in crud_action)
                         ):
                 host.custom_ident = new_custom_id
         except UnexpectedAlertPresentException as e:

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -543,8 +543,6 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
         casecomponent: Infra
         caseimportance: low
         initialEstimate: 1/6h
-    Bugzilla:
-        1634794
     """
     host = appliance.collections.hosts.all()[0]
     if crud_action != 'remove':

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -568,8 +568,8 @@ def test_infrastructure_hosts_crud(appliance, setup_provider, crud_action):
             with update(host,
                         from_details=(crud_action == 'edit_from_details'),
                         cancel=(crud_action == 'cancel'),
-                        nav_away=('nav_away' in crud_action),
-                        changes=('changes' in crud_action and 'no' not in crud_action)
+                        nav_away=(crud_action in ['nav_away_changes', 'nav_away_no_changes']),
+                        changes=(crud_action == 'nav_away_changes')
                         ):
                 host.custom_ident = new_custom_id
         except UnexpectedAlertPresentException as e:


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ for host edit to support cancel of edit and also navigating away before saving updates. The navigating away case will cover customer BZ 1634794.



### PRT Run

{{ pytest: --use-provider complete --long-running cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_crud }}