### PR TITLE
[1LP][RFR] Fix to managed_known_providers name checking

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -68,6 +68,8 @@ RECOGNIZED_BY_CREDS = ["CloudManager", "Nuage::NetworkManager"]
 # A helper for the IDs
 SEQ_FACT = 1e12
 
+EMBEDDED_PROVIDERS = ('Embedded Ansible', )
+
 
 def _current_miqqe_version():
     """Parses MiqQE JS patch version from the patch file
@@ -602,12 +604,13 @@ class IPAppliance:
         found_cruds = set()
         unrecognized_ems_names = set()
         for ems_name in self.managed_provider_names:
+            if ems_name in EMBEDDED_PROVIDERS:
+                # ignore embedded pre-configured providers
+                continue
             for prov in prov_cruds:
                 # Name check is authoritative and the only proper way to recognize a known provider
-                if ems_name == prov.name:
-                    found_cruds.add(prov)
-                    break
-                elif prov.name in ems_name:  # config managers append e.g. 'Automation Manager'
+                # Match either by exact name or by child provider name, e.g., 'XXX Network Manager'
+                if ems_name == prov.name or re.match(f'^{prov.name} [A-Za-z]+ Manager$', ems_name):
                     found_cruds.add(prov)
                     break
             else:

--- a/cfme/utils/tests/test_providers.py
+++ b/cfme/utils/tests/test_providers.py
@@ -1,0 +1,19 @@
+import pytest
+
+from cfme.cloud.provider.azure import AzureProvider
+from cfme.common.provider import BaseProvider
+from cfme.markers.env_markers.provider import ONE_PER_VERSION
+
+
+@pytest.mark.provider([AzureProvider], selector=ONE_PER_VERSION)
+def test_provider_fixtures(provider, setup_provider):
+    """Verify that clearing providers works correctly.
+
+    Polarion:
+        assignee: tpapaioa
+        casecomponent: Appliance
+        initialEstimate: 1/15h
+    """
+    assert provider.exists, f"Provider {provider.name} not found on appliance."
+    BaseProvider.clear_providers()
+    assert not provider.exists, f"Provider {provider.name} not deleted from appliance."


### PR DESCRIPTION
In `IPAppliance.managed_known_providers()`, the name comparison between known managed providers (taken from yaml data) and the providers present on the appliance consists of two checks:

- Exact name match
or
- Provider name from yaml is contained within the provider name from the appliance db.

```
                # Name check is authoritative and the only proper way to recognize a known provider
                if ems_name == prov.name:
                    found_cruds.add(prov)
                    break
                elif prov.name in ems_name:  # config managers append e.g. 'Automation Manager'
                    found_cruds.add(prov)
                    break
```

This second comparison is intended to match on child providers, e.g., the network manager that exists for certain provider types. So, if the name of the yaml provider is 'azure_msdn', then it should be considered a match if the iteration over provider names from the db returns 'azure_msdn Network Manager' before getting to the base provider 'azure_msdn'.

The above string comparison sometimes leads to incorrect results, however, when one yaml provider name happens to be a substring of another. For example, with two providers, 'azure' and 'azure_msdn', then 'azure' incorrectly matches to 'azure_msdn Network Manager'. The `has_no_providers` fixture uses the return value of `known_managed_providers` to delete the given providers, and it errors out when trying to delete the non-existent provider named 'azure' from the db:

```
2020-06-03 20:56:38,753 [I] [cfme] Deleting provider: azure (cfme/common/provider.py:940)
[...]
cfme/fixtures/provider.py:264: in has_no_providers_modscope
    BaseProvider.clear_providers()
cfme/common/provider.py:941: in clear_providers
    prov.delete_rest()
cfme/common/provider.py:635: in delete_rest
    provider_rest = self.appliance.rest_api.collections.providers.get(name=self.name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    def get(self, **params):
        try:
            return self.find_by(**params)[0]
        except IndexError:
>           raise ValueError("No such '{}' matching query {!r}!".format(self.name, params))
E           ValueError: No such 'providers' matching query {'name': 'azure'}!

.cfme_venv/lib64/python3.7/site-packages/manageiq_client/api.py:373: ValueError (cfme/fixtures/log.py:84)
```

This PR makes the name check a bit more exact, so that the yaml name needs to match the pattern `'yaml_name xxxxx Provider'`, where `xxxxx` are one or more alphabetic characters. I've also added an explicit exclusion of the 'Embedded Ansible' provider, which is automatically created by CFME and not by the user. This will stop the repeated warnings in `cfme.log`:

```
2020-06-04 09:51:10,199 [W] [cfme] (XXX.XXX.XXX.XXX) Unrecognized managed providers: Embedded Ansible (cfme/utils/appliance/__init__.py:617)
```

{{ pytest: -vv cfme/utils/tests/test_providers.py --use-provider azure }}