### PR TITLE
[1LP][RFR] Adding exception for volume cleanup and Fixing locator for schedule_migration test

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -2,6 +2,7 @@ from collections import namedtuple
 
 import fauxfactory
 import pytest
+from cinderclient.exceptions import BadRequest
 from manageiq_client.filters import Q
 from riggerlib import recursive_update
 from widgetastic.utils import partial_match
@@ -349,7 +350,10 @@ def cleanup_target(provider, migrated_vm):
         for vol in vm.raw._info['os-extended-volumes:volumes_attached']:
             volumes.append(vol['id'])
         migrated_vm.cleanup_on_provider()
-        provider.mgmt.delete_volume(*volumes)
+        try:
+            provider.mgmt.delete_volume(*volumes)
+        except BadRequest as e:
+            logger.warning(e)
 
 
 def get_vm(request, appliance, source_provider, template_type, datastore='nfs'):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -4777,10 +4777,7 @@ class MigrationPlansList(Widget):
     ITEM_PROMPT_DELETE_BUTTON_LOCATOR = './/div[@role="document"]//button[@class="btn btn-primary"]'
     ITEM_MODAL_CANCEL_BUTTON_LOCATOR = './/button[contains(@class,"btn-cancel btn")]'
     ITEM_MODAL_TEXT_LOCATOR = './/div[ contains(@class,"modal-body")]'
-    ITEM_SCHEDULE_BUTTON_LOCATOR = (
-        './div[contains(@class,"list-view-pf-actions")]'
-        '//button[text()="Schedule" or text()="Unschedule"]'
-    )
+    ITEM_SCHEDULE_BUTTON_LOCATOR = './/button[text()="Schedule" or text()="Unschedule"]'
     ITEM_SCHEDULE_INPUT_LOCATOR = './/input[@id="dateTimeInput"]'
     ITEM_MODAL_SCHEDULE_LOCATOR = (
         './/div[@class="modal-footer"]/' 'button[text()="Schedule" or text()="Unschedule"]'


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

TC is failing due to ITEM_SCHEDULE_BUTTON_LOCATOR button with below error
NoSuchElementException: Message: Could not find an element './div[contains(@Class,"list-view-pf-actions")]//button[text()="Schedule" or text()="Unschedule"]'

This PR will fix the locator issue.

Some time the volume deletion as ceph side failed due to race condition which causes the whole TC  to fail though the cleanup is not under the actual test scope. 

This PR except the exception here for such race condition. 


{{ pytest: cfme/tests/v2v/test_v2v_schedule_migrations.py -k "test_schedule_migration" --use-provider osp13-ims --use-provider vsphere67-ims --provider-limit 2 -v }}

