### PR TITLE
[RFR] Add manual tests for v2v for bugs fixed in 5.11.5

### DIFF
--- a/cfme/tests/v2v/test_v2v_manual.py
+++ b/cfme/tests/v2v/test_v2v_manual.py
@@ -321,3 +321,48 @@ def test_cancel_migration_state_file_missing():
             6. The pod can't be created as conversion-1 name already exist
     """
     pass
+
+
+@pytest.mark.meta(coverage=[1812685])
+@pytest.mark.tier(2)
+def test_migration_with_alternative_ip_address_for_vmware_host():
+    """
+    title: Test migration with alternative ip address for vmware host
+    plans
+    Bugzilla:
+        1812685
+    Polarion:
+        assignee: nachandr
+        casecomponent: V2V
+        initialEstimate: 1/4h
+        startsin: 5.11
+        testSteps:
+            1. Update transformation ip address for vmware host through Rails console
+            2. Start migration
+        expectedResults:
+            1. Alternative ip address should be used for migration
+            2. Migration should succeed
+    """
+    pass
+
+
+@pytest.mark.meta(coverage=[1814876])
+@pytest.mark.tier(3)
+def test_migration_for_vm_without_ip_address():
+    """
+    title: Test migration for VM without IP address
+    plans
+    Bugzilla:
+        1814876
+    Polarion:
+        assignee: nachandr
+        casecomponent: V2V
+        initialEstimate: 1/4h
+        startsin: 5.11
+        testSteps:
+            1. Disconnect VM NIC in vCenter so that the VM doesn't have an IP address
+            2. Start migration
+        expectedResults:
+            1. Migration should succeed
+    """
+    pass


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
