### PR TITLE
[RFR] [NOTEST] Remove obsolete rhv1 marker from test

### DIFF
--- a/cfme/tests/infrastructure/test_snapshot.py
+++ b/cfme/tests/infrastructure/test_snapshot.py
@@ -228,7 +228,6 @@ def verify_revert_snapshot(full_test_vm, provider, soft_assert, register_event, 
         assert ssh_client.run_command('test -e snapshot2.txt') == 1
 
 
-@pytest.mark.rhv1
 @pytest.mark.meta(
     blockers=[BZ(1805803, unblock=lambda provider: not provider.one_of(RHEVMProvider),
                  ignore_bugs={1745065})], automates=[1805803])


### PR DESCRIPTION
A test was added with the rhv1 marker after the rhvX markers were removed. Removing the marker. No testing required.