### PR TITLE
[1LP][RFR] Add comparison of OS data after revert to test_verify_revert_snapshot

### DIFF
--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -458,13 +458,6 @@ class InfraVmOsView(InfraVmView):
     title = Text('#explorer_title_text')
     basic_information = SummaryTable(title="Basic Information")
 
-    '''
-    This looks suspect.
-    @property
-    def is_displayed(self):
-        return self.basic_information.is_displayed
-    '''
-
     @property
     def is_displayed(self):
         expected_title = '"OS Info" for Virtual Machine "{}"'.format(self.context['object'].name)

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -333,7 +333,6 @@ class InfraVmContainerView(VMDetailsEntities):
     @property
     def is_displayed(self):
         return self.basic_information.is_displayed and self.device.is_displayed
-        # does above work?? There is no is_displayed for SummaryTable?
 
 
 class InfraVmDetailsView(InfraVmView):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -460,7 +460,8 @@ class InfraVmOsView(InfraVmView):
 
     @property
     def is_displayed(self):
-        expected_title = '"OS Info" for Virtual Machine "{}"'.format(self.context['object'].name)
+        name = self.context['object'].name
+        expected_title = f'"OS Info" for Virtual Machine "{name}"'
         return self.in_infra_vms and self.title.text == expected_title
 
 

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -333,6 +333,7 @@ class InfraVmContainerView(VMDetailsEntities):
     @property
     def is_displayed(self):
         return self.basic_information.is_displayed and self.device.is_displayed
+        # does above work?? There is no is_displayed for SummaryTable?
 
 
 class InfraVmDetailsView(InfraVmView):
@@ -451,6 +452,24 @@ class InfraVmReconfigureView(BaseLoggedInPage):
         return (self.title.text == 'Reconfigure Virtual Machine' and
                 len([row for row in self.affected_vms.rows()]) == 1 and
                 self.context['object'].name in [row.name.text for row in self.affected_vms.rows()])
+
+
+class InfraVmOsView(InfraVmView):
+    """The Operating System page"""
+    title = Text('#explorer_title_text')
+    basic_information = SummaryTable(title="Basic Information")
+
+    '''
+    This looks suspect.
+    @property
+    def is_displayed(self):
+        return self.basic_information.is_displayed
+    '''
+
+    @property
+    def is_displayed(self):
+        expected_title = '"OS Info" for Virtual Machine "{}"'.format(self.context['object'].name)
+        return self.in_infra_vms and self.title.text == expected_title
 
 
 class InfraVmSnapshotToolbar(View):

--- a/cfme/infrastructure/virtual_machines.py
+++ b/cfme/infrastructure/virtual_machines.py
@@ -1547,6 +1547,15 @@ class VmAllWithTemplatesForProvider(CFMENavigateStep):
         self.view.reset_page()
 
 
+@navigator.register(InfraVm, 'OS Info')
+class VmOsInfo(CFMENavigateStep):
+    VIEW = InfraVmOsView
+    prerequisite = NavigateToSibling('Details')
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.entities.summary('Properties').click_at('Operating System')
+
+
 @navigator.register(InfraTemplate, 'Details')
 @navigator.register(InfraVm, 'Details')
 class VmAllWithTemplatesDetails(CFMENavigateStep):

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -252,14 +252,13 @@ def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event
     view = navigate_to(create_vm, 'Details')
     os_text_initial = view.entities.summary('Properties').get_text_of('Operating System')
     verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
-    # We could put this in verify_revert_snapshot, but we just had a discussion about putting the
-    # validation in the test case?
     # verify that the system info is displayed
     view = navigate_to(create_vm, 'Details')
-    # we can check here that the OS in in the field.
+    # check that the OS is in the field.
     os_text_compare = view.entities.summary('Properties').get_text_of('Operating System')
     assert os_text_compare == os_text_initial
     os_view = navigate_to(create_vm, 'OS Info')
+    # check that the OS Info view is displayed and contains OS data
     assert os_view.is_displayed
     os_text_compare = view.entities.summary('Basic Information').get_text_of('Operating System')
     assert os_text_compare == os_text_initial

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -248,7 +248,20 @@ def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event
         casecomponent: Infra
         initialEstimate: 1/4h
     """
-    verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
+    # getting the initial value for OS details.
+    view = navigate_to(create_vm, 'Details')
+    os_text_initial = view.entities.summary('Properties').get_text_of('Operating System')
+    # verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
+    # We could put this in the method above, but we just had a discussion about putting the
+    # validation in the test case?
+    # verify that the system info is displayed
+    view = navigate_to(create_vm, 'Details')
+    # we can check here that the OS in in the field.
+    os_text_final = view.entities.summary('Properties').get_text_of('Operating System')
+    assert os_text_final == os_text_initial
+    view.entities.summary('Properties').click_at('Operating System')
+    # now verify "Basic Information" table has row "OperatingSystem. And it contains value.
+    # ? should we be capturing this from the initial state before snapshot?
 
 
 @pytest.mark.parametrize('create_vm', ['full_template'], indirect=True)

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -11,7 +11,6 @@ from cfme.base.credential import SSHCredential
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import InfraVm
-from cfme.infrastructure.virtual_machines import InfraVmOsView
 from cfme.infrastructure.virtual_machines import InfraVmSnapshotAddView
 from cfme.infrastructure.virtual_machines import InfraVmSnapshotView
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -252,7 +251,7 @@ def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event
     # getting the initial value for OS details.
     view = navigate_to(create_vm, 'Details')
     os_text_initial = view.entities.summary('Properties').get_text_of('Operating System')
-    # verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
+    verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
     # We could put this in verify_revert_snapshot, but we just had a discussion about putting the
     # validation in the test case?
     # verify that the system info is displayed
@@ -260,10 +259,7 @@ def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event
     # we can check here that the OS in in the field.
     os_text_compare = view.entities.summary('Properties').get_text_of('Operating System')
     assert os_text_compare == os_text_initial
-    # !!! Create a navigate_to for Operating System view
-
-    view.entities.summary('Properties').click_at('Operating System')
-    os_view = create_vm.create_view(InfraVmOsView)
+    os_view = navigate_to(create_vm, 'OS Info')
     assert os_view.is_displayed
     os_text_compare = view.entities.summary('Basic Information').get_text_of('Operating System')
     assert os_text_compare == os_text_initial

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -11,6 +11,7 @@ from cfme.base.credential import SSHCredential
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.infrastructure.virtual_machines import InfraVm
+from cfme.infrastructure.virtual_machines import InfraVmOsView
 from cfme.infrastructure.virtual_machines import InfraVmSnapshotAddView
 from cfme.infrastructure.virtual_machines import InfraVmSnapshotView
 from cfme.utils.appliance.implementations.ui import navigate_to
@@ -248,21 +249,24 @@ def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event
         casecomponent: Infra
         initialEstimate: 1/4h
     """
-    verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
-    # Now verify OS data is displayed in Details View.
     # getting the initial value for OS details.
     view = navigate_to(create_vm, 'Details')
     os_text_initial = view.entities.summary('Properties').get_text_of('Operating System')
+    # verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
     # We could put this in verify_revert_snapshot, but we just had a discussion about putting the
     # validation in the test case?
     # verify that the system info is displayed
     view = navigate_to(create_vm, 'Details')
     # we can check here that the OS in in the field.
-    os_text_final = view.entities.summary('Properties').get_text_of('Operating System')
-    assert os_text_final == os_text_initial
+    os_text_compare = view.entities.summary('Properties').get_text_of('Operating System')
+    assert os_text_compare == os_text_initial
+    # !!! Create a navigate_to for Operating System view
+
     view.entities.summary('Properties').click_at('Operating System')
-    # now verify "Basic Information" table has row "OperatingSystem. And it contains value.
-    # ? should we be capturing this from the initial state before snapshot?
+    os_view = create_vm.create_view(InfraVmOsView)
+    assert os_view.is_displayed
+    os_text_compare = view.entities.summary('Basic Information').get_text_of('Operating System')
+    assert os_text_compare == os_text_initial
 
 
 @pytest.mark.parametrize('create_vm', ['full_template'], indirect=True)

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -228,9 +228,8 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
         assert ssh_client.run_command('test -e snapshot2.txt') == 1
 
 
-@pytest.mark.meta(
-    blockers=[BZ(1805803, unblock=lambda provider: not provider.one_of(RHEVMProvider),
-                 ignore_bugs={1745065})], automates=[1805803])
+@pytest.mark.rhv1
+@pytest.mark.provider([VMwareProvider])
 @pytest.mark.parametrize('create_vm', ['full_template'], indirect=True)
 def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request):
     """Tests revert snapshot
@@ -241,7 +240,7 @@ def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event
         test_flag: snapshot, provision
 
     Bugzilla:
-        1561618
+        1805803
 
     Polarion:
         assignee: prichard

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -228,8 +228,8 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
         assert ssh_client.run_command('test -e snapshot2.txt') == 1
 
 
-@pytest.mark.rhv1
-@pytest.mark.provider([VMwareProvider])
+@pytest.mark.uncollectif(lambda provider: provider.one_of(RHEVMProvider),
+                        reason="RHV providers blocked for BZ 1805803 marked WONTFIX")
 @pytest.mark.parametrize('create_vm', ['full_template'], indirect=True)
 def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request):
     """Tests revert snapshot

--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -248,11 +248,12 @@ def test_verify_revert_snapshot(create_vm, provider, soft_assert, register_event
         casecomponent: Infra
         initialEstimate: 1/4h
     """
+    verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
+    # Now verify OS data is displayed in Details View.
     # getting the initial value for OS details.
     view = navigate_to(create_vm, 'Details')
     os_text_initial = view.entities.summary('Properties').get_text_of('Operating System')
-    # verify_revert_snapshot(create_vm, provider, soft_assert, register_event, request)
-    # We could put this in the method above, but we just had a discussion about putting the
+    # We could put this in verify_revert_snapshot, but we just had a discussion about putting the
     # validation in the test case?
     # verify that the system info is displayed
     view = navigate_to(create_vm, 'Details')


### PR DESCRIPTION
## Purpose or Intent

- __Updating tests__ to add automated coverage for test_snapshot_image_copies_system_info manual test. 

### PRT Run

{{ pytest: --long-running cfme/tests/infrastructure/test_snapshot.py::test_verify_revert_snapshot }}