### PR TITLE
[1LP][RFR] [NOTEST] Only run teardown hooks if artifactor client exists

### DIFF
--- a/cfme/fixtures/artifactor_plugin.py
+++ b/cfme/fixtures/artifactor_plugin.py
@@ -234,6 +234,8 @@ def pytest_runtest_protocol(item):
 
 
 def pytest_runtest_teardown(item, nextitem):
+    if not getattr(item.config, '_art_client'):
+        return
     name, location = get_test_idents(item)
     app = find_appliance(item)
     ip = app.hostname


### PR DESCRIPTION
Fixes issue where browser is started at the end of a test run that doesn't use the browser, if artifactor client is not set up. This probably only happens when running certain tests from the command line, so there's no PRT testing.
