### PR TITLE
[WIPTEST] Fixing locator for schedule_migration test

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -4777,10 +4777,7 @@ class MigrationPlansList(Widget):
     ITEM_PROMPT_DELETE_BUTTON_LOCATOR = './/div[@role="document"]//button[@class="btn btn-primary"]'
     ITEM_MODAL_CANCEL_BUTTON_LOCATOR = './/button[contains(@class,"btn-cancel btn")]'
     ITEM_MODAL_TEXT_LOCATOR = './/div[ contains(@class,"modal-body")]'
-    ITEM_SCHEDULE_BUTTON_LOCATOR = (
-        './div[contains(@class,"list-view-pf-actions")]'
-        '//button[text()="Schedule" or text()="Unschedule"]'
-    )
+    ITEM_SCHEDULE_BUTTON_LOCATOR = './/button[text()="Schedule" or text()="Unschedule"]'
     ITEM_SCHEDULE_INPUT_LOCATOR = './/input[@id="dateTimeInput"]'
     ITEM_MODAL_SCHEDULE_LOCATOR = (
         './/div[@class="modal-footer"]/' 'button[text()="Schedule" or text()="Unschedule"]'


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

TC is failing due to ITEM_SCHEDULE_BUTTON_LOCATOR button with below error
NoSuchElementException: Message: Could not find an element './div[contains(@class,"list-view-pf-actions")]//button[text()="Schedule" or text()="Unschedule"]'

This PR will fix the locator issue.

{{ pytest: cfme/tests/v2v/test_v2v_schedule_migrations.py -k "test_schedule_migration"  --use-provider osp13-ims --use-provider vsphere67-ims --provider-limit 2 -v }}