### PR TITLE
[1LP][RFR] Adding new test dynamic dialog load

### DIFF
--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -127,66 +127,6 @@ def test_request_filter_on_request_page():
 
 @pytest.mark.manual
 @pytest.mark.tier(3)
-def test_edit_catalog_item_after_remove_resource_pool():
-    """ Create catalog item with a resource pool , Remove resource pool from
-        the provider and then edit catalog item.
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/8h
-        startsin: 5.5
-        tags: service
-        testSteps:
-            1. Create a catalog item
-            2. Select cluster and resource pool and Save
-            3. Remove resource pool from provider
-            4. Edit catalog
-        expectedResults:
-            1.
-            2.
-            3.
-            4. Validation message should be shown
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_dialog_dropdown_ui_values_in_the_dropdown_should_be_visible_in_edit_mode():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/16h
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1557508
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_triggered_refresh_shouldnt_occurs_for_dialog_after_changing_type_to_static():
-    """ Triggered Refresh shouldn't Occurs for Dialog After Changing Type to Static
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: service
-    Bugzilla:
-        1614436
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
 def test_default_dialog_entries_should_localized_when_ordering_catalog_item_in_french():
     """ Default dialog entries should localized when ordering catalog item in French
     Polarion:
@@ -198,56 +138,5 @@ def test_default_dialog_entries_should_localized_when_ordering_catalog_item_in_f
         tags: service
     Bugzilla:
         1592573
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_in_dynamic_dropdown_list_the_default_value_should_not_contain_all_the_value_of_the_list():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.10
-        tags: service
-    Bugzilla:
-        1568440
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_user_should_be_able_to_change_the_order_of_values_of_the_drop_down_list():
-    """
-    Polarion:
-        assignee: nansari
-        initialEstimate: 1/16h
-        casecomponent: Services
-        testtype: functional
-        startsin: 5.10
-        tags: service
-    Bugzilla:
-        1594301
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_entries_shouldnt_be_mislabeled_for_dropdown_element_in_dialog_editor():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        initialEstimate: 1/16h
-        testtype: functional
-        startsin: 5.10
-        tags: service
-    Bugzilla:
-        1597802
     """
     pass

--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -51,21 +51,6 @@ def test_service_catalog_crud_ssui(appliance, setup_provider,
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_ssui_myservice_myrequests_and_service_catalog_filter_links():
-    """ Check Filter Links of all pages
-    Polarion:
-        assignee: nansari
-        casecomponent: SelfServiceUI
-        testtype: functional
-        initialEstimate: 1/8h
-        startsin: 5.5
-        tags: ssui
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_ssui_test_all_language_translations():
     """
@@ -125,23 +110,6 @@ def test_ssui_disable_notification(request, appliance, user_self_service_role,
             assert view.alert.read() == "Shopping cart is empty."
 
 
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_in_ssui_portal_reconfigure_service_should_shows_available_provisioning_dialog():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: SelfServiceUI
-        testtype: functional
-        initialEstimate: 1/2h
-        startsin: 5.9
-        tags: ssui
-    Bugzilla:
-        1633453
-    """
-    pass
-
-
 @pytest.mark.tier(1)
 def test_refresh_ssui_page(appliance, generic_service):
     """
@@ -161,23 +129,6 @@ def test_refresh_ssui_page(appliance, generic_service):
         # After refresh it should be on the same page or shouldn't logout
         view.browser.refresh()
         assert view.is_displayed
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_able_to_access_openstack_instance_console_from_self_service_portal():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: SelfServiceUI
-        initialEstimate: 1/2h
-        testtype: functional
-        startsin: 5.9
-        tags: ssui
-    Bugzilla:
-        1624573
-    """
-    pass
 
 
 @pytest.mark.manual
@@ -242,21 +193,6 @@ def test_disabling_dashboard_under_service_ui_for_a_role_shall_disable_the_dashb
         tags: ssui
     Bugzilla:
         1589409
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
-def test_sui_order_and_request_should_be_sorted_by_time():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: SelfServiceUI
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.8
-        tags: ssui
     """
     pass
 


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_dynamic_dialog_field_to_static_field  }}


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
automated -> test_dynamic_dialog_field_to_static_field
removed few tests which are already covered in automation and also a few no need to test.