### PR TITLE
[1LP][RFR] Automating Ansible tower catalog change template

### DIFF
--- a/cfme/tests/services/test_catalog_item.py
+++ b/cfme/tests/services/test_catalog_item.py
@@ -297,35 +297,6 @@ def test_restricted_catalog_items_select_for_catalog_bundle(appliance, request, 
 
 
 @pytest.mark.manual
-@test_requirements.service
-@pytest.mark.tier(1)
-def test_catalog_all_page_after_deleting_selected_template():
-    """
-    Polarion:
-        assignee: nansari
-        initialEstimate: 1/12h
-        caseimportance: low
-        caseposneg: positive
-        testtype: functional
-        startsin: 5.10
-        casecomponent: Services
-        tags: service
-        testSteps:
-            1. Add provider (VMware or scvmm)
-            2. Create catalog item (Remember template you selected.)
-            3. Order Service catalog item
-            4. Go to details page of provider and click on templates
-            5. Either delete this template while provisioning process in progress or after
-               completing process.
-            6. Go to service > catalogs > service catalogs or catalog items
-            7. Click on catalog item you created or ordered
-    Bugzilla:
-        1652858
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_rbac_assigning_multiple_tags_from_same_category_to_catalog_item():
     """ RBAC : Assigning multiple tags from same category to catalog Item
@@ -553,33 +524,6 @@ def test_reorder_buttons_in_catalog_items():
             2.
             3.
             4. Cancel/save button should be present on the bottom
-    """
-    pass
-
-
-@pytest.mark.meta(coverage=[1740814])
-@pytest.mark.manual
-@pytest.mark.ignore_stream('5.10')
-@pytest.mark.tier(2)
-def test_change_ansible_tower_job_template():
-    """
-    Bugzilla:
-        1740814
-
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        caseimportance: medium
-        initialEstimate: 1/16h
-        startsin: 5.11
-        testSteps:
-            1. Add a Ansible Tower provider
-            2. Add an Ansible Tower Catalog Item with 'Display in Catalog' Checked
-            3. Edit the Catalog item, change the Tower job template
-        expectedResults:
-            1.
-            2.
-            3. 'Display in Catalog' remains checked after template change
     """
     pass
 

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -4,6 +4,7 @@ from cfme import test_requirements
 from cfme.infrastructure.config_management.ansible_tower import AnsibleTowerProvider
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
+from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 
@@ -99,3 +100,38 @@ def test_retire_ansible_service(appliance, catalog_item, request, job_type,
     assert order_request.is_succeeded(method='ui'), msg
     myservice = MyService(appliance, catalog_item.name)
     myservice.retire()
+
+
+@pytest.mark.ignore_stream('5.10')
+@pytest.mark.customer_scenario
+@pytest.mark.meta(automates=[1740814])
+@pytest.mark.parametrize('job_type', ['template'], ids=['template_job'])
+def test_change_ansible_tower_job_template(catalog_item, job_type, ansible_api_version_change):
+    """
+    Bugzilla:
+        1740814
+
+    Polarion:
+        assignee: nansari
+        casecomponent: Services
+        initialEstimate: 1/16h
+        startsin: 5.11
+        testSteps:
+            1. Add a Ansible Tower provider
+            2. Add an Ansible Tower Catalog Item with 'Display in Catalog' Checked
+            3. Edit the Catalog item, change the Tower job template
+        expectedResults:
+            1.
+            2.
+            3. 'Display in Catalog' remains checked after template change
+    """
+    view = navigate_to(catalog_item, 'Edit')
+
+    # Change the Ansible Tower Template
+    view.select_orch_template.fill("bz-survey")
+    view.save.click()
+    view = navigate_to(catalog_item, 'Edit')
+
+    # "Display in Catalog" should be checked
+    assert view.display.read()
+    view.cancel.click()

--- a/cfme/tests/test_manual.py
+++ b/cfme/tests/test_manual.py
@@ -229,23 +229,6 @@ def test_heat_stacks_in_non_admin_tenants_shall_also_be_collected():
 
 
 @pytest.mark.manual
-@test_requirements.service
-@pytest.mark.tier(2)
-def test_bundle_stack_deployment():
-    """
-    bundle stack provisioning for entry point catalog items
-
-    Polarion:
-        assignee: sshveta
-        casecomponent: Services
-        caseimportance: medium
-        initialEstimate: 1/4h
-        startsin: 5.5
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_verify_smart_mgmt_orchest_template():
     """


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_config_provider_servicecatalogs.py::test_change_ansible_tower_job_template  -svvvvv --use-provider ansible_tower_34 }}


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
