### PR TITLE
[1LP][RFR] Fixing API 500 error

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -40,6 +40,7 @@ def set_skip_event_history_flag(appliance):
         appliance.evmserverd.restart()
         appliance.evmserverd.wait_for_running()
         appliance.wait_for_web_ui()
+        appliance.wait_for_api_available()
 
 
 def _start_event_workers_for_osp(appliance, provider):


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

Adding *appliance.wait_for_api_available()* after re-starting the evm service to  make sure API should also work.