### PR TITLE
[1LP][RFR] - test to check "Edit Tags" option

### DIFF
--- a/cfme/roles.py
+++ b/cfme/roles.py
@@ -386,7 +386,32 @@ role_access_ui_510z = {
         'Optimize': ['Utilization', 'Planning', 'Bottlenecks'],
         'Monitor': {
             'Alerts': ['Overview', 'All Alerts']
-        }
+        },
+        "Help": ["Documentation", "Product", "About"],
+        "API": [
+            "Pictures",
+            "Metrics",
+            "Apply Config Pattern",
+            "Event Streams",
+            "Service Offerings",
+            "Service Parameters Sets",
+        ],
+        "Service UI": [
+            "Core",
+            "Dashboard",
+            "My Services",
+            "VM Resource",
+            "My Orders",
+            "Service Catalog",
+            "Shopping Cart",
+        ],
+        'Access Rules for all Virtual Machines': [
+            'Instance Access Rules',
+            'Image Access Rules',
+            'VM Access Rules',
+            'Template Access Rules',
+            'API'
+        ]
     },
     'evmgroup-administrator': {
         'Automation': {
@@ -636,6 +661,32 @@ role_access_ui_511z = {
         'Monitor': {
             'Alerts': ['Overview', 'All Alerts']
         },
+        "Help": ["Documentation", "Product", "About"],
+        "API": [
+            "Pictures",
+            "Metrics",
+            "Apply Config Pattern",
+            "Execute Ansible Playbook",
+            "Event Streams",
+            "Service Offerings",
+            "Service Parameters Sets",
+        ],
+        "Service UI": [
+            "Dashboard",
+            "My Services",
+            "VM Resource",
+            "My Orders",
+            "Service Catalog",
+            "Shopping Cart",
+        ],
+        "User Settings": ["My Settings", "Tasks"],
+        "All VM and Instance Access Rules": [
+            "Instance Access Rules",
+            "Image Access Rules",
+            "VM Access Rules",
+            "Template Access Rules",
+        ],
+        "Main Configuration": ["Settings", "Access Control", "Diagnostics", "Database"],
     },
     'evmgroup-administrator': {
         'Overview': ['Dashboard', 'Reports', 'Utilization', 'Chargeback'],
@@ -895,3 +946,12 @@ role_access_ui_511z = {
         }
     }
 }
+
+
+FEATURES_510 = list(
+    role_access_ui_510z["evmgroup-super_administrator"].keys()
+)
+
+FEATURES_511 = list(
+    role_access_ui_511z["evmgroup-super_administrator"].keys()
+)


### PR DESCRIPTION
__adding_test__ Test to check `Edit Tags` option is present or not after clicking on **Policy** on VM details page
<!-- Make sure to prefix the PR Title with any one of the below options...


   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/configure/test_access_control.py  -k 'test_tags_manual_features' --long-running -v}}