### PR TITLE
[1LP][RFR]New test: test_timepicker_on_service_order

### DIFF
--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -187,23 +187,6 @@ def test_triggered_refresh_shouldnt_occurs_for_dialog_after_changing_type_to_sta
 
 @pytest.mark.manual
 @pytest.mark.tier(3)
-def test_timepicker_should_show_date_when_chosen_once():
-    """ Timepicker should show date when chosen once
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.7
-        tags: service
-    Bugzilla:
-        1638079
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
 def test_default_dialog_entries_should_localized_when_ordering_catalog_item_in_french():
     """ Default dialog entries should localized when ordering catalog item in French
     Polarion:
@@ -232,21 +215,6 @@ def test_in_dynamic_dropdown_list_the_default_value_should_not_contain_all_the_v
         tags: service
     Bugzilla:
         1568440
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_timepicker_should_pass_correct_timing_on_service_order():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: service
     """
     pass
 


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__ 
    1. `test_timepicker_on_service_order` - this test automates `test_timepicker_should_show_date_when_chosen_once` and `test_timepicker_should_pass_correct_timing_on_service_order`
- __Enhancement__ 
    1. Add a new `TimePicker` widget to wt.manageiq which is inspired by wt.pf::DatePicker and used for TimePicker dialog element. Currently it can only pick date and not time.

### PRT Run
{{ pytest: cfme/tests/services/test_generic_service_catalogs.py::test_timepicker_on_service_order -svvv }}