### PR TITLE
[1LP][RFR] Fixing test migration_with_no_conversion

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -44,7 +44,7 @@ def set_skip_event_history_flag(appliance):
 
 def _start_event_workers_for_osp(appliance, provider):
     """This is a workaround to start event catchers until BZ 1753364 is fixed"""
-    provider_edit_view = navigate_to(provider, 'Edit')
+    provider_edit_view = navigate_to(provider, 'Edit', wait_for_view=30)
     endpoint_view = provider.endpoints_form(parent=provider_edit_view)
     endpoint_view.events.event_stream.select("AMQP")
     endpoint_view.events.event_stream.select("Ceilometer")

--- a/cfme/tests/v2v/test_v2v_migrations_ui.py
+++ b/cfme/tests/v2v/test_v2v_migrations_ui.py
@@ -555,8 +555,8 @@ def test_duplicate_mapping_name(appliance, mapping_data_vm_obj_mini):
     view.general.cancel_btn.click()
 
 
-def test_migration_with_no_conversion(appliance, delete_conversion_hosts, source_provider,
-                                      request, provider, mapping_data_vm_obj_mini):
+def test_migration_with_no_conversion(appliance, source_provider, request, provider,
+                                      mapping_data_vm_obj_mini, delete_conversion_hosts):
     """
     Test Migration plan without setting conversion hosts
     Polarion:


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

re-ordering fixtures(mapping_data_vm_obj_mini, delete_conversion_hosts) used in test. As for OSP the mapping widget throws error due to a warning window pop's up as shown in attached snap.

It really does not matter for this test if we create mapping before or after deleting the conversion host, what matter's is the migration should start after deletion of conversion host.

Now the order would be like
1. Create Mapping
2. Delete Conversion hosts
3. Start Migration
Expected result---> Migration should fail as appliance has no conversion hosts.


Note: I have increase the wait_for_view from default 10s to 30s as the PRT most of the time failing due to time out as it takes >10s for navigate_to(provider, 'Edit').

{{ pytest: cfme/tests/v2v/test_v2v_migrations_ui.py -k "test_migration_with_no_conversion"  --use-provider={osp13-ims,rhv-ims}  --use-provider vsphere67-ims --provider-limit 2 }}

5.11 : PRT passed for both OSP and RHV
5.10: PRT is failing for OSP in jenkins, Though the exception is not related to my changes, I have tried it locally on 5.10.15.1, It passed .

