### PR TITLE
[1LP][RFR] Automating dynamic dialog refresh field

### DIFF
--- a/cfme/tests/services/test_dynamicdd_dialogelement.py
+++ b/cfme/tests/services/test_dynamicdd_dialogelement.py
@@ -381,22 +381,6 @@ def test_read_dynamic_textbox_dialog_element(appliance, import_datastore, import
     wait_for(lambda: view.fields("dyna_txtbox2").read() == 'YES', timeout=7)
 
 
-@pytest.mark.manual
-@pytest.mark.tier(1)
-def test_automation_executed_on_field_refresh_are_called_twice_in_self_service_dialogs():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-
-    Bugzilla:
-        1576873
-    """
-    pass
-
-
 @pytest.mark.customer_scenario
 @pytest.mark.meta(automates=[1580535, 1694737])
 @pytest.mark.tier(2)

--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -97,23 +97,6 @@ def test_notification_banner_service_event_should_be_shown_in_notification_bell(
 
 @pytest.mark.manual
 @pytest.mark.tier(2)
-def test_reconfigure_service_fields_empty_after_deploying_service():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.8
-        tags: service
-    Bugzilla:
-        1580987
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
 def test_custom_image_on_item_bundle_crud():
     """
     Polarion:
@@ -298,23 +281,6 @@ def test_user_should_be_able_to_change_the_order_of_values_of_the_drop_down_list
         tags: service
     Bugzilla:
         1594301
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_search_field_at_the_top_of_a_dynamic_drop_down_dialog_element_should_display():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1553347
     """
     pass
 


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run

{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_dynamic_dropdown_refresh_load -svvv }}
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
automated above one and removed duplicate tests