### PR TITLE
[1LP][RFR] Automating dialog field associations dialog test

### DIFF
--- a/cfme/automate/dialogs/dialog_element.py
+++ b/cfme/automate/dialogs/dialog_element.py
@@ -67,6 +67,10 @@ class ElementForm(AddBoxView):
         validation_switch = DialogBootstrapSwitch(label='Validation')
         validation = Input(name='validator_rule')
         visible = DialogBootstrapSwitch(label='Visible')
+        refresh_fields_dropdown = BootstrapSelect(
+            locator='//label[contains(normalize-space(.), '
+                    '"Fields to refresh")]/following-sibling::div/span/div'
+        )
 
     @View.nested
     class advanced(WaitTab):  # noqa

--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -1114,3 +1114,38 @@ def test_dialog_not_required_default_value(appliance, generic_catalog_item_with_
 
     view = navigate_to(service_catalogs, "Order")
     assert view.fields("dropdown_list_1").read() == default_drop
+
+
+@pytest.mark.meta(automates=[1559382])
+@pytest.mark.customer_scenario
+@pytest.mark.parametrize(
+    "import_data", [DatastoreImport("bz_1559382.zip", "bz_1559382", None)], ids=["domain"], )
+@pytest.mark.parametrize("file_name", ["bz_1559382.yml"], ids=["dialog"])
+def test_dynamic_dialog_field_associations(appliance, import_datastore, import_dialog,
+                                           import_data):
+    """ Tests dynamic service dialog field associations
+    Bugzilla:
+        1559382
+    Polarion:
+        assignee: nansari
+        casecomponent: Services
+        testtype: functional
+        initialEstimate: 1/4h
+        startsin: 5.10
+    """
+    sd, ele_label = import_dialog
+    navigate_to(sd, "Edit")
+    # update dialog element
+    view = appliance.browser.create_view(EditElementView)
+    view.element.edit_element(ele_label)
+    view.options.click()
+
+    # Select text_area field to refresh
+    view.options.refresh_fields_dropdown.fill("text-area")
+    view.ele_save_button.click()
+    view.save_button.click()
+
+    # check warning flash message
+    view.flash.assert_message([
+        'There was an error editing this dialog: Failed to update service dialog -'
+        'text-box already exists in ["text-box", "textarea"]'])

--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -288,23 +288,6 @@ def test_in_dynamic_dropdown_list_the_default_value_should_not_contain_all_the_v
 
 
 @pytest.mark.manual
-@pytest.mark.tier(3)
-def test_cui_should_check_dialog_field_associations():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/6h
-        startsin: 5.10
-        tags: service
-    Bugzilla:
-        1559382
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(2)
 def test_timepicker_should_pass_correct_timing_on_service_order():
     """


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_dynamic_dialog_field_associations }}


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
