### PR TITLE
[1LP][RFR] Remove version logic for Overview navigation name

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -13,8 +13,6 @@ from cfme.utils import ParamClassName
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
 from cfme.utils.pretty import Pretty
-from cfme.utils.version import Version
-from cfme.utils.version import VersionPicker
 
 
 @attr.s
@@ -33,7 +31,6 @@ class Server(BaseEntity, sentaku.modeling.ElementMixin):
     current_username = sentaku.ContextualMethod()
     current_group_name = sentaku.ContextualMethod()
     group_names = sentaku.ContextualMethod()
-    intel_name = VersionPicker({"5.11": "Overview", Version.lowest(): "Cloud Intel"})
 
     # zone = sentaku.ContextualProperty()
     # slave_servers = sentaku.ContextualProperty()

--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -422,7 +422,7 @@ class RSS(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select(self.obj.intel_name, 'RSS')
+        self.view.navigation.select('Overview', 'RSS')
 
 
 @navigator.register(Server)
@@ -431,7 +431,7 @@ class CloudIntelTimelines(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select(self.obj.intel_name, 'Timelines')
+        self.view.navigation.select('Overview', 'Timelines')
 
 
 @navigator.register(Server)
@@ -458,7 +458,7 @@ class Dashboard(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select(self.obj.intel_name, "Dashboard")
+        self.prerequisite_view.navigation.select('Overview', 'Dashboard')
 
 
 @navigator.register(Server)
@@ -467,7 +467,7 @@ class Chargeback(CFMENavigateStep):
     prerequisite = NavigateToSibling('LoggedIn')
 
     def step(self, *args, **kwargs):
-        self.prerequisite_view.navigation.select(self.obj.intel_name, "Chargeback")
+        self.prerequisite_view.navigation.select('Overview', 'Chargeback')
 
 
 class ServerView(ConfigurationView):

--- a/cfme/dashboard.py
+++ b/cfme/dashboard.py
@@ -221,8 +221,7 @@ class DashboardView(BaseLoggedInPage):
     def is_displayed(self):
         return (
             self.logged_in_as_current_user
-            and self.navigation.currently_selected
-            == [self.context["object"].appliance.server.intel_name, "Dashboard"]
+            and self.navigation.currently_selected == ['Overview', 'Dashboard']
         )
 
 
@@ -456,7 +455,7 @@ class DashboardCollection(BaseCollection):
     def refresh(self):
         """Refreshes the dashboard view by forcibly clicking the navigation again."""
         view = navigate_to(self.appliance.server, 'Dashboard')
-        view.navigation.select(self.appliance.server.intel_name, 'Dashboard')
+        view.navigation.select('Overview', 'Dashboard')
 
     @property
     def zoomed_name(self):

--- a/cfme/intelligence/chargeback/__init__.py
+++ b/cfme/intelligence/chargeback/__init__.py
@@ -11,8 +11,7 @@ class ChargebackView(BaseLoggedInPage):
     def in_chargeback(self):
         return (
             self.logged_in_as_current_user
-            and self.navigation.currently_selected
-            == [self.context["object"].appliance.server.intel_name, "Chargeback"]
+            and self.navigation.currently_selected == ['Overview', 'Chargeback']
         )
 
     @property

--- a/cfme/intelligence/reports/__init__.py
+++ b/cfme/intelligence/reports/__init__.py
@@ -21,8 +21,7 @@ class CloudIntelReportsView(BaseLoggedInPage):
     def in_intel_reports(self):
         return (
             self.logged_in_as_current_user
-            and self.navigation.currently_selected
-            == [self.context["object"].appliance.server.intel_name, "Reports"]
+            and self.navigation.currently_selected == ['Overview', 'Reports']
         )
 
     @property
@@ -83,7 +82,7 @@ class CloudIntelReports(CFMENavigateStep):
     prerequisite = NavigateToSibling("LoggedIn")
 
     def step(self, *args, **kwargs):
-        self.view.navigation.select(self.obj.intel_name, "Reports")
+        self.view.navigation.select('Overview', 'Reports')
 
     def resetter(self, *args, **kwargs):
         self.view.saved_reports.open()

--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -216,10 +216,8 @@ class ReportTimelineView(CloudIntelTimelinesView):
         # which is why tree.currently_selected is checked against tree_path[1:]
         return (
             self.logged_in_as_current_user
-            and self.navigation.currently_selected
-            == [self.context["object"].appliance.server.intel_name, "Timelines"]
-            and self.timelines.tree.currently_selected
-            == self.context["object"].tree_path[1:]
+            and self.navigation.currently_selected == ['Overview', 'Timelines']
+            and self.timelines.tree.currently_selected == self.context["object"].tree_path[1:]
         )
 
 

--- a/cfme/intelligence/rss.py
+++ b/cfme/intelligence/rss.py
@@ -10,6 +10,5 @@ class RSSView(BaseLoggedInPage):
     def is_displayed(self):
         return (
             self.logged_in_as_current_user
-            and self.navigation.currently_selected
-            == [self.context["object"].appliance.server.intel_name, "RSS"]
+            and self.navigation.currently_selected == ['Overview', 'RSS']
         )

--- a/cfme/intelligence/timelines.py
+++ b/cfme/intelligence/timelines.py
@@ -14,8 +14,7 @@ class CloudIntelTimelinesView(BaseLoggedInPage):
     def is_displayed(self):
         return (
             self.logged_in_as_current_user
-            and self.navigation.currently_selected
-            == [self.context["object"].appliance.server.intel_name, "Timelines"]
+            and self.navigation.currently_selected == ['Overview', 'Timelines']
         )
 
     @View.nested

--- a/cfme/tests/intelligence/reports/test_crud.py
+++ b/cfme/tests/intelligence/reports/test_crud.py
@@ -148,7 +148,6 @@ def test_menuwidget_crud(appliance, request):
         caseimportance: critical
         initialEstimate: 1/12h
     """
-    dashboard = f"{appliance.server.intel_name} / Dashboard"
     w = appliance.collections.dashboard_report_widgets.create(
         appliance.collections.dashboard_report_widgets.MENU,
         fauxfactory.gen_alphanumeric(),
@@ -156,7 +155,7 @@ def test_menuwidget_crud(appliance, request):
         active=True,
         shortcuts={
             "Services / Catalogs": fauxfactory.gen_alphanumeric(),
-            dashboard: fauxfactory.gen_alphanumeric(),
+            "Overview / Dashboard": fauxfactory.gen_alphanumeric(),
         },
         visibility="<To All Users>"
     )


### PR DESCRIPTION
The 'Cloud Intel' navigation option was changed to 'Overview' in 5.11. Now that only 5.11 tests are being run, the version-specific logic for this name change has been removed.