### PR TITLE
[1LP][RFR] Partial automation of test_power_operations_from_global_region

### DIFF
--- a/cfme/cloud/instance/azure.py
+++ b/cfme/cloud/instance/azure.py
@@ -11,6 +11,7 @@ class AzureInstance(Instance):
     START = "Start"
     POWER_ON = START  # For compatibility with the infra objects.
     STOP = "Stop"
+    POWER_OFF = STOP  # For compatibility with the infra objects.
     SUSPEND = "Suspend"
     DELETE = "Delete"
     TERMINATE = 'Delete'

--- a/cfme/cloud/instance/ec2.py
+++ b/cfme/cloud/instance/ec2.py
@@ -11,6 +11,7 @@ class EC2Instance(Instance):
     START = "Start"
     POWER_ON = START  # For compatibility with the infra objects.
     STOP = "Stop"
+    POWER_OFF = STOP  # For compatibility with the infra objects.
     DELETE = "Delete"
     TERMINATE = 'Delete'
     # CFME-only power control options

--- a/cfme/cloud/instance/gce.py
+++ b/cfme/cloud/instance/gce.py
@@ -11,6 +11,7 @@ class GCEInstance(Instance):
     START = "Start"
     POWER_ON = START  # For compatibility with the infra objects.
     STOP = "Stop"
+    POWER_OFF = STOP  # For compatibility with the infra objects.
     DELETE = "Delete"
     TERMINATE = 'Delete'
     # CFME-only power control options

--- a/cfme/cloud/instance/openstack.py
+++ b/cfme/cloud/instance/openstack.py
@@ -35,6 +35,7 @@ class OpenStackInstance(Instance):
     HARD_REBOOT = "Hard Reboot"
     # Provider-only power control options
     STOP = "Stop"
+    POWER_OFF = STOP  # For compatibility with the infra objects.
     PAUSE = "Pause"
     RESTART = "Restart"
     SHELVE = "Shelve"

--- a/cfme/tests/cloud_infra_common/test_power_control_manual.py
+++ b/cfme/tests/cloud_infra_common/test_power_control_manual.py
@@ -6,8 +6,6 @@ from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.utils.appliance import ViaREST
-from cfme.utils.appliance import ViaUI
-
 
 pytestmark = [test_requirements.power, pytest.mark.manual]
 
@@ -222,7 +220,7 @@ def test_power_controls_on_vm_in_stack_cloud():
 
 @pytest.mark.manual
 @pytest.mark.tier(2)
-@pytest.mark.parametrize('context', [ViaREST, ViaUI])
+@pytest.mark.parametrize('context', [ViaREST])
 @pytest.mark.provider([CloudProvider, InfraProvider], required_fields=['templates'],
                       selector=ONE_PER_TYPE)
 @test_requirements.multi_region


### PR DESCRIPTION
Automate the non-REST variants of `test_power_operations_from_global_region`, by adding all possible providers to existing test 
`test_replication_vm_power_control`, which previously only run against a virtualcenter provider. I've removed the use of the `register_events` fixture, because of various problems, including:

- event listener runs against the default appliance, not against the temp remote region appliance. It still works, since the provider and vm are set up on the default appliance too, but the event listener spams `cfme.log` every second, during the entire time it takes to configure the remote and global appliances.
- The OpenStack providers currently have a huge number of historical events that take over an hour to import into CFME when the provider is created.

{{ pytest: -vv --long-running -k test_replication_vm_power_control cfme/tests/distributed/test_appliance_replication.py }}
