### PR TITLE
[1LP][RFR] Automate policy_profiles test for rest

### DIFF
--- a/cfme/rest/gen_data.py
+++ b/cfme/rest/gen_data.py
@@ -640,3 +640,15 @@ def custom_buttons(
         data.append(data_dict)
 
     return _creating_skeleton(request, appliance, "custom_buttons", data)
+
+
+def policy_profiles(request, appliance, num=2):
+    data = []
+    for _ in range(num):
+        data.append(
+            {
+                "description": fauxfactory.gen_alpha(start="PP description ", length=17),
+                "name": fauxfactory.gen_alpha(start="test_pp_name_", length=17),
+            }
+        )
+    return _creating_skeleton(request, appliance, "policy_profiles", data)


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__
    1. TestPolicyProfilesRESTAPI

- __Enhancement__ 
    1. Add `policy_profiles` helper function in cfme/rest/gen_data.py to create policy_profile via REST.

### PRT Run
{{ pytest: cfme/tests/control/test_rest_control.py -k "TestPolicyProfilesREST" -svvv }}