### PR TITLE
[1LP][RFR] Adding dialog datepicker on request details page 

### DIFF
--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -257,32 +257,6 @@ def test_dialog_editor_modify_field(dialog):
     view.cancel_button.click(handle_alert=False)
 
 
-@pytest.mark.meta(coverage=[1706848])
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_specific_dates_and_time_in_timepicker():
-    """
-
-    Bugzilla:
-        1706848
-
-    Polarion:
-        assignee: nansari
-        startsin: 5.10
-        casecomponent: Services
-        initialEstimate: 1/16h
-        testSteps:
-            1. Create a dialog with timepicker
-            2. Select specific dates and time, Save
-            3. Edit the dialog
-        expectedResults:
-            1.
-            2.
-            3. Able to set specific dates and time in timepicker
-    """
-    pass
-
-
 @pytest.mark.customer_scenario
 @pytest.mark.meta(automates=[1706693])
 @pytest.mark.tier(2)
@@ -880,31 +854,39 @@ def test_service_dynamic_dialog_tagcontrol(appliance, import_datastore, import_d
     )
 
 
-@pytest.mark.meta(coverage=[1744413])
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_datepicker_in_service_request():
+@pytest.mark.customer_scenario
+@pytest.mark.meta(automates=[1744413])
+@pytest.mark.parametrize("file_name", ["bz_1744413.yml"], ids=["load-init"])
+def test_datepicker_in_service_request(generic_catalog_item_with_imported_dialog):
     """
     Bugzilla:
         1744413
 
     Polarion:
         assignee: nansari
+        startsin: 5.11
         casecomponent: Services
         initialEstimate: 1/6h
-        startsin: 5.10
         testSteps:
-            1. Create Dialog with Date picker
-            2. Create Service with the dialog and order the service
-            3. Mention a date for the date picker
-            4. Navigate to Services -> Requests -> [your_service] -> Dialog Options
+            1. Create Dialog with datepicker
+            2. Create a service and add the dialog
+            3. Order the service
+            4. Go to on service request details page
         expectedResults:
             1.
             2.
             3.
-            4. Date picker should show correct selected dates
+            4. datepicker date should be correct
     """
-    pass
+    catalog_item, _, _ = generic_catalog_item_with_imported_dialog
+    request = ServiceCatalogs(
+        catalog_item.appliance, catalog=catalog_item.catalog, name=catalog_item.name
+    ).order()
+
+    view = navigate_to(request, "Details")
+
+    # Date should be correct on request details page
+    assert view.details.request_details.read()["Datepicker"] == "06/18/2020"
 
 
 @pytest.mark.meta(automates=[1740823])


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_datepicker_in_service_request }}


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
- automated test_datepicker_in_service_request
- removed test_specific_dates_and_time_in_timepicker, its already covered on another test