### PR TITLE
[1LP][RFR][NOTEST]- changing FA owner

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -159,7 +159,7 @@ def catalog_obj(appliance):
 def test_user_crud(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -186,7 +186,7 @@ def test_user_assign_multiple_groups(appliance, request):
         * Confirm that the user has each group visible in the Settings menu
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -215,7 +215,7 @@ def test_user_change_groups(appliance):
     """Assign a user to multiple groups and confirm that the user can successfully change groups
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/4h
         casecomponent: Configuration
     """
@@ -251,7 +251,7 @@ def test_user_login(appliance):
         1035399
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -278,7 +278,7 @@ def test_user_duplicate_username(appliance):
         * Create another user with same credential
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -308,7 +308,7 @@ def test_user_allow_duplicate_name(appliance):
         * Create another user with same full name
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -331,7 +331,7 @@ def test_user_allow_duplicate_name(appliance):
 def test_username_required_error_validation(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -353,7 +353,7 @@ def test_username_required_error_validation(appliance):
 def test_userid_required_error_validation(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -378,7 +378,7 @@ def test_userid_required_error_validation(appliance):
 def test_user_password_required_error_validation(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -405,7 +405,7 @@ def test_user_password_required_error_validation(appliance):
 def test_user_group_error_validation(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -422,7 +422,7 @@ def test_user_group_error_validation(appliance):
 def test_user_email_error_validation(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -495,7 +495,7 @@ def test_delete_default_user(appliance):
         * Try deleting the user
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -517,7 +517,7 @@ def test_current_user_login_delete(appliance, request):
         * Try deleting the user
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -561,7 +561,7 @@ def test_tagvis_user(user_restricted, check_item_visibility):
 def test_group_crud(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -620,7 +620,7 @@ def test_group_duplicate_name(appliance):
     """ Verify that two groups can't have the same name
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         tags: rbac
         casecomponent: Configuration
@@ -691,7 +691,7 @@ def test_group_remove_tag(appliance):
 def test_group_description_required_error_validation(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -716,7 +716,7 @@ def test_delete_default_group(appliance):
         * Try deleting the group EvmGroup-adminstrator
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -733,7 +733,7 @@ def test_delete_group_with_assigned_user(appliance):
     """Test that CFME prevents deletion of a group that has users assigned
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -756,7 +756,7 @@ def test_edit_default_group(appliance):
         * Try editing the group EvmGroup-adminstrator
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -780,7 +780,7 @@ def test_edit_sequence_usergroups(appliance, request):
         * Verify the changed sequence
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         casecomponent: Configuration
         initialEstimate: 1/8h
         tags: rbac
@@ -821,7 +821,7 @@ def test_tagvis_group(user_restricted, group_with_tag, check_item_visibility):
 def test_role_crud(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -853,7 +853,7 @@ def test_role_crud(appliance):
 def test_rolename_required_error_validation(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -874,7 +874,7 @@ def test_rolename_required_error_validation(appliance):
 def test_rolename_duplicate_validation(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         casecomponent: Configuration
         initialEstimate: 1/8h
         tags: rbac
@@ -900,7 +900,7 @@ def test_delete_default_roles(appliance):
         * Try editing the group EvmRole-approver
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -921,7 +921,7 @@ def test_edit_default_roles(appliance):
         * Try editing the group EvmRole-auditor
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -938,7 +938,7 @@ def test_edit_default_roles(appliance):
 def test_delete_roles_with_assigned_group(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -956,7 +956,7 @@ def test_delete_roles_with_assigned_group(appliance):
 def test_assign_user_to_new_group(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -1010,7 +1010,7 @@ def test_permission_edit(appliance, request, product_features):
         action: reference to a function to execute under the test user context
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         caseimportance: medium
         casecomponent: Configuration
         initialEstimate: 1h
@@ -1120,7 +1120,7 @@ def test_permissions(appliance, product_features, allowed_actions, disallowed_ac
             object: [ { "Action Name": function_reference_action }, ...]
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         caseimportance: medium
         casecomponent: Configuration
         initialEstimate: 1h
@@ -1175,7 +1175,7 @@ def single_task_permission_test(appliance, product_features, actions):
 def test_permissions_role_crud(appliance):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/5h
         casecomponent: Configuration
         tags: rbac
@@ -1197,7 +1197,7 @@ def test_permissions_role_crud(appliance):
 def test_permissions_vm_provisioning(appliance, provider, setup_provider):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         caseimportance: medium
         casecomponent: Configuration
         initialEstimate: 1/5h
@@ -1253,7 +1253,7 @@ def test_permissions_vm_provisioning(appliance, provider, setup_provider):
 def test_user_change_password(appliance, request):
     """
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/8h
         casecomponent: Configuration
         tags: rbac
@@ -1288,7 +1288,7 @@ def test_copied_user_password_inheritance(appliance, request):
     empty
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         casecomponent: WebUI
         caseimportance: high
         initialEstimate: 1/15h
@@ -2345,6 +2345,7 @@ def test_ssui_group_switch():
     pass
 
 
+@pytest.mark.customer_scenario
 @pytest.mark.manual
 @test_requirements.rbac
 @test_requirements.ssui

--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -687,6 +687,7 @@ def test_select_edit_group():
     pass
 
 
+@pytest.mark.customer_scenario
 @test_requirements.rbac
 @pytest.mark.tier(2)
 @pytest.mark.meta(coverage=[1730066])

--- a/cfme/tests/services/test_service_rbac.py
+++ b/cfme/tests/services/test_service_rbac.py
@@ -57,7 +57,7 @@ def test_service_rbac_no_permission(appliance, role_user_group):
     """ Test service rbac without user permission
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/4h
         casecomponent: Services
     """
@@ -73,7 +73,7 @@ def test_service_rbac_catalog(appliance, role_user_group, catalog):
     """ Test service rbac with catalog
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/4h
         casecomponent: Services
     """
@@ -93,7 +93,7 @@ def test_service_rbac_service_catalog(
     """ Test service rbac with service catalog
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/4h
         casecomponent: Services
     """
@@ -138,7 +138,7 @@ def test_service_rbac_catalog_item(request, appliance, role_user_group, catalog_
     """ Test service rbac with catalog item
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/4h
         casecomponent: Services
     """
@@ -156,7 +156,7 @@ def test_service_rbac_orchestration(appliance, role_user_group):
     """ Test service rbac with orchestration
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/4h
         casecomponent: Services
     """
@@ -182,7 +182,7 @@ def test_service_rbac_request(appliance, role_user_group, catalog_item, request,
     """ Test service rbac with only request module permissions
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         initialEstimate: 1/4h
         casecomponent: Services
     """

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -29,7 +29,7 @@ def test_login(context, method, appliance):
     """ Tests that the appliance can be logged into and shows dashboard page.
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         casecomponent: Configuration
         initialEstimate: 1/8h
         tags: rbac
@@ -55,7 +55,7 @@ def test_bad_password(context, request, appliance):
     """ Tests logging in with a bad password.
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         casecomponent: WebUI
         initialEstimate: 1/8h
         tags: rbac
@@ -81,7 +81,7 @@ def test_credentials_change_password_with_special_characters():
     Password with only special characters
 
     Polarion:
-        assignee: apagac
+        assignee: dgaikwad
         casecomponent: Appliance
         caseimportance: medium
         initialEstimate: 1/8h


### PR DESCRIPTION
Changing FA owner of RBAC test cases,
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
