### PR TITLE
[1LP][RFR] Manual chargeback test cleanup and parametrization

### DIFF
--- a/cfme/tests/intelligence/test_chargeback_manual.py
+++ b/cfme/tests/intelligence/test_chargeback_manual.py
@@ -1,4 +1,6 @@
 """Manual tests"""
+from collections import namedtuple
+
 import pytest
 
 from cfme import test_requirements
@@ -9,209 +11,28 @@ pytestmark = [
     test_requirements.chargeback
 ]
 
+RateAssignment = namedtuple('RateAssignment', ['rate_type', 'assigned_to'])
 
-@pytest.mark.tier(2)
-def test_validate_chargeback_cost_tiered_rate_fixedvariable_network_cost():
+assignments = [
+    RateAssignment('compute', 'enterprise'),
+    RateAssignment('compute', 'provider'),
+    RateAssignment('compute', 'cluster'),
+    RateAssignment('compute', 'tagged_vm'),
+    RateAssignment('compute', 'tenant'),
+    RateAssignment('storage', 'enterprise'),
+    RateAssignment('storage', 'datastore'),
+    RateAssignment('storage', 'tagged_datastore'),
+    RateAssignment('storage', 'tenant')]
+
+
+@pytest.mark.parametrize('report_period', ['daily_report', 'weekly_report', 'monthly_report'])
+@pytest.mark.parametrize('rate_period', ['hourly_rate', 'weekly_rate', 'monthly_rate'])
+@pytest.mark.parametrize('resource', ['cpu', 'memory', 'storage'])
+@pytest.mark.parametrize('allocation_method', ['maximum', 'average'])
+def test_validate_chargeback_allocation_cost(report_period, rate_period, resource,
+        allocation_method):
     """
-    Validate network I/O used cost  for a tiered rate with fixed and
-    variable components
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_validate_chargeback_cost_resource_allocation_cpu_allocated():
-    """
-    Validate CPU allocated cost in a Chargeback report based on resource
-    allocation. C&U data is not considered for these reports.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_validate_chargeback_cost_tiered_rate_fixedvariable_cpu_cost():
-    """
-    Validate CPU usage cost for a tiered rate with fixed and variable
-    components
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_validate_chargeback_cost_resource_allocation_storage_allocated():
-    """
-    Validate storage allocated cost in a Chargeback report based on
-    resource allocation. C&U data is not considered for these reports.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_validate_chargeback_cost_tiered_rate_fixedvariable_disk_cost():
-    """
-    Validate disk I/O used cost for a tiered rate with fixed and variable
-    components
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_validate_chargeback_cost_resource_allocation_memory_allocated():
-    """
-    Validate memory allocated cost in a Chargeback report based on
-    resource allocation. C&U data is not considered for these reports.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_validate_chargeback_cost_tiered_rate_fixedvariable_memory_cost():
-    """
-    Validate memory usage cost  for a tiered rate with fixed and variable
-    components
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_chargeback_report_weekly():
-    """
-    Verify that 1)weekly chargeback reports can be generated and 2)that
-    the report contains relevant data for the relevant period.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_weekly_usage_memory():
-    """
-    Validate cost for memory usage for a VM in a weekly chargeback report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_weekly_allocation_storage():
-    """
-    Validate cost for VM storage allocation in a weekly report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_weekly_usage_disk():
-    """
-    Validate cost for disk io for a VM in a weekly chargeback report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_weekly_usage_storage():
-    """
-    Validate cost for storage usage for a VM in a weekly report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_weekly_usage_cpu():
-    """
-    Validate cost for CPU usage for a VM in a weekly chargeback report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_weekly_allocation_memory():
-    """
-    Validate cost for VM memory allocation in a weekly report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_weekly_usage_network():
-    """
-    Validate cost for network io for a VM  in a weekly chargeback report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_weekly_allocation_cpu():
-    """
-    Validate cost for VM CPU allocation in a weekly report
+    Validate cost for VM resource allocation.
 
     Polarion:
         assignee: tpapaioa
@@ -238,128 +59,11 @@ def test_saved_chargeback_report():
 
 
 @pytest.mark.tier(3)
-def test_chargeback_report_compute_provider():
-    """
-    Assign compute rates to provider;Generate chargeback report and verify
-    that rates are applied to selected providers only
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.tier(3)
-def test_chargeback_report_storage_tenants():
-    """
-    Assign storage rates to tenants;Generate chargeback report and verify
-    that rates are applied to the tenant.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(3)
-def test_chargeback_report_compute_tenants():
-    """
-    Assign compute rates to tenants;Generate chargeback report and verify
-    that rates are applied to the tenant.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/10h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_chargeback_report_storage_tagged_datastore():
-    """
-    Assign storage rates to tagged datastore;Generate chargeback report
-    and verify that rates are applied to selected datastores only
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_chargeback_report_storage_enterprise():
-    """
-    Assign storage rates to Enterprise;Generate chargeback report and
-    verify that rates are applied to Enterprise
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_chargeback_report_compute_cluster():
-    """
-    Assign compute rates to cluster;Generate chargeback report and verify
-    that rates are applied to selected clusters only
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.tier(2)
-def test_chargeback_report_compute_enterprise():
-    """
-    Assign compute rates to Enterprise;Generate chargeback report and
-    verify that rates are applied to Enterprise
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.tier(3)
-def test_chargeback_report_compute_tagged_vm():
-    """
-    Assign compute rates to tagged Vms;Generate chargeback report and
-    verify that rates are applied to tagged VMs only
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.tier(3)
-def test_chargeback_report_storage_datastore():
-    """
-    Assign storage rates to datastore;Generate chargeback report and
-    verify that rates are applied to selected datastores only
+@pytest.mark.parametrize('assignment', assignments,
+    ids=[f'{a.rate_type}_{a.assigned_to}' for a in assignments])
+def test_chargeback_report_assignment(assignment):
+    """Assign compute or storage rate to the given entity. Generate a chargeback report and verify
+    that the rate is applied to the selected entities only.
 
     Polarion:
         assignee: tpapaioa
@@ -387,149 +91,17 @@ def test_consistent_capitalization_of_cpu_when_creating_compute_chargeback_rate(
     pass
 
 
-def test_validate_cost_monthly_usage_storage():
-    """
-    Validate cost for storage usage for a VM in a monthly chargeback
-    report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_monthly_usage_disk():
-    """
-    Validate cost for disk io for a VM in a monthly chargeback report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_monthly_allocation_cpu():
-    """
-    Validate cost for VM cpu allocation in a monthly report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_monthly_allocation_storage():
-    """
-    Validate cost for VM storage allocation in a monthly report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_monthly_usage_cpu():
-    """
-    Validate cost for CPU usage for a VM in a monthly chargeback report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_monthly_allocation_memory():
-    """
-    Validate cost for VM memory allocation in a monthly report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_monthly_usage_memory():
-    """
-    Validate cost for memory usage for a VM in a monthly chargeback report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
-def test_validate_cost_monthly_usage_network():
-    """
-    Validate cost for network io for a VM in a monthly chargeback report
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-    """
-    pass
-
-
 @pytest.mark.tier(2)
-def test_chargeback_report_filter_owner():
+@pytest.mark.parametrize('filter_by', ['tag', 'owner'])
+def test_chargeback_report_filter(filter_by):
     """
-    Verify that chargeback reports can be generated by filtering on
-    owners.Make sure to include the "owner" column in the report.
+    Verify that chargeback reports can be generated by filtering on the given entity.
 
     Polarion:
         assignee: tpapaioa
         casecomponent: CandU
         caseimportance: medium
         initialEstimate: 1/4h
-    """
-    pass
-
-
-@pytest.mark.tier(3)
-def test_chargeback_report_filter_tag():
-    """
-    Verify that chargeback reports can be generated by filtering on tags
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/4h
-    """
-    pass
-
-
-def test_chargeback_report_monthly():
-    """
-    Verify that 1)monthly chargeback reports can be generated and 2)that
-    the report contains relevant data for the relevant period.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        initialEstimate: 1/6h
     """
     pass
 
@@ -544,103 +116,5 @@ def test_chargeback_preview():
         casecomponent: CandU
         caseimportance: medium
         initialEstimate: 1/10h
-    """
-    pass
-
-
-def test_validate_chargeback_cost_resource_average_cpu():
-    """
-    Validate cost for allocated CPU with "Average" method for allocated
-    metrics.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.9
-    """
-    pass
-
-
-def test_validate_chargeback_cost_resource_average_memory():
-    """
-    Validate cost for allocated memory with "Average" method for allocated
-    metrics
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.9
-    """
-    pass
-
-
-def test_validate_chargeback_cost_resource_maximum_cpu():
-    """
-    Validate cost for allocated CPU with "Maximum" method for allocated
-    metrics
-    1))Let VM run for a few hours(3- 24 hours)
-    2)Sometime during that interval(3-24 hours),reconfigure VM to have
-    different resources from when it was created(add/remove
-    vCPU,memory,disk)
-    3)Validate that chargeback costs are appropriate for vCPU allocated
-    when method for allocated metrics is "Maximum".
-    Also, see RHCF3-34343, RHCF3-34344, RHCF3-34345, RHCF3-34346,
-    RHCF3-34347 .
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.9
-    """
-    pass
-
-
-def test_validate_chargeback_cost_resource_maximum_storage():
-    """
-    Validate cost for allocated storage with "Maximum" method for
-    allocated metrics
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.9
-    """
-    pass
-
-
-def test_validate_chargeback_cost_resource_average_stoarge():
-    """
-    Validate cost for allocated storage with "Average" method for
-    allocated metrics
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.9
-    """
-    pass
-
-
-def test_validate_chargeback_cost_resource_maximum_memory():
-    """
-    Validate cost for allocated memory with "Maximum" method for allocated
-    metrics
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: CandU
-        caseimportance: medium
-        initialEstimate: 1/6h
-        startsin: 5.9
     """
     pass


### PR DESCRIPTION
Parametrized manual chargeback report tests instead of having one test method per resource (cpu, memory, etc.), report period (weekly, monthly, etc.) and so on. Some of these manual tests partially overlap with the automated tests, and will be dealt with in a later PR.
