### PR TITLE
[1LP][RFR] Fix HTTP 503 everywhere

### DIFF
--- a/cfme/containers/provider/openshift.py
+++ b/cfme/containers/provider/openshift.py
@@ -374,7 +374,7 @@ class OpenshiftProvider(ContainersProvider, ConsoleMixin, Taggable):
             # restarting evemserverd to apply the new SSL certificate
             self.appliance.evmserverd.restart()
             self.appliance.evmserverd.wait_for_running()
-            self.appliance.wait_for_web_ui()
+            self.appliance.wait_for_miq_ready()
 
     def get_system_id(self):
         mgmt_systems_tbl = self.appliance.db.client['ext_management_systems']

--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -68,7 +68,7 @@ def sprout_appliances(
             # Web UI not available on unconfigured appliances
             if preconfigured:
                 logger.info("Appliance update finished on temp appliance, waiting for UI ...")
-                app.wait_for_web_ui()
+                app.wait_for_miq_ready()
             logger.info("Appliance update finished on temp appliance...")
 
     try:

--- a/cfme/fixtures/appliance_update.py
+++ b/cfme/fixtures/appliance_update.py
@@ -28,5 +28,5 @@ def pytest_sessionstart(session):
     urls = session.config.getoption("update_urls")
     store.current_appliance.update_rhel(*urls, reboot=True)
     store.write_line("Appliance update finished, waiting for UI ...")
-    store.current_appliance.wait_for_web_ui()
+    store.current_appliance.wait_for_miq_ready()
     store.write_line("Appliance update finished ...")

--- a/cfme/fixtures/authentication.py
+++ b/cfme/fixtures/authentication.py
@@ -141,7 +141,7 @@ def configure_auth(temp_appliance_preconfig_long, auth_mode, auth_provider, user
     # return to original auth config
     temp_appliance_preconfig_long.server.authentication.auth_settings = original_config
     temp_appliance_preconfig_long.evmserverd.restart()
-    temp_appliance_preconfig_long.wait_for_web_ui()
+    temp_appliance_preconfig_long.wait_for_miq_ready()
     # after waiting for web ui to reappear we are greeted with an API logout message
     # and stuck on the login screen without the login widgets having loaded
     sleep(30)

--- a/cfme/fixtures/candu.py
+++ b/cfme/fixtures/candu.py
@@ -89,4 +89,4 @@ def candu_db_restore(temp_appliance_extended_db):
     app.db.fix_auth_key()
     app.db.fix_auth_dbyml()
     app.evmserverd.start()
-    app.wait_for_web_ui()
+    app.wait_for_miq_ready()

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -346,7 +346,7 @@ def ext_appliances_with_providers(multiple_preupdate_appliances, app_creds_modsc
     app_ip = appl1.hostname
     # configure appliances
     appl1.configure(region=0)
-    appl1.wait_for_web_ui()
+    appl1.wait_for_miq_ready()
     appl2.appliance_console_cli.configure_appliance_external_join(
         app_ip,
         app_creds_modscope["username"],
@@ -356,7 +356,7 @@ def ext_appliances_with_providers(multiple_preupdate_appliances, app_creds_modsc
         app_creds_modscope["sshlogin"],
         app_creds_modscope["sshpass"],
     )
-    appl2.wait_for_web_ui()
+    appl2.wait_for_miq_ready()
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl1).setup()
     provider_app_crud(OpenStackProvider, appl1).setup()

--- a/cfme/fixtures/multi_region.py
+++ b/cfme/fixtures/multi_region.py
@@ -33,7 +33,7 @@ def setup_global_appliance(multi_region_cluster, app_creds_modscope):
                       dbdisk=global_app.unpartitioned_disks[0])
     global_app.appliance_console_cli.configure_appliance_internal(**app_params)
     global_app.evmserverd.wait_for_running()
-    global_app.wait_for_web_ui()
+    global_app.wait_for_miq_ready()
 
 
 @pytest.fixture(scope='module')
@@ -52,7 +52,7 @@ def setup_remote_appliances(multi_region_cluster, setup_global_appliance, app_cr
                           sshpass=app_creds_modscope['sshpass'])
         app.appliance_console_cli.configure_appliance_internal_fetch_key(**app_params)
         app.evmserverd.wait_for_running()
-        app.wait_for_web_ui()
+        app.wait_for_miq_ready()
         app.set_pglogical_replication(replication_type=':remote')
 
 

--- a/cfme/fixtures/ui_coverage.py
+++ b/cfme/fixtures/ui_coverage.py
@@ -145,7 +145,7 @@ class CoverageManager:
         self._install_simplecov()
         self._install_coverage_hook()
         self.ipapp.evmserverd.restart()
-        self.ipapp.wait_for_web_ui()
+        self.ipapp.wait_for_miq_ready()
 
     def collect(self):
         self.print_message('collecting reports')

--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -41,7 +41,6 @@ def set_skip_event_history_flag(appliance):
         appliance.evmserverd.restart()
         appliance.evmserverd.wait_for_running()
         appliance.wait_for_web_ui()
-        appliance.wait_for_api_available()
 
 
 def _start_event_workers_for_osp(appliance, provider):

--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -40,7 +40,7 @@ def set_skip_event_history_flag(appliance):
             {'ems': {'ems_openstack': {'event_handling': {'event_skip_history': True}}}})
         appliance.evmserverd.restart()
         appliance.evmserverd.wait_for_running()
-        appliance.wait_for_web_ui()
+        appliance.wait_for_miq_ready()
 
 
 def _start_event_workers_for_osp(appliance, provider):

--- a/cfme/scripting/appliance.py
+++ b/cfme/scripting/appliance.py
@@ -83,7 +83,7 @@ def upgrade_appliance(appliance_ip, cfme_only, update_to):
     print('Starting EVM')
     app.evmserverd.start()
     print('Waiting for webui')
-    app.wait_for_web_ui()
+    app.wait_for_miq_ready()
     print('Appliance upgrade completed')
 
 
@@ -131,7 +131,7 @@ def backup_migrate(appliance_ip, db_url, keys_url, backup):
     print('Starting EVM')
     app.evmserverd.start()
     print('Waiting for webui')
-    app.wait_for_web_ui()
+    app.wait_for_miq_ready()
     print('Appliance upgrade completed')
 
 

--- a/cfme/scripting/setup_env.py
+++ b/cfme/scripting/setup_env.py
@@ -67,13 +67,13 @@ def setup_distributed_env(cfme_version, provider_type, provider, lease, desc):
         TimedCommand(pwd, 360), '')
     apps[0].appliance_console.run_commands(command_set0)
     apps[0].evmserverd.wait_for_running()
-    apps[0].wait_for_web_ui()
+    apps[0].wait_for_miq_ready()
     print(f"VMDB appliance provisioned and configured {ip0}")
     command_set1 = ('ap', '', opt, '2', ip0, '', pwd, '', '3') + port + ('', '',
         pwd, TimedCommand(pwd, 360), '')
     apps[1].appliance_console.run_commands(command_set1)
     apps[1].evmserverd.wait_for_running()
-    apps[1].wait_for_web_ui()
+    apps[1].wait_for_miq_ready()
     print(f"Non-VMDB appliance provisioned and configured {ip1}")
     print(f"Appliance pool lease time is {lease}")
 
@@ -108,7 +108,7 @@ def setup_ha_env(cfme_version, provider_type, provider, lease, desc):
         TimedCommand(pwd, 360), '')
     apps[1].appliance_console.run_commands(command_set1)
     apps[1].evmserverd.wait_for_running()
-    apps[1].wait_for_web_ui()
+    apps[1].wait_for_miq_ready()
     print(f"Non-VMDB appliance provisioned and region created {ip1}")
 
     command_set2 = ('ap', '', '8', '1', '1', '', '', pwd, pwd, ip0, 'y', '')
@@ -178,7 +178,7 @@ def setup_replication_env(cfme_version, provider_type, provider, lease, sprout_p
         TimedCommand(pwd, 360), '')
     apps[0].appliance_console.run_commands(command_set0)
     apps[0].evmserverd.wait_for_running()
-    apps[0].wait_for_web_ui()
+    apps[0].wait_for_miq_ready()
     print(f"Done: Global @ {ip0}")
 
     print("Remote Appliance Configuration")
@@ -186,7 +186,7 @@ def setup_replication_env(cfme_version, provider_type, provider, lease, sprout_p
         TimedCommand(pwd, 360), '')
     apps[1].appliance_console.run_commands(command_set1)
     apps[1].evmserverd.wait_for_running()
-    apps[1].wait_for_web_ui()
+    apps[1].wait_for_miq_ready()
     print(f"Done: Remote @ {ip1}")
 
     if remote_worker:
@@ -195,7 +195,7 @@ def setup_replication_env(cfme_version, provider_type, provider, lease, sprout_p
         command_set2 = ['ap', '', opt, '2', ip1, '', pwd, '', '3', ip1, '', '', '', pwd, pwd]
         apps[2].appliance_console.run_commands(command_set2)
         apps[2].evmserverd.wait_for_running()
-        apps[2].wait_for_web_ui()
+        apps[2].wait_for_miq_ready()
         print(f"Done: Remote Worker @ {ip2}")
 
     print("Configuring Replication")
@@ -270,7 +270,7 @@ def setup_multiregion_env(cfme_version, provider_type, provider, lease, sprout_p
                       dbdisk=global_app.unpartitioned_disks[0])
     global_app.appliance_console_cli.configure_appliance_internal(**app_params)
     global_app.evmserverd.wait_for_running()
-    global_app.wait_for_web_ui()
+    global_app.wait_for_miq_ready()
 
     print(f"Done: Global @ {gip}")
 
@@ -289,7 +289,7 @@ def setup_multiregion_env(cfme_version, provider_type, provider, lease, sprout_p
 
         app.appliance_console_cli.configure_appliance_internal_fetch_key(**app_params)
         app.evmserverd.wait_for_running()
-        app.wait_for_web_ui()
+        app.wait_for_miq_ready()
         print(f"Done: Remote @ {app.hostname}, region: {region_n}")
 
         print("Configuring Replication")

--- a/cfme/test_framework/appliance_police.py
+++ b/cfme/test_framework/appliance_police.py
@@ -54,7 +54,7 @@ def appliance_police(appliance):
             # and (sadly) the only fix is a rude restart
             appliance.restart_evm_rude()
             try:
-                appliance.wait_for_miq_ready(900)
+                appliance.wait_for_miq_ready()
                 store.write_line('EVM was frozen and had to be restarted.', purple=True)
                 return
             except TimedOutError:

--- a/cfme/test_framework/appliance_police.py
+++ b/cfme/test_framework/appliance_police.py
@@ -54,7 +54,7 @@ def appliance_police(appliance):
             # and (sadly) the only fix is a rude restart
             appliance.restart_evm_rude()
             try:
-                appliance.wait_for_web_ui(900)
+                appliance.wait_for_miq_ready(900)
                 store.write_line('EVM was frozen and had to be restarted.', purple=True)
                 return
             except TimedOutError:

--- a/cfme/tests/automate/custom_button/test_custom_menu.py
+++ b/cfme/tests/automate/custom_button/test_custom_menu.py
@@ -36,7 +36,7 @@ def update_adv_setting_and_wait(appliance, data):
     """
     appliance.update_advanced_settings(data)
     appliance.evmserverd.restart()
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
 
 
 @pytest.mark.tier(1)

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -96,7 +96,7 @@ def test_appliance_console_cli_internal_fetch_key(app_creds, unconfigured_applia
         unconfigured_appliance.unpartitioned_disks[0], fetch_key_ip, app_creds['sshlogin'],
         app_creds['sshpass'])
     unconfigured_appliance.evmserverd.wait_for_running()
-    unconfigured_appliance.wait_for_web_ui()
+    unconfigured_appliance.wait_for_miq_ready()
 
 
 @pytest.mark.tier(2)
@@ -114,7 +114,7 @@ def test_appliance_console_cli_external_join(app_creds, appliance,
         appliance_ip, app_creds['username'], app_creds['password'], 'vmdb_production', appliance_ip,
         app_creds['sshlogin'], app_creds['sshpass'])
     temp_appliance_unconfig_funcscope.evmserverd.wait_for_running()
-    temp_appliance_unconfig_funcscope.wait_for_web_ui()
+    temp_appliance_unconfig_funcscope.wait_for_miq_ready()
 
 
 @pytest.mark.rhel_testing
@@ -133,7 +133,7 @@ def test_appliance_console_cli_external_create(app_creds, dedicated_db_appliance
         hostname, app_creds['username'], app_creds['password'], 'vmdb_production', hostname,
         app_creds['sshlogin'], app_creds['sshpass'])
     unconfigured_appliance_secondary.evmserverd.wait_for_running()
-    unconfigured_appliance_secondary.wait_for_web_ui()
+    unconfigured_appliance_secondary.wait_for_miq_ready()
 
 
 @pytest.mark.parametrize('auth_type', ['sso_enabled', 'saml_enabled', 'local_login_disabled'],
@@ -259,7 +259,7 @@ def test_appliance_console_cli_ha_crud(unconfigured_appliances, app_creds):
         app0_ip, app_creds['username'], app_creds['password'], 'vmdb_production', app0_ip,
         app_creds['sshlogin'], app_creds['sshpass'])
     apps[2].evmserverd.wait_for_running()
-    apps[2].wait_for_web_ui()
+    apps[2].wait_for_miq_ready()
     # Configure primary node
     apps[0].appliance_console_cli.configure_appliance_dedicated_ha_primary(
         app_creds['username'], app_creds['password'], 'primary', app0_ip, '1', 'vmdb_production'
@@ -283,4 +283,4 @@ def test_appliance_console_cli_ha_crud(unconfigured_appliances, app_creds):
         assert result.success, f"Failed to stop APPLIANCE_PG_SERVICE: {result.output}"
 
     apps[2].evmserverd.wait_for_running()
-    apps[2].wait_for_web_ui()
+    apps[2].wait_for_miq_ready()

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -210,7 +210,7 @@ def test_appliance_console_internal_db(app_creds, unconfigured_appliance):
                    TimedCommand(pwd, 360), RETURN)
     unconfigured_appliance.appliance_console.run_commands(command_set, timeout=20)
     unconfigured_appliance.evmserverd.wait_for_running()
-    unconfigured_appliance.wait_for_web_ui()
+    unconfigured_appliance.wait_for_miq_ready()
 
 
 @pytest.mark.tier(2)
@@ -236,7 +236,7 @@ def test_appliance_console_internal_db_reset(temp_appliance_preconfig_funcscope)
     temp_appliance_preconfig_funcscope.appliance_console.run_commands(command_set)
     temp_appliance_preconfig_funcscope.ssh_client.run_command('systemctl start evmserverd')
     temp_appliance_preconfig_funcscope.evmserverd.wait_for_running()
-    temp_appliance_preconfig_funcscope.wait_for_web_ui()
+    temp_appliance_preconfig_funcscope.wait_for_miq_ready()
 
 
 @pytest.mark.tier(2)
@@ -327,7 +327,7 @@ def test_appliance_console_ha_crud(unconfigured_appliances, app_creds):
                    RETURN, RETURN, RETURN, pwd, TimedCommand(pwd, 360), RETURN)
     apps[2].appliance_console.run_commands(command_set)
     apps[2].evmserverd.wait_for_running()
-    apps[2].wait_for_web_ui()
+    apps[2].wait_for_miq_ready()
     # Configure primary replication node
     command_set = ('ap', RETURN, '8', '1', '1', RETURN, RETURN, pwd, pwd, app0_ip, 'y',
                    TimedCommand('y', 60), RETURN)
@@ -352,7 +352,7 @@ def test_appliance_console_ha_crud(unconfigured_appliances, app_creds):
         assert result.success, f"Failed to stop APPLIANCE_PG_SERVICE: {result.output}"
 
     apps[2].evmserverd.wait_for_running()
-    apps[2].wait_for_web_ui()
+    apps[2].wait_for_miq_ready()
 
 
 @pytest.mark.tier(2)
@@ -389,7 +389,7 @@ def test_appliance_console_external_db(temp_appliance_unconfig_funcscope, app_cr
 
     temp_appliance_unconfig_funcscope.appliance_console.run_commands(command_set, timeout=20)
     temp_appliance_unconfig_funcscope.evmserverd.wait_for_running()
-    temp_appliance_unconfig_funcscope.wait_for_web_ui()
+    temp_appliance_unconfig_funcscope.wait_for_miq_ready()
 
 
 @pytest.mark.tier(2)
@@ -423,7 +423,7 @@ def test_appliance_console_external_db_create(
                    RETURN, RETURN, RETURN, pwd, TimedCommand(pwd, 300), RETURN)
     unconfigured_appliance_secondary.appliance_console.run_commands(command_set)
     unconfigured_appliance_secondary.evmserverd.wait_for_running(timeout=900)
-    unconfigured_appliance_secondary.wait_for_web_ui()
+    unconfigured_appliance_secondary.wait_for_miq_ready()
 
 
 @pytest.mark.tier(2)
@@ -620,7 +620,7 @@ def test_appliance_console_dhcp(unconfigured_appliance, soft_assert):
     """
     command_set = ('ap', RETURN, '1', '1', 'y', TimedCommand('y', 90), RETURN, RETURN)
     unconfigured_appliance.appliance_console.run_commands(command_set)
-    unconfigured_appliance.reboot(wait_for_web_ui=False)
+    unconfigured_appliance.reboot(wait_for_miq_ready=False)
 
     soft_assert(unconfigured_appliance.ssh_client.run_command(
         r"ip a show dev eth0 | grep 'inet\s.*dynamic'").success)
@@ -653,7 +653,7 @@ def test_appliance_console_static_ipv4(unconfigured_appliance, soft_assert):
     """
     command_set = ('ap', RETURN, '1', '2', RETURN, RETURN, RETURN, RETURN, RETURN, RETURN, 'y')
     unconfigured_appliance.appliance_console.run_commands(command_set, timeout=90)
-    unconfigured_appliance.reboot(wait_for_web_ui=False)
+    unconfigured_appliance.reboot(wait_for_miq_ready=False)
 
     soft_assert(unconfigured_appliance.ssh_client.run_command(
         "ip -4 a show dev eth0 | grep 'inet .*scope global eth0'"))
@@ -684,7 +684,7 @@ def test_appliance_console_static_ipv6(unconfigured_appliance, soft_assert):
     """
     command_set = ('ap', RETURN, '1', '3', '1::1', RETURN, '1::f', RETURN, RETURN, RETURN, 'y', '')
     unconfigured_appliance.appliance_console.run_commands(command_set, timeout=90)
-    unconfigured_appliance.reboot(wait_for_web_ui=False)
+    unconfigured_appliance.reboot(wait_for_miq_ready=False)
 
     soft_assert(unconfigured_appliance.ssh_client.run_command(
         "ip -6 a show dev eth0 | grep 'inet6 1::1.*scope global'"))
@@ -785,7 +785,7 @@ def test_appliance_console_restart(temp_appliance_preconfig_funcscope):
         fail_condition=True
     )
 
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
     navigate_to(appliance.server, "LoggedIn")
 
 
@@ -886,7 +886,7 @@ def test_appliance_console_evm_start(request, temp_appliance_preconfig_funcscope
     start_evm_command = ("ap", RETURN, app_con_menu["start_evm"], "Y", RETURN,
                          RETURN, app_con_menu["quit"])
     appliance.appliance_console.run_commands(start_evm_command, timeout=30)
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
     logged_in_page = appliance.server.login()
     request.addfinalizer(appliance.server.logout)
     assert logged_in_page.is_displayed, "UI is not working after starting the EVM service."
@@ -1242,7 +1242,7 @@ def test_appliance_console_vmdb_httpd(temp_appliance_preconfig_funcscope):
     # Starting the EVM service
     command_set = ("ap", RETURN, app_con_menu["start_evm"], TimedCommand("Y", 120))
     appliance.appliance_console.run_commands(command_set, timeout=30)
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
 
 
 @pytest.mark.tier(2)

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -57,14 +57,12 @@ def get_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm):
 
     for app in temp_appliances_unconfig_funcscope_rhevm:
         app.wait_for_web_ui()
-        app.wait_for_api_available()
 
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl1).setup()
     provider_app_crud(OpenStackProvider, appl1).setup()
     appl1.db.backup()
     appl1.wait_for_web_ui()
-    appl1.wait_for_api_available()
     return temp_appliances_unconfig_funcscope_rhevm
 
 
@@ -80,7 +78,6 @@ def get_appliance_with_ansible(temp_appliance_preconfig_funcscope):
     appl1.wait_for_embedded_ansible()
     appl1.db.backup()
     appl1.wait_for_web_ui()
-    appl1.wait_for_api_available()
     return temp_appliance_preconfig_funcscope
 
 
@@ -95,7 +92,6 @@ def get_ext_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm, 
     # configure appliances
     appl1.configure(region=0)
     appl1.wait_for_web_ui()
-    appl1.wait_for_api_available()
 
     appl2.appliance_console_cli.configure_appliance_external_join(
         app_ip, app_creds_modscope['username'], app_creds_modscope['password'], 'vmdb_production',
@@ -248,7 +244,6 @@ def test_appliance_console_dump_restore_db_local(request, get_appliances_with_pr
     restore_db(appl2)
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
-    appl2.wait_for_api_available()
 
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == set(appl1.managed_provider_names), (
@@ -308,7 +303,6 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
-    appl2.wait_for_api_available()
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'
@@ -337,7 +331,6 @@ def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansi
     manager.quit()
     appl1.evmserverd.start()
     appl1.wait_for_web_ui()
-    appl1.wait_for_api_available()
     appl1.wait_for_embedded_ansible()
     repositories = appl1.collections.ansible_repositories
     try:
@@ -387,8 +380,7 @@ def test_appliance_console_restore_pg_basebackup_replicated(
     appl2.evmserverd.start()
     appl1.wait_for_web_ui()
     appl2.wait_for_web_ui()
-    appl1.wait_for_api_available()
-    appl2.wait_for_api_available()
+
     # Assert providers exist after restore and replicated to second appliances
     assert providers_before_restore == set(appl1.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -476,8 +468,6 @@ def test_appliance_console_restore_db_replicated(
     appl2.evmserverd.start()
     appl1.wait_for_web_ui()
     appl2.wait_for_web_ui()
-    appl1.wait_for_api_available()
-    appl2.wait_for_api_available()
 
     # reconfigure replication between appliances which switches to "disabled"
     # during restore
@@ -547,7 +537,6 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
 
     appl3.evmserverd.start()
     appl3.wait_for_web_ui()
-    appl3.wait_for_api_available()
     # Assert providers still exist after restore
     assert providers_before_restore == set(appl3.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -561,7 +550,6 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
 
     appl3.evmserverd.wait_for_running()
     appl3.wait_for_web_ui()
-    appl3.wait_for_api_available()
     # Assert providers still exist after ha failover
     assert providers_before_restore == set(appl3.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -642,7 +630,6 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
-    appl2.wait_for_api_available()
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'
@@ -729,7 +716,6 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
 
     appl2.evmserverd.start()
     appl2.wait_for_web_ui()
-    appl2.wait_for_api_available()
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'

--- a/cfme/tests/cli/test_appliance_console_db_restore.py
+++ b/cfme/tests/cli/test_appliance_console_db_restore.py
@@ -56,13 +56,13 @@ def get_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm):
     appl2.configure(region=0)
 
     for app in temp_appliances_unconfig_funcscope_rhevm:
-        app.wait_for_web_ui()
+        app.wait_for_miq_ready()
 
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl1).setup()
     provider_app_crud(OpenStackProvider, appl1).setup()
     appl1.db.backup()
-    appl1.wait_for_web_ui()
+    appl1.wait_for_miq_ready()
     return temp_appliances_unconfig_funcscope_rhevm
 
 
@@ -77,7 +77,7 @@ def get_appliance_with_ansible(temp_appliance_preconfig_funcscope):
     appl1.enable_embedded_ansible_role()
     appl1.wait_for_embedded_ansible()
     appl1.db.backup()
-    appl1.wait_for_web_ui()
+    appl1.wait_for_miq_ready()
     return temp_appliance_preconfig_funcscope
 
 
@@ -91,12 +91,12 @@ def get_ext_appliances_with_providers(temp_appliances_unconfig_funcscope_rhevm, 
     app_ip = appl1.hostname
     # configure appliances
     appl1.configure(region=0)
-    appl1.wait_for_web_ui()
+    appl1.wait_for_miq_ready()
 
     appl2.appliance_console_cli.configure_appliance_external_join(
         app_ip, app_creds_modscope['username'], app_creds_modscope['password'], 'vmdb_production',
         app_ip, app_creds_modscope['sshlogin'], app_creds_modscope['sshpass'])
-    appl2.wait_for_web_ui()
+    appl2.wait_for_miq_ready()
     # Add infra/cloud providers and create db backup
     provider_app_crud(VMwareProvider, appl1).setup()
     provider_app_crud(OpenStackProvider, appl1).setup()
@@ -150,7 +150,7 @@ def get_ha_appliances_with_providers(unconfigured_appliances, app_creds):
         TimedCommand(pwd, 360), '')
     appl3.appliance_console.run_commands(command_set)
     appl3.evmserverd.wait_for_running()
-    appl3.wait_for_web_ui()
+    appl3.wait_for_miq_ready()
     # Configure primary replication node
     command_set = ('ap', '', '8', '1', '1', '', '', pwd, pwd, app0_ip, TimedCommand('y', 60), '')
     appl1.appliance_console.run_commands(command_set)
@@ -243,7 +243,7 @@ def test_appliance_console_dump_restore_db_local(request, get_appliances_with_pr
     appl2.db.create()
     restore_db(appl2)
     appl2.evmserverd.start()
-    appl2.wait_for_web_ui()
+    appl2.wait_for_miq_ready()
 
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == set(appl1.managed_provider_names), (
@@ -302,7 +302,7 @@ def test_appliance_console_backup_restore_db_local(request, two_appliances_one_w
         interaction.answer('Press any key to continue.', '', timeout=80)
 
     appl2.evmserverd.start()
-    appl2.wait_for_web_ui()
+    appl2.wait_for_miq_ready()
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'
@@ -330,7 +330,7 @@ def test_appliance_console_restore_pg_basebackup_ansible(get_appliance_with_ansi
     restore_db(appl1, '/tmp/evm_db.backup')
     manager.quit()
     appl1.evmserverd.start()
-    appl1.wait_for_web_ui()
+    appl1.wait_for_miq_ready()
     appl1.wait_for_embedded_ansible()
     repositories = appl1.collections.ansible_repositories
     try:
@@ -378,8 +378,8 @@ def test_appliance_console_restore_pg_basebackup_replicated(
     restore_db(appl2, '/tmp/evm_db.backup')
     appl1.evmserverd.start()
     appl2.evmserverd.start()
-    appl1.wait_for_web_ui()
-    appl2.wait_for_web_ui()
+    appl1.wait_for_miq_ready()
+    appl2.wait_for_miq_ready()
 
     # Assert providers exist after restore and replicated to second appliances
     assert providers_before_restore == set(appl1.managed_provider_names), (
@@ -419,9 +419,9 @@ def test_appliance_console_restore_db_external(request, get_ext_appliances_with_
     appl1.db.create()
     restore_db(appl1)
     appl1.evmserverd.start()
-    appl1.wait_for_web_ui()
+    appl1.wait_for_miq_ready()
     appl2.evmserverd.start()
-    appl2.wait_for_web_ui()
+    appl2.wait_for_miq_ready()
     # Assert providers after restore on both apps
     assert providers_before_restore == set(appl1.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -466,8 +466,8 @@ def test_appliance_console_restore_db_replicated(
     restore_db(appl1)
     appl1.evmserverd.start()
     appl2.evmserverd.start()
-    appl1.wait_for_web_ui()
-    appl2.wait_for_web_ui()
+    appl1.wait_for_miq_ready()
+    appl2.wait_for_miq_ready()
 
     # reconfigure replication between appliances which switches to "disabled"
     # during restore
@@ -536,7 +536,7 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
     appl3.evm_failover_monitor.restart()
 
     appl3.evmserverd.start()
-    appl3.wait_for_web_ui()
+    appl3.wait_for_miq_ready()
     # Assert providers still exist after restore
     assert providers_before_restore == set(appl3.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -549,7 +549,7 @@ def test_appliance_console_restore_db_ha(request, unconfigured_appliances, app_c
         appl1.db_service.stop()
 
     appl3.evmserverd.wait_for_running()
-    appl3.wait_for_web_ui()
+    appl3.wait_for_miq_ready()
     # Assert providers still exist after ha failover
     assert providers_before_restore == set(appl3.managed_provider_names), (
         'Restored DB is missing some providers'
@@ -629,7 +629,7 @@ def test_appliance_console_restore_db_nfs(request, two_appliances_one_with_provi
         interaction.answer('Press any key to continue.', '', timeout=80)
 
     appl2.evmserverd.start()
-    appl2.wait_for_web_ui()
+    appl2.wait_for_miq_ready()
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'
@@ -715,7 +715,7 @@ def test_appliance_console_restore_db_samba(request, two_appliances_one_with_pro
         interaction.answer('Press any key to continue.', '', timeout=80)
 
     appl2.evmserverd.start()
-    appl2.wait_for_web_ui()
+    appl2.wait_for_miq_ready()
     # Assert providers on the second appliance
     assert set(appl2.managed_provider_names) == appl1_provider_names, (
         'Restored DB is missing some providers'

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -124,7 +124,7 @@ def do_yum_update(appliance):
     output = '\n'.join(filter(lambda x: not re.match(rpmnew_regex, x), result.output.splitlines()))
 
     appliance.evmserverd.start()
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
     return output
 
 
@@ -220,7 +220,7 @@ def test_update_embedded_ansible_webui(enabled_embedded_appliance, appliance, ol
                             num_sec=60)
             assert wait_for(func=lambda: enabled_embedded_appliance.nginx.running,
                             num_sec=60)
-    enabled_embedded_appliance.wait_for_web_ui()
+    enabled_embedded_appliance.wait_for_miq_ready()
 
     with enabled_embedded_appliance:
         repositories = enabled_embedded_appliance.collections.ansible_repositories
@@ -260,7 +260,7 @@ def test_update_distributed_webui(ext_appliances_with_providers, appliance,
                 num_sec=900, delay=20, handle_exception=True,
                 message='Waiting for appliance to update')
         updated_appliance.evmserverd.wait_for_running()
-        updated_appliance.wait_for_web_ui()
+        updated_appliance.wait_for_miq_ready()
 
     # Verify that existing provider can detect new VMs on both apps
     virtual_crud_appl1 = provider_app_crud(VMwareProvider, ext_appliances_with_providers[0])
@@ -297,8 +297,8 @@ def test_update_replicated_webui(replicated_appliances_preupdate_with_providers,
              message='Waiting for appliance to update')
     preupdate_appls[0].evmserverd.wait_for_running()
     preupdate_appls[1].evmserverd.wait_for_running()
-    preupdate_appls[0].wait_for_web_ui()
-    preupdate_appls[1].wait_for_web_ui()
+    preupdate_appls[0].wait_for_miq_ready()
+    preupdate_appls[1].wait_for_miq_ready()
 
     # Assert providers exist after upgrade and replicated to second preupdate_appls
     assert providers_before_upgrade == set(
@@ -347,7 +347,7 @@ def test_update_ha(ha_appliances_with_providers, appliance, update_strategy, req
         ha_appliances_with_providers[0].db_service.stop()
 
     ha_appliances_with_providers[2].evmserverd.wait_for_running()
-    ha_appliances_with_providers[2].wait_for_web_ui()
+    ha_appliances_with_providers[2].wait_for_miq_ready()
     # Verify that existing provider can detect new VMs
     virtual_crud = provider_app_crud(VMwareProvider, ha_appliances_with_providers[2])
     vm = provision_vm(request, virtual_crud)

--- a/cfme/tests/cli/test_evmserverd.py
+++ b/cfme/tests/cli/test_evmserverd.py
@@ -7,10 +7,10 @@ from cfme.utils.wait import wait_for_decorator
 @pytest.fixture(scope="module")
 def start_evmserverd_after_module(appliance):
     appliance.evmserverd.start()
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
     yield
     appliance.evmserverd.restart()
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
 
 
 pytestmark = [

--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -1194,7 +1194,7 @@ def test_create_azure_vm_from_azure_image(connect_az_account, cfme_vhd, upload_i
         assert unlock.success
 
     app.configure()
-    app.wait_for_web_ui()
+    app.wait_for_miq_ready()
 
     # Check we can login
     logged_in_page = app.server.login()

--- a/cfme/tests/configure/test_log_depot_operation.py
+++ b/cfme/tests/configure/test_log_depot_operation.py
@@ -106,7 +106,7 @@ def configured_external_appliance(temp_appliance_preconfig, app_creds_modscope,
         hostname, app_creds_modscope['sshlogin'], app_creds_modscope['sshpass'])
     temp_appliance_unconfig.evmserverd.start()
     temp_appliance_unconfig.evmserverd.wait_for_running()
-    temp_appliance_unconfig.wait_for_web_ui()
+    temp_appliance_unconfig.wait_for_miq_ready()
     return temp_appliance_unconfig
 
 

--- a/cfme/tests/containers/test_blacklisted_container_events.py
+++ b/cfme/tests/containers/test_blacklisted_container_events.py
@@ -112,7 +112,7 @@ def appliance_cleanup(provider, appliance, namespace):
     appliance.ssh_client.run_rails_console(
         "BlacklistedEvent.where(:event_name => 'POD_CREATED').destroy_all")
     appliance.evmserverd.restart()
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
 
     try:
         delete_pod(provider=provider, namespace=namespace)
@@ -173,7 +173,7 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
         {"ems": {"ems_openshift": {"blacklisted_event_names": ["POD_CREATED"]}}}
     )
     appliance.evmserverd.restart()
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
 
     rails_result_blacklist = get_blacklisted_event_names(appliance)
 
@@ -203,7 +203,7 @@ def test_blacklisted_container_events(request, appliance, provider, app_creds):
     assert "POD_CREATED" not in rails_result_default
 
     appliance.evmserverd.restart()
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
 
     evm_tail_no_blacklist.start_monitoring()
 

--- a/cfme/tests/intelligence/reports/test_reports_schedules.py
+++ b/cfme/tests/intelligence/reports/test_reports_schedules.py
@@ -283,7 +283,7 @@ def test_miq_schedule_validation_failed(temp_appliance_preconfig):
         pytest.fail("Failed to download the file to the appliance.")
 
     # In case the failure pattern is encountered, the following piece of code will raise
-    # a TimedOutError from appliance.wait_for_web_ui
+    # a TimedOutError from appliance.wait_for_miq_ready
     # The matched_patterns will only be found on successful database restore.
     with LogValidator(
         "/var/www/miq/vmdb/log/evm.log",

--- a/cfme/tests/optimize/test_bottlenecks.py
+++ b/cfme/tests/optimize/test_bottlenecks.py
@@ -55,7 +55,7 @@ def db_restore(temp_appliance_extended_db):
     app.db.fix_auth_key()
     app.db.fix_auth_dbyml()
     app.evmserverd.start()
-    app.wait_for_web_ui()
+    app.wait_for_miq_ready()
 
 
 @pytest.mark.rhel_testing

--- a/cfme/tests/test_appliance.py
+++ b/cfme/tests/test_appliance.py
@@ -440,7 +440,7 @@ def test_codename_in_log(appliance):
     lv.start_monitoring()
     appliance.ssh_client.run_command('appliance_console_cli --server=restart')
     assert lv.validate(wait="60s")
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
 
 
 def test_codename_in_stdout(appliance):
@@ -462,7 +462,7 @@ def test_codename_in_stdout(appliance):
             fr'journalctl -u evmserverd -c "{cursor}" | egrep -i "codename: \w+$"')
         return r.success
 
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
 
 
 @test_requirements.distributed

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -150,7 +150,7 @@ def download_and_migrate_db(app, db_url):
     except ApplianceException:
         result = app.ssh_client.run_rake_command("evm:start")
         assert result.success, f"Couldn't start evmserverd: {result.output}"
-    app.wait_for_miq_ready(timeout=600)
+    app.wait_for_miq_ready(num_sec=600)
     app.db.reset_user_pass()
     wait_for(navigate_to, (app.server, 'LoginScreen'), handle_exception=True, timeout='5m')
     app.server.login(app.user)
@@ -224,7 +224,7 @@ def test_db_migrate_replication(temp_appliance_remote, dbversion, temp_appliance
     except ApplianceException:
         result = app.ssh_client.run_rake_command("evm:start")
         assert result.success, f"Couldn't start evmserverd: {result.output}"
-    app.wait_for_miq_ready(timeout=600)
+    app.wait_for_miq_ready(num_sec=600)
     # Reset user's password, just in case (necessary for customer DBs)
     app.db.reset_user_pass()
     app.server.login(app.user)

--- a/cfme/tests/test_db_migrate.py
+++ b/cfme/tests/test_db_migrate.py
@@ -54,7 +54,7 @@ def temp_appliance_global_region(temp_appliance_unconfig_funcscope_rhevm):
         99, 'localhost', credentials['database']['username'], credentials['database']['password'],
         'vmdb_production', temp_appliance_unconfig_funcscope_rhevm.unpartitioned_disks[0])
     temp_appliance_unconfig_funcscope_rhevm.evmserverd.wait_for_running()
-    temp_appliance_unconfig_funcscope_rhevm.wait_for_web_ui()
+    temp_appliance_unconfig_funcscope_rhevm.wait_for_miq_ready()
     return temp_appliance_unconfig_funcscope_rhevm
 
 
@@ -150,7 +150,7 @@ def download_and_migrate_db(app, db_url):
     except ApplianceException:
         result = app.ssh_client.run_rake_command("evm:start")
         assert result.success, f"Couldn't start evmserverd: {result.output}"
-    app.wait_for_web_ui(timeout=600)
+    app.wait_for_miq_ready(timeout=600)
     app.db.reset_user_pass()
     wait_for(navigate_to, (app.server, 'LoginScreen'), handle_exception=True, timeout='5m')
     app.server.login(app.user)
@@ -224,7 +224,7 @@ def test_db_migrate_replication(temp_appliance_remote, dbversion, temp_appliance
     except ApplianceException:
         result = app.ssh_client.run_rake_command("evm:start")
         assert result.success, f"Couldn't start evmserverd: {result.output}"
-    app.wait_for_web_ui(timeout=600)
+    app.wait_for_miq_ready(timeout=600)
     # Reset user's password, just in case (necessary for customer DBs)
     app.db.reset_user_pass()
     app.server.login(app.user)
@@ -258,7 +258,7 @@ def test_upgrade_single_inplace(appliance_preupdate, appliance):
     appliance_preupdate.db.automate_reset()
     appliance_preupdate.db_service.restart()
     appliance_preupdate.evmserverd.start()
-    appliance_preupdate.wait_for_web_ui()
+    appliance_preupdate.wait_for_miq_ready()
     result = appliance_preupdate.ssh_client.run_command('cat /var/www/miq/vmdb/VERSION')
     assert result.output in appliance.version
 

--- a/cfme/tests/test_replication.py
+++ b/cfme/tests/test_replication.py
@@ -60,7 +60,7 @@ def setup_replication(configured_appliance, unconfigured_appliance):
 
     global_app.appliance_console_cli.configure_appliance_internal_fetch_key(**app_params)
     global_app.evmserverd.wait_for_running()
-    global_app.wait_for_web_ui()
+    global_app.wait_for_miq_ready()
 
     remote_app.set_pglogical_replication(replication_type=':remote')
     global_app.set_pglogical_replication(replication_type=':global')
@@ -279,7 +279,7 @@ def test_replication_appliance_set_type_global_ui(configured_appliance, unconfig
 
     global_app.appliance_console_cli.configure_appliance_internal_fetch_key(**app_params)
     global_app.evmserverd.wait_for_running()
-    global_app.wait_for_web_ui()
+    global_app.wait_for_miq_ready()
 
     # Making configured app to Remote Appliance using UI
     remote_region = remote_app.collections.regions.instantiate()
@@ -459,7 +459,7 @@ def test_replication_subscription_revalidation_pglogical(configured_appliance,
 
     global_app.appliance_console_cli.configure_appliance_internal_fetch_key(**app_params)
     global_app.evmserverd.wait_for_running()
-    global_app.wait_for_web_ui()
+    global_app.wait_for_miq_ready()
 
     remote_app.set_pglogical_replication(replication_type=':remote')
     region = global_app.collections.regions.instantiate(number=99)

--- a/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
+++ b/cfme/tests/v2v/test_v2v_migrations_single_vcenter.py
@@ -364,7 +364,7 @@ def test_migration_restart(request, appliance, provider,
         delay=10,
         num_sec=1800
     )
-    appliance.wait_for_web_ui()
+    appliance.wait_for_miq_ready()
     try:
         assert migration_plan.wait_for_state("In_Progress")
     except WebDriverException:

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -497,7 +497,6 @@ class IPAppliance:
             # restarted:
             restart_evm = False
             self.wait_for_web_ui(log_callback=log_callback)
-            self.wait_for_api_available()
             if self.version < '5.11':
                 self.configure_vm_console_cert(log_callback=log_callback)
                 restart_evm = True
@@ -509,7 +508,6 @@ class IPAppliance:
             if restart_evm:
                 self.evmserverd.restart(log_callback=log_callback)
                 self.wait_for_web_ui(timeout=1800, log_callback=log_callback)
-                self.wait_for_api_available()
 
     def configure_gce(self, log_callback=None):
         # Force use of IPAppliance's configure method
@@ -1490,10 +1488,11 @@ class IPAppliance:
         (log_callback or self.log.info)('Waiting for web UI to ' + prefix + 'appear')
         result, wait = wait_for(self._check_appliance_ui_wait_fn, num_sec=timeout,
             fail_condition=not running, delay=10)
+        self.wait_for_api_available()  # TODO deal with timeout and the running parameter
         return result
 
     def wait_for_api_available(self, num_sec=600):
-        """Waits for the web UI to be running / to not be running
+        """ Waits for the MIQ API to be available. Invalidates the cached client.
 
         Args:
             num_sec: Number of seconds to wait until num_sec(default ``600``)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -507,7 +507,7 @@ class IPAppliance:
 
             if restart_evm:
                 self.evmserverd.restart(log_callback=log_callback)
-                self.wait_for_miq_ready(timeout=1800, log_callback=log_callback)
+                self.wait_for_miq_ready(num_sec=1800, log_callback=log_callback)
 
     def configure_gce(self, log_callback=None):
         # Force use of IPAppliance's configure method
@@ -1476,19 +1476,17 @@ class IPAppliance:
             self.wait_for_miq_ready()
 
     @logger_wrap("Waiting for web_ui: {}")
-    def wait_for_miq_ready(self, timeout=900, running=True, log_callback=None):
+    def wait_for_miq_ready(self, num_sec: int = 900, log_callback=None):
         """Waits for the web UI and API server to be ready / to not ready
 
         Args:
-            timeout: Number of seconds to wait until timeout (default ``600``)
-            running: Specifies if we wait for web UI to start or stop (default ``True``)
-                     ``True`` == start, ``False`` == stop
+            num_secs: Number of seconds to wait until timeout (default ``900``)
+            log_callback: Function to use for writing log messages.
         """
-        prefix = "" if running else "dis"
-        (log_callback or self.log.info)('Waiting for web UI to ' + prefix + 'appear')
-        result, wait = wait_for(self._check_appliance_ui_wait_fn, num_sec=timeout,
-            fail_condition=not running, delay=10)
-        self.wait_for_api_available()  # TODO deal with timeout and the running parameter
+        (log_callback or self.log.info)('Waiting for web UI to appear')
+        result, secs_taken = wait_for(self._check_appliance_ui_wait_fn,
+                                      num_sec=num_sec, fail_condition=False, delay=10)
+        self.wait_for_api_available(num_sec - secs_taken)
         return result
 
     def wait_for_api_available(self, num_sec=600):

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -380,7 +380,7 @@ def configure_appliances_ha(appliances, pwd):
         interaction.answer('Press any key to continue.', '', timeout=360)
 
     apps2.evmserverd.wait_for_running()
-    apps2.wait_for_web_ui()
+    apps2.wait_for_miq_ready()
 
     apps0.appliance_console.configure_primary_replication_node(pwd)
     apps1.appliance_console.configure_standby_replication_node(pwd, app0_ip)

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -677,7 +677,7 @@ class ApplianceDB(AppliancePlugin):
             self.migrate()
             self.automate_reset()
         self.appliance.evmserverd.start()
-        self.appliance.wait_for_web_ui(timeout=600)
+        self.appliance.wait_for_miq_ready(timeout=600)
         self.reset_user_pass()
         # need to refresh the appliance
         delattr(self.appliance, "rest_api")

--- a/cfme/utils/appliance/db.py
+++ b/cfme/utils/appliance/db.py
@@ -677,7 +677,7 @@ class ApplianceDB(AppliancePlugin):
             self.migrate()
             self.automate_reset()
         self.appliance.evmserverd.start()
-        self.appliance.wait_for_miq_ready(timeout=600)
+        self.appliance.wait_for_miq_ready(num_sec=600)
         self.reset_user_pass()
         # need to refresh the appliance
         delattr(self.appliance, "rest_api")

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -352,7 +352,7 @@ class CFMENavigateStep(NavigateStep):
                 ssh.run_rails_command("\"(MiqVimBrokerWorker.all + MiqUiWorker.all).each &:kill\"")
             logger.info("Waiting for web UI to come back alive.")
             sleep(10)   # Give it some rest
-            self.appliance.wait_for_web_ui()
+            self.appliance.wait_for_miq_ready()
             self.appliance.browser.quit_browser()
             self.appliance.browser.open_browser(url_key=self.obj.appliance.server.address())
             self.go(_tries, *args, **go_kwargs)
@@ -500,7 +500,7 @@ class CFMENavigateStep(NavigateStep):
         if restart_evmserverd:
             logger.info("evmserverd restart requested")
             self.appliance.evmserverd.restart()
-            self.appliance.wait_for_web_ui()
+            self.appliance.wait_for_miq_ready()
             self.go(_tries, *args, **go_kwargs)
 
         if recycle or restart_evmserverd:

--- a/notebooks/BasicApplianceSetup.ipynb
+++ b/notebooks/BasicApplianceSetup.ipynb
@@ -75,7 +75,7 @@
     "\n",
     "app0_ip.appliance_console.run_commands(command_set)\n",
     "app0_ip.evmserverd.wait_for_running()\n",
-    "app0_ip.wait_for_web_ui()\n"
+    "app0_ip.wait_for_miq_ready()\n"
    ]
   },
   {
@@ -93,7 +93,7 @@
     "\n",
     "app1_ip.appliance_console.run_commands(command_set)\n",
     "app1_ip.evmserverd.wait_for_running()\n",
-    "app1_ip.wait_for_web_ui()"
+    "app1_ip.wait_for_miq_ready()"
    ]
   },
   {
@@ -117,7 +117,7 @@
     "\n",
     "app1_ip.appliance_console.run_commands(command_set_0)\n",
     "app1_ip.evmserverd.wait_for_running()\n",
-    "app1_ip.wait_for_web_ui()\n"
+    "app1_ip.wait_for_miq_ready()\n"
    ]
   },
   {

--- a/scripts/update_rhel.py
+++ b/scripts/update_rhel.py
@@ -28,7 +28,7 @@ def main():
     if res.rc == 0:
         if args.reboot:
             print('Rebooting')
-            ip_a.reboot(wait_for_web_ui=args.no_wait_ui)
+            ip_a.reboot(wait_for_miq_ready=args.no_wait_ui)
         print('Appliance update complete')
 
     return res.rc

--- a/scripts/wait_for_appliance_ui.py
+++ b/scripts/wait_for_appliance_ui.py
@@ -19,7 +19,7 @@ def main():
 
     args = parser.parse_args()
     ip_a = IPAppliance.from_url(args.url)
-    result = ip_a.wait_for_miq_ready(timeout=args.num_sec)
+    result = ip_a.wait_for_miq_ready(num_sec=args.num_sec)
 
     if not result:
         return 1

--- a/scripts/wait_for_appliance_ui.py
+++ b/scripts/wait_for_appliance_ui.py
@@ -19,7 +19,7 @@ def main():
 
     args = parser.parse_args()
     ip_a = IPAppliance.from_url(args.url)
-    result = ip_a.wait_for_web_ui(timeout=args.num_sec)
+    result = ip_a.wait_for_miq_ready(timeout=args.num_sec)
 
     if not result:
         return 1

--- a/sprout/appliances/tasks/service_ops.py
+++ b/sprout/appliances/tasks/service_ops.py
@@ -86,7 +86,7 @@ def appliance_reboot(self, appliance_id, if_needs_restarting=False):
             appliance = Appliance.objects.get(id=appliance_id)
             appliance.set_power_state(Appliance.Power.REBOOTING)
             appliance.save()
-        appliance.ipapp.reboot(wait_for_web_ui=False, log_callback=appliance.set_status)
+        appliance.ipapp.reboot(wait_for_miq_ready=False, log_callback=appliance.set_status)
         with transaction.atomic():
             appliance = Appliance.objects.get(id=appliance_id)
             appliance.set_power_state(Appliance.Power.ON)


### PR DESCRIPTION
### Introduce wait_for_miq_ready, remove wait_for_web_ui

We were hitting HTTP 503 when accessing MIQ API right after the server
got restarted. We were waiting for Web UI availability, but api, though
served on similar URL, was handled probably by separate process and it could
happen the requests to it returned HTTP 503 when the rest of the UI was working.

This patch renames `wait_for_web_ui` to `wait_for_miq_ready` and adds the
blocking call for waiting for the API to it.

No work though has been done to remove any other stale API objects somewhere
else if there are any!

#### Test results advocacy:
 * I ran the tests I have in my FAs. I saw no problem related to this PR.
 * I ran tests related to v2v where @sshveta saw HTTP 503. I saw quite a lot of failed tests (about 50% success rate), but I don't think the failures were related. I suspect the tests are failing even without the code in this PR in effect.
 * smoke tests were all good, except unrelated problem with wait_for in test: `cfme/tests/test_appliance.py/test_codename_in_log`

```
# Dont mind this. This was used to test the v2v, now deactivated to see the smoke tests results.
#{#{ py#test: cfme/tests/v2v/ -v --use-provider complete --long-running --provider-limit 4 }}
```