### PR TITLE
[RFR] Fix test_multi_host_multi_vm_migration

### DIFF
--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -100,9 +100,9 @@ def test_single_vm_migration_power_state_tags_retirement(appliance, provider,
 @pytest.mark.parametrize('source_type, dest_type, template_type',
                          [
                              ['nfs', 'nfs', [Templates.RHEL7_MINIMAL,
-                                             Templates.UBUNTU16_TEMPLATE,
-                                             Templates.RHEL69_TEMPLATE,
-                                             Templates.WIN7_TEMPLATE]
+                                             Templates.RHEL7_MINIMAL,
+                                             Templates.RHEL7_MINIMAL,
+                                             Templates.RHEL7_MINIMAL]
                               ]
                          ])
 def test_multi_host_multi_vm_migration(request, appliance, provider,
@@ -137,14 +137,15 @@ def test_multi_host_multi_vm_migration(request, appliance, provider,
     vms = request_details_list.read()
     # testing multi-host utilization
 
-    def _is_migration_started():
-        for vm in vms:
-            if 'Migrating' not in request_details_list.get_message_text(vm):
-                return False
+    def _is_migration_started(vm):
+        if 'Converting' not in request_details_list.get_message_text(vm):
+            return False
         return True
 
-    wait_for(func=_is_migration_started, message="migration is not started for all VMs, "
-             "be patient please", delay=5, num_sec=5400)
+    for vm in vms:
+        wait_for(func=_is_migration_started, func_args=[vm],
+            message="migration has not started for all VMs", delay=5, num_sec=300)
+
     host_creds = provider.hosts.all()
     hosts_dict = {key.name: [] for key in host_creds}
     for vm in vms:

--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -137,10 +137,12 @@ def test_multi_host_multi_vm_migration(request, appliance, provider,
     vms = request_details_list.read()
     # testing multi-host utilization
 
+    match = ['Converting', 'Migrating']
+
     def _is_migration_started(vm):
-        if 'Converting' not in request_details_list.get_message_text(vm):
-            return False
-        return True
+        if any(string in request_details_list.get_message_text(vm) for string in match):
+            return True
+        return False
 
     for vm in vms:
         wait_for(func=_is_migration_started, func_args=[vm],


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{ pytest: cfme/tests/v2v/test_v2v_migrations_single_vcenter.py --use-template-cache --provider-limit 2 --use-provider rhv43 --use-provider vsphere67-ims -k test_multi_host_multi_vm_migration}}

510 - PASS
511 - PASS
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
