### PR TITLE
[1LP][RFR] Remove the workaround for BZ 1797706

### DIFF
--- a/cfme/tests/infrastructure/test_provisioning_dialog.py
+++ b/cfme/tests/infrastructure/test_provisioning_dialog.py
@@ -147,8 +147,6 @@ def check_all_tabs(provision_request, provider):
     for name in provider.provisioning_dialog_widget_names:
         widget = getattr(view, name)
         widget.click()
-        if BZ(1797706).blocks and provider.one_of(RHEVMProvider):
-            pytest.skip('Skipping as this fails due to BZ 1797706')
         assert widget.is_displayed
 
 

--- a/cfme/tests/infrastructure/test_vm_clone.py
+++ b/cfme/tests/infrastructure/test_vm_clone.py
@@ -87,8 +87,7 @@ def test_template_clone(request, appliance, provider, clone_vm_name):
     vm.clone_template("email@xyz.com", "first", "last", clone_vm_name, provision_type)
     request_row = appliance.collections.requests.instantiate(clone_vm_name, partial_check=True)
 
-    if not BZ(1797706).blocks and provider.one_of(RHEVMProvider):
-        check_all_tabs(request_row, provider)
+    check_all_tabs(request_row, provider)
     request_row.wait_for_request(method='ui')
     msg = f"Request failed with the message {request_row.row.last_message.text}"
     assert request_row.is_succeeded(method='ui'), msg


### PR DESCRIPTION
## Purpose or Intent
- __Removing BZ workaround__ as BZ is fixed.
{{ py.test: -v --use-provider complete cfme/tests/infrastructure/test_vm_clone.py::test_template_clone  cfme/tests/infrastructure/test_provisioning_dialog.py::test_power_on_or_off_after_provision  cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py::test_provision_cloud_init --use-provider complete --ignore cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py::test_provision_cloud_init[ec2] }}

## PRT results:
The ec2 test failed because of other known issue: RHCFQE-14596