### PR TITLE
[1LP][RFR] NTP settings fixes

### DIFF
--- a/cfme/tests/configure/test_ntp_server.py
+++ b/cfme/tests/configure/test_ntp_server.py
@@ -1,170 +1,158 @@
 from datetime import datetime
 from datetime import timedelta
-from functools import partial
 
 import fauxfactory
 import pytest
 
 from cfme import test_requirements
-from cfme.utils.browser import quit
 from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
 
-pytestmark = [test_requirements.configuration,
-              pytest.mark.rhel_testing]
+
+pytestmark = [test_requirements.configuration, pytest.mark.rhel_testing]
+
+STAT_CMD = "stat --format '%y' /etc/chrony.conf"
+POOL_SED_CMD = "sed -i 's/^pool /# &/' /etc/chrony.conf"
 
 
 @pytest.fixture
-def ntp_servers_keys(appliance):
+def ntp_server_keys(appliance):
+    """Return list of NTP server keys (widget attribute names) from ServerInformationView"""
     return appliance.server.settings.ntp_servers_fields_keys
 
 
 @pytest.fixture
-def empty_ntp_dict(ntp_servers_keys):
-    return dict.fromkeys(ntp_servers_keys, '')
+def empty_ntp(ntp_server_keys):
+    """Return dictionary of NTP server keys with blank values"""
+    return dict.fromkeys(ntp_server_keys, '')
+
+
+@pytest.fixture
+def random_ntp(ntp_server_keys):
+    """Return dictionary of NTP server keys with random alphanumeric values"""
+    return dict(zip(ntp_server_keys, [fauxfactory.gen_alphanumeric() for _ in range(3)]))
+
+
+@pytest.fixture
+def random_max_ntp(ntp_server_keys):
+    """Return dictionary of NTP server keys with random alphanumeric values of max length"""
+    return dict(zip(ntp_server_keys, [fauxfactory.gen_alphanumeric(255) for _ in range(3)]))
+
+
+@pytest.fixture
+def config_ntp(ntp_server_keys):
+    """Return dictionary of NTP server keys with server names from config yaml"""
+    return dict(zip(ntp_server_keys, cfme_data['clock_servers']))
 
 
 def appliance_date(appliance):
-    result = appliance.ssh_client.run_command("date --iso-8601=hours")
-    return datetime.strptime(result.output.rsplit('-', 1)[0], '%Y-%m-%dT%H')
+    """Return appliance server datetime, in ISO-8601 format"""
+    result = appliance.ssh_client.run_command("date --iso-8601")
+    return datetime.fromisoformat(result.output.rstrip())
 
 
-def check_ntp_grep(appliance, clock):
-    result = appliance.ssh_client.run_command(
-        f"cat /etc/chrony.conf| grep {clock}")
-    return not bool(result.rc)
+def chrony_servers(appliance):
+    """Return list of the NTP servers from /etc/chrony.conf"""
+    servers = appliance.ssh_client.run_command(f"grep ^server /etc/chrony.conf").output
+    return [s.split()[1] for s in servers.splitlines()]
 
 
-def clear_ntp_settings(appliance, empty_ntp_dict):
-    ntp_file_date_stamp = appliance.ssh_client.run_command(
-        "stat --format '%y' /etc/chrony.conf").output
-    appliance.server.settings.update_ntp_servers(empty_ntp_dict)
-    wait_for(lambda: ntp_file_date_stamp != appliance.ssh_client.run_command(
-        "stat --format '%y' /etc/chrony.conf").output, num_sec=60, delay=10)
+def clear_ntp_settings(appliance, empty_ntp):
+    """Clear all NTP servers in the UI"""
+    last_updated = appliance.ssh_client.run_command(STAT_CMD).output
+    appliance.server.settings.update_ntp_servers(empty_ntp)
+    wait_for(lambda: last_updated != appliance.ssh_client.run_command(STAT_CMD).output,
+        num_sec=60, delay=10)
+
+
+def update_check_ntp(appliance, ntp_fill):
+    """Update NTP servers in the UI, then verify that the changes are reflected in
+    /etc/chrony.conf.
+
+    Args:
+        appliance: appliance to update
+        ntp_fill: :py:class:`dict` of servers to add to UI
+    """
+    appliance.server.settings.update_ntp_servers(ntp_fill)
+
+    # Check that config file has been updated. Defaults to zone-level NTP settings if server-level
+    # values were blank.
+    expected_servers = [s for s in ntp_fill.values() if s != '']
+    if not expected_servers:
+        expected_servers = appliance.server.zone.advanced_settings['ntp']['server']
+    wait_for(lambda: chrony_servers(appliance) == expected_servers, num_sec=60, delay=10)
 
 
 @pytest.mark.tier(2)
-def test_ntp_crud(request, appliance, empty_ntp_dict, ntp_servers_keys):
-    """
+def test_ntp_crud(request, appliance, random_ntp, empty_ntp, config_ntp):
+    """Update and delete NTP servers in the Server Configuration page, and verify that they are
+    updated in /etc/chrony.conf. Finally, restore the NTP servers to the yaml config values.
+
+    TODO: Implement zone- and region-level NTP settings.
+
     Polarion:
         assignee: tpapaioa
         casecomponent: Configuration
         caseimportance: low
         initialEstimate: 1/12h
     """
-    # Adding finalizer
-    request.addfinalizer(lambda: appliance.server.settings.update_ntp_servers(empty_ntp_dict))
-    """ Insert, Update and Delete the NTP servers """
-    # set from yaml file
-    appliance.server.settings.update_ntp_servers(dict(list(zip(
-        ntp_servers_keys, [ntp_server for ntp_server in cfme_data['clock_servers']]))))
-    # Set from random values
-    appliance.server.settings.update_ntp_servers(dict(list(zip(
-        ntp_servers_keys, [fauxfactory.gen_alphanumeric(start="key_") for _ in range(3)]))))
-    # Deleting the ntp values
-    appliance.server.settings.update_ntp_servers(empty_ntp_dict)
+    request.addfinalizer(lambda: update_check_ntp(appliance, config_ntp))
+
+    # Set NTP servers from random values
+    update_check_ntp(appliance, random_ntp)
+
+    # Update NTP servers from config
+    update_check_ntp(appliance, config_ntp)
+
+    # Delete NTP servers
+    update_check_ntp(appliance, empty_ntp)
 
 
 @pytest.mark.tier(3)
-def test_ntp_server_max_character(request, appliance, ntp_servers_keys, empty_ntp_dict):
-    """
+def test_ntp_server_max_character(request, appliance, random_max_ntp, config_ntp):
+    """Update NTP servers in UI with 255 char hostname values, and verify that they are added to
+    /etc/chrony.conf, then restore the NTP servers to the yaml config values.
+
+    TODO: Implement zone- and region-level NTP settings.
+
     Polarion:
         assignee: tpapaioa
         casecomponent: Configuration
         caseimportance: low
         initialEstimate: 1/8h
     """
-    request.addfinalizer(partial(clear_ntp_settings, appliance, empty_ntp_dict))
-    ntp_file_date_stamp = appliance.ssh_client.run_command(
-        "stat --format '%y' /etc/chrony.conf").output
-    appliance.server.settings.update_ntp_servers(dict(list(zip(
-        ntp_servers_keys, [fauxfactory.gen_alphanumeric(start="key_") for _ in range(3)]))))
-    wait_for(lambda: ntp_file_date_stamp != appliance.ssh_client.run_command(
-        "stat --format '%y' /etc/chrony.conf").output, num_sec=60, delay=10)
+    request.addfinalizer(lambda: update_check_ntp(appliance, config_ntp))
+    update_check_ntp(appliance, random_max_ntp)
 
 
 @pytest.mark.tier(3)
-def test_ntp_conf_file_update_check(request, appliance, empty_ntp_dict, ntp_servers_keys):
+@pytest.mark.meta(automates=[1832278])
+def test_ntp_server_check(appliance):
+    """Modify server date, and verify that the configured NTP servers restore it.
 
-    """
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: Configuration
-        initialEstimate: 1/4h
-    """
-    request.addfinalizer(lambda: appliance.server.settings.update_ntp_servers(empty_ntp_dict))
-    ntp_file_date_stamp = appliance.ssh_client.run_command(
-        "stat --format '%y' /etc/chrony.conf").output
-    # Adding the ntp server values
-    appliance.server.settings.update_ntp_servers(dict(list(zip(
-        ntp_servers_keys, [ntp_server for ntp_server in cfme_data['clock_servers']]))))
-    wait_for(lambda: ntp_file_date_stamp != appliance.ssh_client.run_command(
-        "stat --format '%y' /etc/chrony.conf").output, num_sec=60, delay=10)
-    for clock in cfme_data['clock_servers']:
-        status, wait_time = wait_for(lambda: check_ntp_grep(appliance, clock),
-            fail_condition=False, num_sec=60, delay=5)
-        assert status is True, f"Clock value {clock} not update in /etc/chrony.conf file"
+    TODO: Implement zone- and region-level NTP settings.
 
-    # Unsetting the ntp server values
-    ntp_file_date_stamp = appliance.ssh_client.run_command(
-        "stat --format '%y' /etc/chrony.conf").output
-    appliance.server.settings.update_ntp_servers(empty_ntp_dict)
-    wait_for(lambda: ntp_file_date_stamp != appliance.ssh_client.run_command(
-        "stat --format '%y' /etc/chrony.conf").output, num_sec=60, delay=10)
-    for clock in cfme_data['clock_servers']:
-        status, wait_time = wait_for(lambda: check_ntp_grep(appliance, clock),
-            fail_condition=True, num_sec=60, delay=5)
-        assert status is False, f"Found clock record '{clock}' in /etc/chrony.conf file"
+    Bugzilla:
+        1832278
 
-
-@pytest.mark.tier(3)
-def test_ntp_server_check(request, appliance, ntp_servers_keys, empty_ntp_dict):
-    """
     Polarion:
         assignee: tpapaioa
         initialEstimate: 1/4h
         casecomponent: Configuration
     """
-    request.addfinalizer(lambda: appliance.server.settings.update_ntp_servers(empty_ntp_dict))
     orig_date = appliance_date(appliance)
-    past_date = orig_date - timedelta(days=10)
-    logger.info("dates: orig_date - %s, past_date - %s", orig_date, past_date)
-    appliance.ssh_client.run_command("date +%Y%m%d -s \"{}\""
-                                     .format(past_date.strftime('%Y%m%d')))
-    new_date = appliance_date(appliance)
-    if new_date != orig_date:
-        logger.info("Successfully modified the date in the appliance")
-        # Configuring the ntp server and restarting the appliance
-        # checking if ntp property is available, adding if it is not available
-        appliance.server.settings.update_ntp_servers(dict(list(zip(
-            ntp_servers_keys, [ntp_server for ntp_server in cfme_data['clock_servers']]))))
-        # adding the ntp interval to 1 minute and updating the configuration
-        ntp_settings = appliance.advanced_settings.get('ntp', {})  # should have the servers in it
-        ntp_settings['interval'] = '1.minutes'  # just modify interval
-        appliance.update_advanced_settings({'ntp': ntp_settings})
-        # restarting the evmserverd for NTP to work
-        appliance.restart_evm_rude()
-        appliance.wait_for_web_ui(timeout=1200)
-        # Incase if ntpd service is stopped
-        appliance.ssh_client.run_command("service chronyd restart")
-        # Providing two hour runtime for the test run to avoid day changing problem
-        # (in case if the is triggerred in the midnight)
-        wait_for(
-            lambda: (orig_date - appliance_date(appliance)).total_seconds() <= 7200, num_sec=300)
-    else:
-        raise Exception("Failed modifying the system date")
-    # Calling the browser quit() method to compensate the session after the evm service restart
-    quit()
+    past_date = orig_date - timedelta(days=1)
+    logger.info(f"Server dates: original {orig_date}, new {past_date}.")
 
+    # Remove any pool configuration settings. Workaround for BZ1832278.
+    appliance.ssh_client.run_command(POOL_SED_CMD)
+    appliance.ssh_client.run_command("systemctl restart chronyd")
 
-@pytest.mark.tier(3)
-def test_clear_ntp_settings(request, appliance, empty_ntp_dict):
-    """
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: Configuration
-        caseimportance: low
-        initialEstimate: 1/30h
-    """
-    request.addfinalizer(lambda: appliance.server.settings.update_ntp_servers(empty_ntp_dict))
+    appliance.ssh_client.run_command(f"date --iso-8601 -s '{past_date.isoformat()}'")
+    assert appliance_date(appliance) == past_date, "Failed to modify appliance date."
+    logger.info("Successfully modified the date in the appliance.")
+
+    wait_for(
+        lambda: abs((appliance_date(appliance) - orig_date).total_seconds()) <= 3600, delay=10,
+        num_sec=300)


### PR DESCRIPTION
Made a few changes to the NTP server tests. The main changes are:
- Changed the test finalizers to make sure the server-level NTP servers are set to the ones defined in cfme_data, instead of being cleared out. If the server-level settings are cleared out, then the zone-level defaults are used, and those public NTP server defaults are not the ones we want to use.
- Moved NTP server dictionaries for empty / config / random / max char length values out of the tests and into fixtures.

{{ pytest: -vv cfme/tests/configure/test_ntp_server.py }}