### PR TITLE
[RFR] - user login with special char password

### DIFF
--- a/cfme/tests/integration/test_db_auth.py
+++ b/cfme/tests/integration/test_db_auth.py
@@ -14,10 +14,11 @@ pytestmark = [test_requirements.auth]
 TEST_PASSWORDS = [
     f"{fauxfactory.gen_alpha()} ",  # trailing whitespace
     f" {fauxfactory.gen_alpha()}",  # leading whitespace
-    f"$#!{fauxfactory.gen_alpha()}",  # spec char
+    f"$#!{fauxfactory.gen_alpha()}",  # leading spec char
     f"{fauxfactory.gen_alpha(17)}",  # pw > 16 char
     "",  # blank
     fauxfactory.gen_alpha().upper(),  # uppercase char
+    r"$%&'()*+,-./:;<=>?@[\]^_{|}~",  # special char only
 ]
 
 
@@ -52,7 +53,7 @@ def nonexistent_user(appliance):
     "pwd",
     TEST_PASSWORDS,
     ids=["trailing_whitspace", "leading_whitespace", "spec_char", "gt_16char",
-         "blank", "upper_case"]
+         "blank", "upper_case", "special_char_only"]
 )
 def test_db_user_pwd(appliance, user, pwd, soft_assert):
     """

--- a/cfme/tests/test_login.py
+++ b/cfme/tests/test_login.py
@@ -73,23 +73,6 @@ def test_bad_password(context, request, appliance):
         assert view.password.read() == '' and view.username.read() == ''
 
 
-@pytest.mark.manual
-@test_requirements.rbac
-@pytest.mark.tier(2)
-def test_credentials_change_password_with_special_characters():
-    """
-    Password with only special characters
-
-    Polarion:
-        assignee: dgaikwad
-        casecomponent: Appliance
-        caseimportance: medium
-        initialEstimate: 1/8h
-        tags: rbac
-    """
-    pass
-
-
 @pytest.mark.tier(3)
 @pytest.mark.ignore_stream("5.10")
 @test_requirements.multi_region


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/integration/test_db_auth.py -k "test_db_user_pwd" --long-running -vv}}