### PR TITLE
[1LP][RFR] Fixing the vm is_display

### DIFF
--- a/cfme/v2v/migration_plans.py
+++ b/cfme/v2v/migration_plans.py
@@ -188,7 +188,7 @@ class AddMigrationPlanView(View):
         @property
         def is_displayed(self):
             return self.table.is_displayed and (
-                len(self.browser.elements(".//div[contains(@class,'spinner')]")) == 0
+                not self.browser.elements(".//h3[contains(text(),'Discovering VMs')]")
             )
 
         def csv_import(self, vm_list):
@@ -245,8 +245,9 @@ class AddMigrationPlanView(View):
 
         @property
         def is_displayed(self):
-            return (self.table.is_displayed and
-                    (len(self.browser.elements(".//div[contains(@class,'spinner')]")) == 0))
+            return self.table.is_displayed and (
+                not self.browser.elements(".//h3[contains(text(),'Discovering VMs')]")
+            )
 
         def fill(self, values):
             """


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

{{ pytest: cfme/tests/v2v/test_csv_import.py -k "test_csv_valid_vm" --use-provider rhv-ims --use-provider vsphere67-ims --provider-limit 2 -v }}

vm is_display is failing due to the below line in is_display code

>> len(self.browser.elements(".//div[contains(@class,'spinner')]")) == 0)

So, this line make sure that the vm loading spinner gets over which means vm data gets loaded in vm table.
However, in current upstream build, the background card view has been replaced with list view (**As shown in attached screenshots**), Due to which Now the spinner is available in background as well if multiple plans is in progress.
Now the issue is with is_display code -->  .//div[contains(@class,'spinner')]")) , It consider the background spinner as well in consideration and return **False** for vm is_display.   
   
So, to be more specific to VM page, the spinner logic is replaced with the below text which display during loading of VM data.

>> not self.browser.elements(".//h3[contains(text(),'Discovering VMs')]")