### PR TITLE
[1LP][RFR] Add test_infrastructure_hosts_tagging

### DIFF
--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -625,7 +625,7 @@ def test_infrastructure_hosts_tagging(appliance, setup_provider):
     Polarion:
         assignee: prichard
         casecomponent: Infra
-        caseimportance: low
+        caseimportance: high
         initialEstimate: 1/6h
     """
     host = appliance.collections.hosts.all()[0]

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -617,3 +617,22 @@ def test_infrastructure_hosts_crud(appliance, setup_provider):
     # Case6 - lastly do the delete. First try is canceled.
     host.delete(cancel=True)
     host.delete
+
+
+@test_requirements.infra_hosts
+def test_infrastructure_hosts_tagging(appliance, setup_provider):
+    """
+    Polarion:
+        assignee: prichard
+        casecomponent: Infra
+        caseimportance: low
+        initialEstimate: 1/6h
+    """
+    host = appliance.collections.hosts.all()[0]
+    tag = host.add_tag()
+    host_tags = host.get_tags()
+    assert any(
+        tag.category.display_name == host_tag.category.display_name and
+        tag.display_name == host_tag.display_name
+        for host_tag in host_tags
+    ), "tag is not assigned"

--- a/cfme/tests/infrastructure/test_host.py
+++ b/cfme/tests/infrastructure/test_host.py
@@ -636,3 +636,4 @@ def test_infrastructure_hosts_tagging(appliance, setup_provider):
         tag.display_name == host_tag.display_name
         for host_tag in host_tags
     ), "tag is not assigned"
+    host.remove_tag(tag)

--- a/cfme/tests/infrastructure/test_host_manual.py
+++ b/cfme/tests/infrastructure/test_host_manual.py
@@ -566,37 +566,6 @@ def test_host_viewing():
 
 
 @test_requirements.infra_hosts
-def test_host_tagging():
-    """
-    Testing tagging hosts.
-
-
-    Polarion:
-        assignee: prichard
-        casecomponent: Infra
-        caseimportance: high
-        initialEstimate: 1/4h
-        testSteps:
-            1. Navigate to the Compute > Infrastructure > Hosts view.
-            2. Click checkbox in quadicon to select a host.
-            3. Click Edit Tags in the Policy dropdown.
-            4. Select a customer tag from the first dropdown and then a value for the tag.
-            5. Click save.
-            6. Click on the same quadicon as in step 2.
-            7. Repeat steps 1 thru 6, but select multiple hosts.
-        expectedResults:
-            1. Hosts view is displayed.
-            2.
-            3. Tag Assignement view is displayed.
-            4.
-            5. "Tag edits successfully saved." message is displayed.
-            6. Tags added in step 4 are displayed in Smart Management section of hosts summary.
-            7. Expected results are the same as steps 1 thru 6 for multiple hosts.
-    """
-    pass
-
-
-@test_requirements.infra_hosts
 def test_host_drift_analysis():
     """
     Testing drift detection for hosts.


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ for host tagging to replace manual test, test_host_tagging.
version1.2.3.

### PRT Run

{{ pytest: cfme/tests/infrastructure/test_host.py::test_infrastructure_hosts_tagging }}