### PR TITLE
[WIPTEST] Fix so that BZ blocks if target release is 'future'

### DIFF
--- a/cfme/utils/bz.py
+++ b/cfme/utils/bz.py
@@ -181,10 +181,12 @@ class Bugzilla:
         for variant in sorted(variants, key=lambda variant: variant.id):
             if variant.id in ignore_bugs:
                 continue
-            if variant.version is not None and variant.version > version:
+            if variant.version and variant.version > version:
                 continue
-
-            if variant.release_flag is not None and version.is_in_series(variant.release_flag):
+            if variant.release_flag and (
+                variant.release_flag == 'future' or
+                version.is_in_series(variant.release_flag)
+            ):
                 logger.info('Found matching bug for %d by release - #%d', bug.id, variant.id)
                 filtered.clear()
                 filtered.add(variant)


### PR DESCRIPTION
When a BZ is first created, the 'Target Release' field defaults to 'cfme-future', which the Bugzilla API returns as 'future'. Currently a BZ with a version that matches the appliance version does not block when the target release has this default value, and you have to use the `forced_streams` keyword to force it to block. This PR updates the BZ blocker logic so that a release flag of 'future' is considered a match.
