### PR TITLE
[1LP][RFR] Fix provider parametrization for 'all' selector

### DIFF
--- a/cfme/utils/tests/test_providers.py
+++ b/cfme/utils/tests/test_providers.py
@@ -2,6 +2,7 @@ import pytest
 
 from cfme.cloud.provider.azure import AzureProvider
 from cfme.common.provider import BaseProvider
+from cfme.markers.env_markers.provider import ALL
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
 
 
@@ -17,3 +18,11 @@ def test_provider_fixtures(provider, setup_provider):
     assert provider.exists, f"Provider {provider.name} not found on appliance."
     BaseProvider.clear_providers()
     assert not provider.exists, f"Provider {provider.name} not deleted from appliance."
+
+
+@pytest.mark.provider([BaseProvider], selector=ALL)
+def test_provider_all_selector(request, provider):
+    """Verify that the 'all' selector works, and that the provider matches the parametrization."""
+    expected_id = f"test_provider_all_selector[{provider.type}-{provider.version}-{provider.key}]"
+    test_id = request.node.name
+    assert test_id == expected_id, f"Provider parametrization failed."


### PR DESCRIPTION
The 'all' selector for the provider marker doesn't work when more than one provider of the same category, type, and version are selected for parametrization on a test. This PR fixes that behavior by including the selected provider's `key` attribute along with the category, type, and version.

`SHRIVER: updated Jun 23 2020 to include more than just the unit test for ALL`
{{ pytest: -vv --use-provider rhv4 --use-provider vsphere65-nested cfme/utils/tests/test_providers.py cfme/tests/infrastructure/test_providers.py }}
