### PR TITLE
[1LP][RFR] Fix provider filter on test_vm_create

### DIFF
--- a/cfme/tests/cloud_infra_common/test_events.py
+++ b/cfme/tests/cloud_infra_common/test_events.py
@@ -14,7 +14,7 @@ from cfme.utils.wait import wait_for
 
 
 all_prov = ProviderFilter(classes=[InfraProvider, CloudProvider],
-                          required_fields=['provisioning', 'events'])
+                          required_flags=['provision', 'events'])
 excluded = ProviderFilter(classes=[KubeVirtProvider], inverted=True)
 pytestmark = [
     pytest.mark.usefixtures('uses_infra_providers', 'uses_cloud_providers'),


### PR DESCRIPTION
This test was always uncollected because the provider filter was incorrect. Fixed the filter to point to the correct `required_flags` instead of `required_fields`.

{{ pytest: -vv cfme/tests/cloud_infra_common/test_events.py }}