### PR TITLE
[RFR]Automate: test_database_wildcard_should_work_and_be_included_in_the_query

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -198,13 +198,10 @@ def rates(request, appliance, num=3):
     return _creating_skeleton(request, appliance, 'rates', data)
 
 
-def vm(request, provider, appliance):
+def vm(request, provider, appliance, **kwargs):
+    vm_name = kwargs.pop("name", fauxfactory.gen_alphanumeric(length=18, start="test_rest_vm_"))
     provider_rest = appliance.rest_api.collections.providers.get(name=provider.name)
-    vm = deploy_template(
-        provider.key,
-        fauxfactory.gen_alphanumeric(length=18, start="test_rest_vm_")
-    )
-    vm_name = vm.name
+    vm = deploy_template(provider.key, vm_name)
 
     @request.addfinalizer
     def _finished():

--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -27,23 +27,6 @@ def test_notification_banner_vm_provisioning_notification_and_service_request_sh
 
 @pytest.mark.manual
 @pytest.mark.tier(3)
-def test_database_wildcard_should_work_and_be_included_in_the_query():
-    """ Database wildcard should work and be included in the query
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.10
-        tags: service
-    Bugzilla:
-        1581853
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
 def test_user_should_be_able_to_see_requests_irrespective_of_tags_assigned():
     """ User should be able to see requests irrespective of tags assigned
     Polarion:


### PR DESCRIPTION
## Purpose or Intent
- __Extending__ 
    1. `cfme.rest.gen_data.vm` to take kwargs and a custom name.
- __Adding tests__ 
    2. Automate : test_database_wildcard_should_work_and_be_included_in_the_query

### PRT Run
{{ pytest: cfme/tests/infrastructure/test_vm_rest.py -k "test_database_wildcard_should_work_and_be_included_in_the_query" -svvv }}