### PR TITLE
[1LP][RFR] - check Key Pair list using aws provider

### DIFF
--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -632,37 +632,3 @@ def test_login_self_service_ui():
             error flash message appear immediately
     """
     pass
-
-
-@pytest.mark.customer_scenario
-@test_requirements.rbac
-@pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1730066])
-def test_aws_keypair_list():
-    """
-    Should able to view AWS keypair list as tenant_administrator
-    Bugzilla:
-        1730066
-    Polarion:
-        assignee: dgaikwad
-        casecomponent: Configuration
-        caseimportance: critical
-        initialEstimate: 1/4h
-        testSteps:
-            1. Copy the EvmRole_tenant_admin role to a new role (Since this role does not have
-             the Auth Key Pairs feature enabled)
-            2. In the role, enable the Auth Key Pairs feature
-            3. Add either new or existing groups to the newly created tenant admin role
-            4. If the added groups belong to the Top-Level Tenant (Parent Tenant),
-            then users in that group will be able to see the WAS Key Pairs
-            5. Otherwise, if the added groups belong to one of the sub-tenant (Children tenant),
-             users in those groups will not be able to see the AWS Key Pairs
-        expectedResults:
-            1.
-            2.
-            3.
-            4.
-            5. Users in groups that belong to either the top-level tenant or any of the
-            children tenants (sub-tenants) should be able to see the key Pairs.
-    """
-    pass


### PR DESCRIPTION
__adding_test__ test to check key pair able to see or not for custom user when tenant as Parent tenant and Child - tenant
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/configure/test_access_control.py -k test_aws_keypair_list --long-running -v}}