### PR TITLE
[1LP][RFR] automate test_update_yum_no_errors

### DIFF
--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -1,3 +1,4 @@
+import re
 from collections import namedtuple
 
 import fauxfactory
@@ -120,9 +121,9 @@ def do_yum_update(appliance):
     return result
 
 
-@pytest.mark.meta(automates=[1714236])
+@pytest.mark.meta(automates=[1714236], coverage=[1674055])
 def test_update_yum(appliance_preupdate, appliance):
-    """Tests appliance update between versions
+    """Tests appliance update between versions - version changed no warnings or errors
 
     Polarion:
         assignee: jhenner
@@ -133,37 +134,11 @@ def test_update_yum(appliance_preupdate, appliance):
     Bugzilla:
         1714236
     """
-    do_yum_update(appliance_preupdate)
+    update_output = do_yum_update(appliance_preupdate).output
     result = appliance_preupdate.ssh_client.run_command('cat /var/www/miq/vmdb/VERSION')
     assert result.output in appliance.version
-
-
-@pytest.mark.meta(coverage=[1674055])
-def test_update_yum_no_errors(appliance_preupdate):
-    """ Test that the yum update doesn't spill any erros or warnings.
-
-    Polarion:
-        assignee: jhenner
-        caseimportance: high
-        casecomponent: Appliance
-        initialEstimate: 1/4h
-        testSteps:
-            1. Boot preupdate CFME
-            2. Add repos to update to.
-            3. Do the yum update, check there are no errors in the stderr and
-               perhaps also in stdout.
-        expectedResults:
-            1.
-            2.
-            3. No errors in the stderr and stdout, yum exit status is 0
-
-    Bugzilla:
-        1674055
-    """
-    result = do_yum_update(appliance_preupdate)
-    for phrase in ["fail", "error", "warning"]:
-        assert phrase not in result.output.lower(), f"update output contains {phrase}\n\
-        n{result.output}"
+    matches = re.search(r'error|warning|fail', update_output, re.IGNORECASE)
+    assert not matches, f"update output contains {matches.group()}\n\n{update_output}"
 
 
 @pytest.mark.ignore_stream("upstream")

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -128,9 +128,9 @@ def do_yum_update(appliance):
     return output
 
 
-@pytest.mark.meta(automates=[1714236], coverage=[1674055])
+@pytest.mark.meta(automates=[1714236, 1674055])
 def test_update_yum(appliance_preupdate, appliance):
-    """Tests appliance update between versions - version changed no warnings or errors
+    """Tests appliance update between versions - version changed and there are no warnings or errors
 
     Polarion:
         assignee: jhenner

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -117,6 +117,7 @@ def do_yum_update(appliance):
         assert result.success, f"update failed {result.output}"
     appliance.evmserverd.start()
     appliance.wait_for_web_ui()
+    return result
 
 
 @pytest.mark.meta(automates=[1714236])
@@ -137,9 +138,8 @@ def test_update_yum(appliance_preupdate, appliance):
     assert result.output in appliance.version
 
 
-@pytest.mark.manual
 @pytest.mark.meta(coverage=[1674055])
-def test_update_yum_no_errors(old_version):
+def test_update_yum_no_errors(appliance_preupdate):
     """ Test that the yum update doesn't spill any erros or warnings.
 
     Polarion:
@@ -155,12 +155,15 @@ def test_update_yum_no_errors(old_version):
         expectedResults:
             1.
             2.
-            3. No erros in the stderr and stdout, yum exit status is 0
+            3. No errors in the stderr and stdout, yum exit status is 0
 
     Bugzilla:
         1674055
     """
-    pass
+    result = do_yum_update(appliance_preupdate)
+    for phrase in ["fail", "error", "warning"]:
+        assert phrase not in result.output.lower(), f"update output contains {phrase}\n\
+        n{result.output}"
 
 
 @pytest.mark.ignore_stream("upstream")


### PR DESCRIPTION
Merged the manual test with test_yum_update. New test was failing because of warnings about .rpmnew files. But it doesn’t look like a problem, admins should see this warning to check their config files... So this kind of warning is filtered from yum update output.

{{pytest: cfme/tests/cli/test_appliance_update.py::test_update_yum --long-running}}