### PR TITLE
[1LP][RFR] Fix test: test_download_pdf

### DIFF
--- a/cfme/tests/intelligence/test_download_report.py
+++ b/cfme/tests/intelligence/test_download_report.py
@@ -3,6 +3,7 @@ import pytest
 from cfme import test_requirements
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE
+from cfme.utils.appliance.implementations.ui import navigate_to
 
 pytestmark = [test_requirements.report]
 
@@ -30,6 +31,8 @@ def test_download_report(setup_provider_modscope, report, filetype):
         initialEstimate: 1/20h
     """
     if filetype == "pdf":
-        # TODO: fix pdf download or create a manual test
-        pytest.skip("pdf printing opens a window and all the next tests fail")
-    report.download(filetype)
+        view = navigate_to(report, "Details")
+        # since multiple window handling is not possible, we just assert that the option is enabled.
+        assert view.download.item_enabled("Print or export as PDF")
+    else:
+        report.download(filetype)

--- a/cfme/tests/networks/test_sdn_downloads.py
+++ b/cfme/tests/networks/test_sdn_downloads.py
@@ -31,18 +31,17 @@ OBJECTCOLLECTIONS = [
 
 def download(objecttype, extension):
     view = navigate_to(objecttype, 'All')
-    if view.browser.product_version >= '5.10' and extension == 'pdf':
+    if extension == 'pdf':
         view.toolbar.download.item_select("Print or export as PDF")
         handle_extra_tabs(view)
     else:
-        view.toolbar.download.item_select("Download as {}".format(extensions_mapping[extension]))
+        view.toolbar.download.item_select(f"Download as {extensions_mapping[extension]}")
 
 
 def download_summary(spec_object):
     view = navigate_to(spec_object, 'Details')
     view.toolbar.download.click()
-    if view.browser.product_version >= '5.10':
-        handle_extra_tabs(view)
+    handle_extra_tabs(view)
 
 
 def handle_extra_tabs(view):


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ 
    1. `test_download_report` by fixing it for PDF.
- ___Enhancment__
    1. Remove references older than 5.10 from `test_sdn_downloads.py` and `SavedReports.download()`.
    2. Replace `SavedReportsDetailsView.download` from nested view to a dropdown widget.
    3. Modify `SavedReports.download()` to print a logger message for PDF.

### PRT Run
{{ pytest: cfme/tests/intelligence/test_download_report.py cfme/tests/networks/test_sdn_downloads.py -svvv}}