### PR TITLE
[1LP][RFR] Add BZ and enhacement card coverage  

### DIFF
--- a/cfme/intelligence/reports/reports.py
+++ b/cfme/intelligence/reports/reports.py
@@ -248,6 +248,8 @@ class SavedReportDetailsView(CloudIntelReportsView):
             and self.reports.is_opened
             and self.reports.tree.currently_selected == self.context["object"].tree_path
             and self.context["object"].queued_datetime_in_title in self.title.text
+            and self.breadcrumb.locations
+            == ["Overview", "Reports", "Reports", self.context["object"].datetime_in_tree]
         )
 
 

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -299,7 +299,7 @@ class RequestsView(RequestBasicView):
         contains = '' if not partial_check else '__contains'
         column_list = self.table.attributized_headers
         cells = copy(cells)
-        for key in cells.keys():
+        for key in list(cells):
             for column_name, column_text in column_list.items():
                 if key == column_text:
                     cells[f'{column_name}{contains}'] = cells.pop(key)

--- a/cfme/tests/cloud_infra_common/test_provisioning.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning.py
@@ -86,12 +86,16 @@ def provisioned_instance(provider, instance_args, appliance):
                        .format(ex.message))
 
 
+@pytest.mark.meta(automates=[1830305])
 @pytest.mark.parametrize('instance_args', [True, False], ids=["Auto", "Manual"], indirect=True)
-def test_provision_from_template(provider, provisioned_instance):
+def test_provision_from_template(provisioned_instance):
     """ Tests instance provision from template via CFME UI
 
     Metadata:
         test_flag: provision
+
+    Bugzilla:
+        1830305
 
     Polarion:
         assignee: jhenner

--- a/cfme/tests/configure/test_workers.py
+++ b/cfme/tests/configure/test_workers.py
@@ -94,7 +94,7 @@ def set_memory_threshold_in_advanced_settings(appliance, worker, new_threshold):
 
 @test_requirements.settings
 @pytest.mark.tier(2)
-@pytest.mark.meta(automates=[1658373, 1715633, 1787350, 1799443, 1805845])
+@pytest.mark.meta(automates=[1658373, 1715633, 1787350, 1799443, 1805845, 1810773])
 @pytest.mark.parametrize('set_memory_threshold',
     [set_memory_threshold_in_ui, set_memory_threshold_in_advanced_settings],
     ids=['in_UI', 'in_advanced_setting'])
@@ -107,6 +107,7 @@ def test_set_memory_threshold(appliance, worker, request, set_memory_threshold):
         1787350
         1799443
         1805845
+        1810773
 
     Polarion:
         assignee: tpapaioa

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -212,12 +212,3 @@ def test_database_wildcard_should_work_and_be_included_in_the_query(appliance, r
 
     assert result.subcount
     assert vm_name in [vm.name for vm in result.resources]
-
-@pytest.mark.ignore_stream("5.10")
-@pytest.mark.parametrize(
-    'from_detail', [True, False],
-    ids=['from_detail', 'from_collection'])
-def test_rename_vm(vm, appliance, from_detail, request):
-    request.addfinalizer(vm.action.delete)
-    new_name = fauxfactory.gen_alphanumeric(15, start="Renamed VM")
-    payload = {"new_name": new_name}

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -81,10 +81,6 @@ def test_vm_scan(appliance, vm, from_detail):
 @pytest.mark.meta(automates=[1833362, 1428250])
 @pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
 @pytest.mark.parametrize("attribute", ["name", "description"])
-@pytest.mark.uncollectif(
-    lambda attribute, appliance: appliance.version < "5.11" and attribute == "name",
-    reason="Renaming a VM via rest is not possible on 5.10."
-)
 def test_edit_vm(request, vm, appliance, from_detail, attribute):
     """Tests edit VMs using REST API.
 

--- a/cfme/tests/infrastructure/test_vm_rest.py
+++ b/cfme/tests/infrastructure/test_vm_rest.py
@@ -78,16 +78,24 @@ def test_vm_scan(appliance, vm, from_detail):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.parametrize(
-    'from_detail', [True, False],
-    ids=['from_detail', 'from_collection'])
-def test_edit_vm(request, vm, appliance, from_detail):
+@pytest.mark.meta(automates=[1833362, 1428250])
+@pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
+@pytest.mark.parametrize("attribute", ["name", "description"])
+@pytest.mark.uncollectif(
+    lambda attribute, appliance: appliance.version < "5.11" and attribute == "name",
+    reason="Renaming a VM via rest is not possible on 5.10."
+)
+def test_edit_vm(request, vm, appliance, from_detail, attribute):
     """Tests edit VMs using REST API.
 
     Testing BZ 1428250.
 
     Metadata:
         test_flag: rest
+
+    Bugzilla:
+        1428250
+        1833362
 
     Polarion:
         assignee: pvala
@@ -96,25 +104,22 @@ def test_edit_vm(request, vm, appliance, from_detail):
         initialEstimate: 1/4h
     """
     request.addfinalizer(vm.action.delete)
-    new_description = fauxfactory.gen_alphanumeric(18, start="Test REST VM ")
-    payload = {'description': new_description}
+    payload = {attribute: fauxfactory.gen_alphanumeric(15, start=f"Edited-{attribute}-")}
     if from_detail:
         edited = vm.action.edit(**payload)
         assert_response(appliance)
     else:
-        payload.update(vm._ref_repr())
-        edited = appliance.rest_api.collections.vms.action.edit(payload)
+        edited = appliance.rest_api.collections.vms.action.edit({**payload, **vm._ref_repr()})
         assert_response(appliance)
         edited = edited[0]
 
     record, __ = wait_for(
-        lambda: appliance.rest_api.collections.vms.find_by(
-            description=new_description) or False,
+        lambda: appliance.rest_api.collections.vms.find_by(**payload) or False,
         num_sec=100,
         delay=5,
     )
     vm.reload()
-    assert vm.description == edited.description == record[0].description
+    assert getattr(vm, attribute) == getattr(edited, attribute) == getattr(record[0], attribute)
 
 
 @pytest.mark.tier(3)
@@ -211,3 +216,12 @@ def test_database_wildcard_should_work_and_be_included_in_the_query(appliance, r
 
     assert result.subcount
     assert vm_name in [vm.name for vm in result.resources]
+
+@pytest.mark.ignore_stream("5.10")
+@pytest.mark.parametrize(
+    'from_detail', [True, False],
+    ids=['from_detail', 'from_collection'])
+def test_rename_vm(vm, appliance, from_detail, request):
+    request.addfinalizer(vm.action.delete)
+    new_name = fauxfactory.gen_alphanumeric(15, start="Renamed VM")
+    payload = {"new_name": new_name}

--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -1,8 +1,8 @@
 import pytest
 
 from cfme import test_requirements
-from cfme.utils.appliance.implementations.ui import ViaUI
 from cfme.utils.appliance.implementations.rest import ViaREST
+from cfme.utils.appliance.implementations.ui import ViaUI
 
 pytestmark = [test_requirements.auth, pytest.mark.manual]
 

--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -575,11 +575,15 @@ def test_session_timeout():
     pass
 
 
-@pytest.mark.meta(coverage=[1784145])
+@pytest.mark.meta(coverage=[1784145, 1805914])
 @pytest.mark.parametrize("context", [ViaREST, ViaUI])
 def test_openid_auth_provider(context):
     """
     Test setting up CFME with OpenID Auth Provider
+
+    Bugzilla:
+        1784145
+        1805914
 
     Polarion:
         assignee: dgaikwad

--- a/cfme/tests/integration/test_auth_manual.py
+++ b/cfme/tests/integration/test_auth_manual.py
@@ -1,6 +1,8 @@
 import pytest
 
 from cfme import test_requirements
+from cfme.utils.appliance.implementations.ui import ViaUI
+from cfme.utils.appliance.implementations.rest import ViaREST
 
 pytestmark = [test_requirements.auth, pytest.mark.manual]
 
@@ -574,7 +576,8 @@ def test_session_timeout():
 
 
 @pytest.mark.meta(coverage=[1784145])
-def test_openid_auth_provider():
+@pytest.mark.parametrize("context", [ViaREST, ViaUI])
+def test_openid_auth_provider(context):
     """
     Test setting up CFME with OpenID Auth Provider
 
@@ -599,6 +602,7 @@ def test_openid_auth_provider():
                     --oidc-client-id <appliance-fqdn>
                     --oidc-client-secret <client-secret>
             5. Login to appliance with OpenID user (clicking "Login to Corporate Account")
+                via given context.
         expectedResults:
             1.
             2.

--- a/cfme/tests/intelligence/reports/test_reports_manual.py
+++ b/cfme/tests/intelligence/reports/test_reports_manual.py
@@ -37,27 +37,3 @@ def test_reports_in_global_region(context, report):
 
     """
     pass
-
-
-@pytest.mark.ignore_stream("5.10")
-@test_requirements.report
-@pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1714197])
-def test_optimization_reports():
-    """
-    Bugzilla:
-        1714197
-
-    Polarion:
-        assignee: pvala
-        casecomponent: Reporting
-        initialEstimate: 1/2h
-        startsin: 5.11
-        testSteps:
-            1. Navigate to Overview > Optimization.
-            2. Queue all the 7 parametrized reports and check if it exists.
-        expectedResults:
-            1.
-            2. Reports must exist.
-    """
-    pass

--- a/cfme/tests/intelligence/test_optimization.py
+++ b/cfme/tests/intelligence/test_optimization.py
@@ -20,12 +20,13 @@ REPORTS = [
 ]
 
 
-@pytest.mark.meta(automates=[1769346])
+@pytest.mark.meta(automates=[1769346, 1714197])
 @pytest.mark.parametrize("menu_name", REPORTS, ids=[attributize_string(i) for i in REPORTS])
 def test_generate_optimization_report(appliance, menu_name):
     """
     Bugzilla:
         1769346
+        1714197
 
     Polarion:
         assignee: pvala


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ 
    1. `test_edit_vm` to add coverage for BZ(1833362).
    2.  `test_openid_auth_provider` by adding coverage for BZ(1805914).
    3. `test_generate_optimization_report` to add coverage for BZ(1714197) and delete duplicate test `test_optimization_reports`
    4. `test_provision_from_template` by adding coverage for BZ(1830305).
    5. `test_set_memory_threshold` by adding coverage for BZ(1810773).
- __Fixing tests__:
    1. `test_provision_from_template` by fixing `cfme/services/requests.py::find_request()` that caused python3 `RuntimeError: dictionary keys changed during iteration` error.

### PRT Run
{{ pytest: cfme/tests/infrastructure/test_vm_rest.py::test_edit_vm cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_from_template --use-provider={vsphere65-nested,ec2west}  -svvv }}