### PR TITLE
[RFR] Fix log collection tests.

### DIFF
--- a/cfme/fixtures/depot.py
+++ b/cfme/fixtures/depot.py
@@ -7,9 +7,12 @@ from cfme.utils.conf import cfme_data
 from cfme.utils.log import logger
 from cfme.utils.net import find_pingable
 from cfme.utils.net import find_pingable_ipv6
+from cfme.utils.net import pick_responding_ip
 from cfme.utils.virtual_machines import deploy_template
 from cfme.utils.wait import TimedOutError
 from cfme.utils.wait import wait_for
+
+FTP_PORT = 21
 
 
 @pytest.fixture(scope="module")
@@ -34,13 +37,9 @@ def depot_machine_ip(request, appliance):
         pytest.skip(msg)
 
     try:
-        found_ip, _ = wait_for(
-            find_pingable,
-            func_args=[vm],
-            fail_condition=None,
-            delay=5,
-            num_sec=300
-        )
+        # TODO It would be better to use retry_connect here, but this requires changes to other
+        #  fixtures.
+        found_ip = pick_responding_ip(lambda: vm.all_ips, FTP_PORT, 300, 5, 10)
     except TimedOutError:
         msg = 'Timed out waiting for reachable depot VM IP'
         logger.exception(msg)

--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1756,6 +1756,10 @@ class IPAppliance:
 
     @property
     def is_ssh_running(self):
+        # WORKAROUND INC1296328
+        # https://redhat.service-now.com/help?id=rh_ticket&table=incident&sys_id=65b98d19db701050c0c8464e139619eb
+        is_pingable(self.hostname)
+
         if self.openshift_creds and 'hostname' in self.openshift_creds:
             hostname = self.openshift_creds['hostname']
         else:

--- a/cfme/utils/net.py
+++ b/cfme/utils/net.py
@@ -3,6 +3,8 @@ import re
 import socket
 from collections import defaultdict
 
+from wrapanapi.entities.vm import Vm
+
 from cfme.fixtures.pytest_store import store
 from cfme.utils.log import logger
 from cfme.utils.wait import wait_for
@@ -104,10 +106,8 @@ def retry_connect_vm(vm, connection_factory, num_sec, delay):
 
 
 def net_check(port, addr=None, force=False, timeout=10):
-    """Checks the availablility of a port"""
+    """Checks the availability of a port"""
     port = int(port)
-    if not addr:
-        addr = store.current_appliance.hostname
     if port not in _ports[addr] or force:
         # First try DNS resolution
         try:
@@ -194,14 +194,14 @@ def is_pingable(ip_addr):
         if status == 0:
             logger.info('IP: %s is RESPONDING !', ip_addr)
             return True
-        logger.info('ping exit status: %d, IP: %s is UNREACHABLE !', status, ip_addr)
+        logger.info(f'ping of {ip_addr:s} exit status: {status:d}')
         return False
     except Exception as e:
         logger.exception(e)
         return False
 
 
-def find_pingable(mgmt_vm, allow_ipv6=True):
+def find_pingable(mgmt_vm: Vm, allow_ipv6=True):
     """Looks for a pingable address from mgmt_vm.all_ips
 
      Assuming mgmt_vm is a wrapanapi VM entity, with all_ips and ip methods
@@ -209,7 +209,7 @@ def find_pingable(mgmt_vm, allow_ipv6=True):
      Returns:
          In priority: first pingable address, address 'selected' by wrapanapi (possibly None)
      """
-    for ip in getattr(mgmt_vm, 'all_ips', []):
+    for ip in mgmt_vm.all_ips:
         if ip:
             if not allow_ipv6 and is_ipv6(ip):
                 logger.debug('VMs ip is ipv6, skipping it: %s', ip)
@@ -226,7 +226,7 @@ def find_pingable(mgmt_vm, allow_ipv6=True):
         return getattr(mgmt_vm, 'ip', None)
 
 
-def find_pingable_ipv6(mgmt_vm):
+def find_pingable_ipv6(mgmt_vm: Vm):
     """Looks for a pingable ipv6 address from mgmt_vm.all_ips
 
      Assuming mgmt_vm is a wrapanapi VM entity, with all_ips and ip methods

--- a/cfme/utils/net.py
+++ b/cfme/utils/net.py
@@ -60,15 +60,15 @@ def ip_echo_socket(port=32123):
             conn.close()
 
 
-def pick_responding_ip(vm, port, num_sec, rounds_delay_second, attempt_timeout):
+def pick_responding_ip(ips_getter, port, num_sec, rounds_delay_second, attempt_timeout):
     """
     Given a vm and port, pick one of the vm's addresses that is connectible
     on the given port
 
     Args:
-        vm: mgmt vm
+        ips_getter: a function returning the IPs for each round of connectivity trial
         port: port number to attempt connecting to
-        num_sec: Minimal ammount of time how long to keep checking (slight
+        num_sec: Minimal amount of time how long to keep checking (slight
                  variation may happen -- approximately the attempt_timeout).
         rounds_delay_second: The delay to wait after checking each IP round in
                              immediate succession.
@@ -81,7 +81,7 @@ def pick_responding_ip(vm, port, num_sec, rounds_delay_second, attempt_timeout):
         if net_check(port, ip, attempt_timeout):
             return ip
 
-    return retry_connect(vm, connection_factory, num_sec, rounds_delay_second)
+    return retry_connect(ips_getter, connection_factory, num_sec, rounds_delay_second)
 
 
 def retry_connect(ips_getter, connection_factory, num_sec, delay):
@@ -99,10 +99,6 @@ def retry_connect(ips_getter, connection_factory, num_sec, delay):
         return False
     connection, _ = wait_for(_try_batch_of_ips, num_sec=num_sec, delay=delay)
     return connection
-
-
-def retry_connect_vm(vm, connection_factory, num_sec, delay):
-    return retry_connect(lambda: vm.all_ips, connection_factory, num_sec, delay)
 
 
 def net_check(port, addr=None, force=False, timeout=10):

--- a/cfme/utils/net.py
+++ b/cfme/utils/net.py
@@ -89,6 +89,10 @@ def retry_connect(ips_getter, connection_factory, num_sec, delay):
         for ip in ips_getter():
             try:
                 connection = connection_factory(ip)
+                if not connection:
+                    logger.warning(f"The connection factory {connection_factory} returned None. "
+                                   "Trying again.")
+                    continue
             except Exception as ex:
                 logger.warning(f"Failed to connect {ip}: {ex}")
                 continue
@@ -219,7 +223,7 @@ def find_pingable(mgmt_vm: Vm, allow_ipv6=True):
 
     else:
         logger.info('No reachable IPs found for VM, just returning wrapanapi IP')
-        return getattr(mgmt_vm, 'ip', None)
+        return mgmt_vm.ip
 
 
 def find_pingable_ipv6(mgmt_vm: Vm):
@@ -230,7 +234,7 @@ def find_pingable_ipv6(mgmt_vm: Vm):
      Returns:
          In priority: first pingable ipv6 address, address 'selected' by wrapanapi (possibly None)
      """
-    for ip in getattr(mgmt_vm, 'all_ips', []):
+    for ip in mgmt_vm.all_ips:
         if not is_ipv6(ip) or not is_pingable(ip):
             logger.debug(f"Could not reach mgmt IP on VM: {ip}")
             continue

--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -12,20 +12,20 @@ import iso8601
 import paramiko
 from cached_property import cached_property
 from scp import SCPClient
+from wrapanapi.entities import Vm
 
 from cfme.fixtures.pytest_store import store
 from cfme.utils import conf
 from cfme.utils import ports
 from cfme.utils.log import logger
 from cfme.utils.net import net_check
-from cfme.utils.net import retry_connect_vm
+from cfme.utils.net import retry_connect
 from cfme.utils.path import project_path
 from cfme.utils.quote import quote
 from cfme.utils.timeutil import parsetime
 from cfme.utils.version import Version
 from cfme.utils.version import VersionPicker
 from cfme.utils.wait import wait_for
-
 # Default blocking time before giving up on an ssh command execution,
 # in seconds (float)
 RUNCMD_TIMEOUT = 1200.0
@@ -867,7 +867,7 @@ def unquirked_ssh_client(**kwargs):
     return client
 
 
-def connect_ssh(vm, creds,
+def connect_ssh(vm: Vm, creds,
                 num_sec=CONNECT_RETRIES_TIMEOUT,
                 connect_timeout=CONNECT_TIMEOUT,
                 delay=CONNECT_SSH_DELAY):
@@ -887,4 +887,4 @@ def connect_ssh(vm, creds,
     msg = "The num_sec is smaller then connect_timeout. This looks like a bug."
     assert num_sec > connect_timeout, msg
 
-    return retry_connect_vm(vm, _connection_factory, num_sec=num_sec, delay=delay)
+    return retry_connect(lambda: vm.all_ips, _connection_factory, num_sec=num_sec, delay=delay)


### PR DESCRIPTION
There is an incident in our lab preventing the tests to pass as they cannot connect ssh. This happens only with certain sprout vm  provider. This was worked-around.

Test appeared to be wrongly trying to match appliance.server.sid as a zone id. I believe this is not correct. I made the tests passing by using the server's zone every time.

{{ py.test: -sv 'cfme/tests/configure/test_log_depot_operation.py::test_collect_multiple_servers' -v --use-provider 'complete'  --long-running cfme/utils/tests/test_connect_ssh.py cfme/tests/configure/test_proxy.py cfme/tests/cli/test_appliance_console_db_restore.py cfme/tests/infrastructure/test_snapshot.py::test_verify_revert_snapshot }}

There is one test failed with `[Errno 104] Connection reset by peer` which is the same failure I have seen before. Not related