### PR TITLE
[WIPTEST] Fixing wait_for_view for navigate_to method

### DIFF
--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -538,7 +538,8 @@ class CFMENavigateStep(NavigateStep):
         )
 
     def go(self, _tries=0, *args, **kwargs):
-        nav_args = {'use_resetter': True, 'wait_for_view': 10, 'force': False}
+        nav_args = {'use_resetter': True, 'wait_for_view': kwargs.get('wait_for_view', 10),
+                    'force': False}
         self.log_message("Beginning Navigation...", level="info")
         start_time = time.time()
         if _tries > 2:


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

>> navigate_to(provider, 'Edit')

The default time is hard-coded to 10s for is_display of the above navigation, However it is very likely for some page it takes >10s to load, I got into the situation while working IMS TC where TC failed as OSP provider edit page takes more than 10's to load and TC failed with below timeout error.

~~~~~~~~
cfme/utils/appliance/implementations/ui.py:593: TimedOutError
TimedOutError
b"Could not do 'Waiting for view [CloudProvidersView] to display' at /cfme/cfme_tests/cfme/utils/appliance/implementations/ui.py:592 in time"
~~~~~~~~

It is not good to use hard-coded value of wait_for_view, This PR will provide option to pass value of *wait_for_view* along with *Navigate_to* method and will keep default value to 10s.

>> navigate_to(src_provider, "Edit", wait_for_view=30)