### PR TITLE
[RFR] Update automates and blocker markers and fix a small bug

### DIFF
--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -453,7 +453,7 @@ def test_infrastructure_hosts_navigation_after_download(
 @pytest.mark.uncollectif(
     lambda provider, num_hosts: provider.one_of(RHEVMProvider, SCVMMProvider) and num_hosts > 2,
     reason=UNCOLLECT_REASON)
-@pytest.mark.meta(blockers=[BZ(1746214, forced_streams=["5.10"])], automates=[1746214, 1784181])
+@pytest.mark.meta(automates=[1746214, 1784181, 1794438])
 def test_infrastructure_hosts_compare(appliance, setup_provider_min_hosts, provider, num_hosts,
                         hosts_collection):
     """
@@ -470,8 +470,8 @@ def test_infrastructure_hosts_compare(appliance, setup_provider_min_hosts, provi
 
 
 @test_requirements.infra_hosts
-@pytest.mark.meta(blockers=[BZ(1747545, forced_streams=["5.10"]), BZ(1746214, forced_streams=[
-    "5.10"])], automates=[1747545])
+@pytest.mark.meta(blockers=[BZ(1747545, forced_streams=["5.10"])], automates=[1747545, 1738664,
+                                                                             1746214])
 @pytest.mark.parametrize("num_hosts", [2, 4])
 @pytest.mark.parametrize("hosts_collection", ["provider", "appliance"])
 @pytest.mark.parametrize('report_format', DownloadOptions, ids=[fmt.name for fmt in
@@ -489,7 +489,7 @@ def test_infrastructure_hosts_navigation_after_download_from_compare(
         1747545
     """
     h_coll = locals()[hosts_collection].collections.hosts
-    hosts_view = h_coll.compare_entities(provider, entities_list=h_coll.all()[:num_hosts])
+    hosts_view = h_coll.compare_entities(entities_list=h_coll.all()[:num_hosts])
     hosts_view.toolbar.download.item_select(report_format.value)
     if report_format == DownloadOptions.PDF:
         handle_extra_tabs(hosts_view)

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -19,7 +19,6 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.markers.env_markers.provider import ONE
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
 from cfme.utils.appliance.implementations.ui import navigate_to
-from cfme.utils.blockers import BZ
 from cfme.utils.update import update
 from cfme.utils.wait import wait_for
 
@@ -502,7 +501,7 @@ def setup_provider_min_templates(request, appliance, provider, min_templates):
 @pytest.mark.provider([InfraProvider], selector=ONE, scope="function")
 @pytest.mark.parametrize("min_templates", [2, 4])
 @pytest.mark.parametrize("templates_collection", ["provider", "appliance"])
-@pytest.mark.meta(blockers=[BZ(1784180, forced_streams=["5.10"])], automates=[1784180])
+@pytest.mark.meta(automates=[1784180, 1794434, 1746449])
 def test_compare_templates(appliance, setup_provider_min_templates, provider, min_templates,
                            templates_collection):
     """
@@ -513,6 +512,8 @@ def test_compare_templates(appliance, setup_provider_min_templates, provider, mi
         initialEstimate: 1/6h
     Bugzilla:
         1746449
+        1784180
+        1794434
     """
     t_coll = locals()[templates_collection].collections.infra_templates.all()[:min_templates]
     compare_view = locals()[templates_collection].collections.infra_templates.compare_entities(


### PR DESCRIPTION
…ked test test_infrastructure_hosts_navigation_after_download_from_compare


## Purpose or Intent

- __Updating tests__ markers so all covered BZs are included in automates and remove outdated blockers
- __Fixing test__ test_infrastructure_hosts_navigation_after_download_from_compare to support recent changes. This test was and is blocked by BZ.

### PRT Run
{{ pytest: --long-running --use-provider rhv43 cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_compare }}

