### PR TITLE
[1LP][RFR] Test to create group

### DIFF
--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -636,35 +636,6 @@ def test_login_self_service_ui():
 
 @test_requirements.rbac
 @pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1813375])
-def test_create_group_console_no():
-    """
-    Should able to create group if atleast one 'Show in Console' category to NO
-    Bugzilla:
-        1813375
-    Polarion:
-        assignee: dgaikwad
-        casecomponent: Configuration
-        caseimportance: critical
-        initialEstimate: 1/4h
-        testSteps:
-            1. Go to Configuration > Settings accordion > Region node in accordion > Tags tab >
-            My Company Categories tab
-            2. For a new/an existing category set 'Show in Console' to 'No' and save the category
-            3. Go to Configuration > Access Control accordion > Groups
-            4. Toolbar: Configuration > Add a new Group
-        expectedResults:
-            1.
-            2.
-            3.
-            4. Should able to create group and there should not be error in production.log
-
-    """
-    pass
-
-
-@test_requirements.rbac
-@pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1803952])
 def test_select_edit_group():
     """


### PR DESCRIPTION
__adding_test__ test to create group if at least one category **show_in_console** value is **No**
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/configure/test_access_control.py -k "test_create_group_console_no" --long-running -v}}
