### PR TITLE
[1LP][RFR] Remove references to has_no_cloud_providers and has_no_infra_providers

### DIFF
--- a/cfme/tests/cloud/test_providers.py
+++ b/cfme/tests/cloud/test_providers.py
@@ -263,9 +263,10 @@ def test_add_cancelled_validation_cloud(request, appliance):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.usefixtures('has_no_cloud_providers')
 @test_requirements.discovery
-def test_cloud_provider_add_with_bad_credentials(request, provider, enable_regions, appliance):
+def test_cloud_provider_add_with_bad_credentials(
+    request, provider, has_no_providers, enable_regions, appliance
+):
     """ Tests provider add with bad credentials
 
     Metadata:
@@ -313,9 +314,8 @@ def test_cloud_provider_add_with_bad_credentials(request, provider, enable_regio
 
 @pytest.mark.tier(1)
 @pytest.mark.smoke
-@pytest.mark.usefixtures('has_no_cloud_providers')
 @test_requirements.discovery
-def test_cloud_provider_crud(provider, enable_regions):
+def test_cloud_provider_crud(provider, has_no_providers, enable_regions):
     """ Tests provider add with good credentials
 
     Metadata:
@@ -694,8 +694,9 @@ def test_openstack_provider_has_dashboard(appliance, openstack_provider):
 @test_requirements.ec2
 @pytest.mark.tier(3)
 @pytest.mark.provider([EC2Provider], scope="function")
-def test_select_key_pair_none_while_provisioning(appliance, request, has_no_cloud_providers,
-                                                 provider):
+def test_select_key_pair_none_while_provisioning(
+    appliance, request, has_no_providers, provider
+):
     """
         GH Issue: https://github.com/ManageIQ/manageiq/issues/10575
 
@@ -733,8 +734,9 @@ def test_select_key_pair_none_while_provisioning(appliance, request, has_no_clou
 @pytest.mark.tier(3)
 @test_requirements.azure
 @pytest.mark.provider([AzureProvider])
-def test_azure_instance_password_requirements(appliance, request,
-        has_no_cloud_providers, setup_provider):
+def test_azure_instance_password_requirements(
+    appliance, has_no_providers, setup_provider
+):
     """
         Requirement: Have an Azure provider
         1. Compute -> Cloud -> Instances
@@ -1200,9 +1202,10 @@ def test_create_azure_vm_from_azure_image(connect_az_account, cfme_vhd, upload_i
 
 
 @test_requirements.ec2
-@pytest.mark.usefixtures('has_no_cloud_providers')
 @pytest.mark.provider([EC2Provider], scope="function", selector=ONE)
-def test_refresh_with_stack_without_parameters(provider, request, stack_without_parameters):
+def test_refresh_with_stack_without_parameters(
+    provider, has_no_providers, request, stack_without_parameters
+):
     """
     Polarion:
         assignee: mmojzis
@@ -1275,7 +1278,7 @@ def test_public_images_enable_disable(setup_provider, request, appliance, provid
 
 @test_requirements.ec2
 @pytest.mark.provider([EC2Provider], scope="function", selector=ONE)
-def test_create_sns_topic(has_no_cloud_providers, provider, request):
+def test_create_sns_topic(has_no_providers, provider, request):
     """
     Requires: No SNS topic(AWS_Config) for tested region
 

--- a/cfme/tests/infrastructure/test_provider_discovery.py
+++ b/cfme/tests/infrastructure/test_provider_discovery.py
@@ -92,8 +92,14 @@ def delete_providers_after_test():
 
 
 @pytest.mark.tier(2)
-@pytest.mark.usefixtures('has_no_infra_providers', 'delete_providers_after_test')
-def test_discover_infra(appliance, providers_for_discover, start_ip, max_range):
+def test_discover_infra(
+    appliance,
+    has_no_providers,
+    providers_for_discover,
+    start_ip,
+    max_range,
+    delete_providers_after_test,
+):
     """
     Polarion:
         assignee: pvala

--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -216,9 +216,8 @@ def test_api_port_max_character_validation_infra(appliance):
         assert text == prov.default_endpoint.api_port[0:15]
 
 
-@pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(1)
-def test_providers_discovery(request, appliance, provider):
+def test_providers_discovery(request, appliance, has_no_providers, provider):
     """Tests provider discovery
 
     Metadata:
@@ -243,8 +242,7 @@ def test_providers_discovery(request, appliance, provider):
     appliance.collections.infra_providers.wait_for_a_provider()
 
 
-@pytest.mark.usefixtures('has_no_infra_providers')
-def test_infra_provider_add_with_bad_credentials(provider):
+def test_infra_provider_add_with_bad_credentials(has_no_providers, provider):
     """Tests provider add with bad credentials
 
     Metadata:
@@ -266,10 +264,9 @@ def test_infra_provider_add_with_bad_credentials(provider):
         provider.create(validate_credentials=True)
 
 
-@pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(1)
 @pytest.mark.smoke
-def test_infra_provider_crud(provider):
+def test_infra_provider_crud(provider, has_no_providers):
     """Tests provider add with good credentials
 
     Metadata:
@@ -296,11 +293,10 @@ def test_infra_provider_crud(provider):
     provider.wait_for_delete()
 
 
-@pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(1)
 @pytest.mark.parametrize('verify_tls', [False, True], ids=['no_tls', 'tls'])
 @pytest.mark.provider([RHEVMProvider])
-def test_provider_rhv_create_delete_tls(request, provider, verify_tls):
+def test_provider_rhv_create_delete_tls(request, has_no_providers, provider, verify_tls):
     """Tests RHV provider creation with and without TLS encryption
 
     Metadata:

--- a/cfme/tests/services/test_service_catalogs.py
+++ b/cfme/tests/services/test_service_catalogs.py
@@ -134,9 +134,10 @@ def test_order_catalog_bundle(appliance, provider, catalog_item, request):
 
 @pytest.mark.skip('Catalog items are converted to collections. Refactoring is required')
 # Note here this needs to be reduced, doesn't need to test against all providers
-@pytest.mark.usefixtures('has_no_infra_providers')
 @pytest.mark.tier(3)
-def test_no_template_catalog_item(provider, provisioning, dialog, catalog, appliance):
+def test_no_template_catalog_item(
+    has_no_providers, provider, provisioning, dialog, catalog, appliance
+):
     """Tests no template catalog item
     Metadata:
         test_flag: provision


### PR DESCRIPTION
## Purpose or Intent

- __Updating tests__
    1. Removing reference to fixtures such as `has_no_cloud_providers` and `has_no_infra_providers` and replacing them with `has_no_providers`.

### PRT Run
{{ pytest: cfme/tests -k "test_add_cancelled_validation_cloud or test_cloud_provider_add_with_bad_credentials or test_openstack_provider_has_dashboard or test_select_key_pair_none_while_provisioning or test_create_azure_vm_from_azure_image or test_public_images_enable_disable or test_api_port_max_character_validation_infra or test_providers_discovery or test_infra_provider_add_with_bad_credentials or test_infra_provider_crud or test_no_template_catalog_item" --long-running -svvv }}