### PR TITLE
[1LP][RFR] - checking error on appliance console

### DIFF
--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -9,6 +9,7 @@ from widgetastic.utils import VersionPick
 
 import cfme.utils.auth as authutil
 from cfme import test_requirements
+from cfme.exceptions import SSHExpectTimeoutError
 from cfme.tests.cli import app_con_menu
 from cfme.utils import conf
 from cfme.utils.appliance.console import waiting_for_ha_monitor_started
@@ -18,6 +19,7 @@ from cfme.utils.conf import credentials
 from cfme.utils.log import logger
 from cfme.utils.log_validator import LogValidator
 from cfme.utils.net import net_check
+from cfme.utils.ssh_expect import SSHExpect
 from cfme.utils.version import LOWEST
 
 SECONDARY_DNS_REGEX = r'(Secondary DNS:\s*)(?P<secondary_dns>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'
@@ -1798,10 +1800,9 @@ def test_appliance_console_logfile_config_reboot():
     pass
 
 
-@pytest.mark.manual
 @pytest.mark.tier(0)
-@pytest.mark.meta(coverage=[1790995])
-def test_appliance_console_menubar():
+@pytest.mark.meta(automates=[1790995])
+def test_appliance_console_menubar(appliance):
     """
     There should not be error on menubar on appliance console
     Bugzilla:
@@ -1820,7 +1821,12 @@ def test_appliance_console_menubar():
             2.
             3. "translation missing: en.advanced_settings.timezone" should not be displayed
     """
-    pass
+    with SSHExpect(appliance) as interaction:
+        interaction.send('ap')
+        interaction.answer('Press any key to continue.', '', timeout=20)
+        interaction.expect('Choose the advanced setting: ', timeout=60)
+        with pytest.raises(SSHExpectTimeoutError):
+            interaction.expect('translation missing: ', timeout=60)
 
 
 @pytest.mark.manual


### PR DESCRIPTION
__adding_test__ test to check error on appliance console on menu page
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/cli/test_appliance_console.py -k "test_appliance_console_menubar" -v}}