### PR TITLE
[1LP][RFR] Automating service dialog load test

### DIFF
--- a/cfme/tests/services/test_dynamicdd_dialogelement.py
+++ b/cfme/tests/services/test_dynamicdd_dialogelement.py
@@ -243,23 +243,6 @@ def test_dynamic_dropdowns_should_show_value_only_once():
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_dd_multiselect_default_element_is_shouldnt_be_blank_when_loaded_by_another_element():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        initialEstimate: 1/16h
-        testtype: functional
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1645555
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_ssui_dd_values_are_not_loaded_in_dropdown_unless_refresh_button_is_pressed():
     """
@@ -533,3 +516,36 @@ def test_update_dynamic_field_on_refresh(appliance, import_datastore, import_dat
         lambda: view.fields("dynamic_1").read() == 'reboot' and
         view.fields("dynamic_2").read() == 'reboot', timeout=7
     )
+
+
+@pytest.mark.meta(automates=[1595776])
+@pytest.mark.customer_scenario
+@pytest.mark.parametrize("import_data", [DatastoreImport("bz_1595776.zip", "bz_1595776", None)],
+                         ids=["datastore"])
+@pytest.mark.parametrize("file_name", ["bz_1595776.yml"], ids=["sample_dialog"],)
+def test_load_service_dialog(appliance, import_datastore,
+                             generic_catalog_item_with_imported_dialog):
+    """
+    Bugzilla:
+        1595776
+
+    Polarion:
+        assignee: nansari
+        startsin: 5.10
+        casecomponent: Services
+        initialEstimate: 1/16h
+    """
+    auto_log = '/var/www/miq/vmdb/log/automation.log'
+    catalog_item, _, _ = generic_catalog_item_with_imported_dialog
+    service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
+
+    with LogValidator(auto_log, matched_patterns=["Service dialog load - Begin"]
+                      ).waiting(timeout=120):
+        view = navigate_to(service_catalogs, "Order")
+
+    with LogValidator(auto_log, failure_patterns=["Service dialog load - Begin"]
+                      ).waiting(timeout=120):
+        view.submit_button.click()
+        description = f'Provisioning Service [{catalog_item.name}] from [{catalog_item.name}]'
+        provision_request = appliance.collections.requests.instantiate(description)
+        provision_request.wait_for_request(method='ui')

--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -203,23 +203,6 @@ def test_dialog_dropdown_ui_values_in_the_dropdown_should_be_visible_in_edit_mod
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_dialogs_should_only_run_once():
-    """ Dialogs should only run once
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        startsin: 5.9
-        initialEstimate: 1/4h
-        tags: service
-    Bugzilla:
-        1595776
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_triggered_refresh_shouldnt_occurs_for_dialog_after_changing_type_to_static():
     """ Triggered Refresh shouldn't Occurs for Dialog After Changing Type to Static


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run

{{pytest: cfme/tests/services/test_dynamicdd_dialogelement.py::test_load_service_dialog --long-running }}


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
removed `test_dd_multiselect_default_element_is_shouldnt_be_blank_when_loaded_by_another_element` test. we already have automation for multiselect dropdown