### PR TITLE
[RFR] openssl in quickstart

### DIFF
--- a/cfme/scripting/quickstart/system.py
+++ b/cfme/scripting/quickstart/system.py
@@ -72,6 +72,8 @@ REDHAT_PACKAGES_SPECS = [
     ("Fedora release 28", "openssl", RH_BASE_NEW + DNF_EXTRA),
     ("Fedora release 29", "openssl", RH_BASE_NEW + DNF_EXTRA),
     ("Fedora release 30", "openssl", RH_BASE_NEW + DNF_EXTRA),
+    ("Fedora release 31", "openssl", RH_BASE_NEW + DNF_EXTRA),
+    ("Fedora release 32", "openssl", RH_BASE_NEW + DNF_EXTRA),
     ("CentOS Linux release 7", "nss", RH_BASE + YUM_EXTRA),
     ("Red Hat Enterprise Linux Server release 7", "nss", RH_BASE + YUM_EXTRA),
     ("Red Hat Enterprise Linux Workstation release 7", "nss",
@@ -92,7 +94,7 @@ OS_PACKAGES_SPECS = [
     ("Ubuntu", "16.04", "openssl", DEB_PKGS),  # as it appears in travis
     ("Ubuntu", "16.04.4 LTS (Xenial Xerus)", "openssl", DEB_PKGS),
     ("Ubuntu", "17.10 (Artful Aardvark)", "openssl", DEB_PKGS),
-    ("Ubuntu", "18.04", "gnutls", DEB_PKGS),  # as it appears in travis
+    ("Ubuntu", "18.04", "openssl", DEB_PKGS),  # as it appears in travis
     ("Ubuntu", "18.04.1 LTS (Bionic Beaver)", "openssl", DEB_PKGS),
     ("Debian GNU/Linux", "9 (stretch)", "openssl", DEB_PKGS),
 ]


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run

- quickstart setup check for os version adding fedora 31 and 32 openssl.
- I was trying gh-action and found that ubuntu 18.04 need openssl. I was just separating two PRs as it will proposal.

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
