### PR TITLE
[1LP][RFR] New test:test_edit_zone

### DIFF
--- a/cfme/base/__init__.py
+++ b/cfme/base/__init__.py
@@ -385,11 +385,15 @@ class Region(BaseEntity, sentaku.modeling.ElementMixin):
 
     @property
     def settings_string(self):
+        # TODO: This does not work when region description is not set to default.
         return f"{self.appliance.product_name} Region: Region {self.number} [{self.number}]"
 
     @property
     def region_string(self):
-        """Return Region string like `Region 0`"""
+        """
+        Return Region string like `Region 0`
+        TODO: This does not work when region description is not set to default.
+        """
         return f"Region {self.number}"
 
     @property
@@ -469,6 +473,15 @@ class Region(BaseEntity, sentaku.modeling.ElementMixin):
         })
         view.submit.click()
         view.flash.assert_no_error()
+
+    @property
+    def rest_api_entity(self):
+        try:
+            return self.appliance.rest_api.collections.regions.get(region_number=self.number)
+        except ValueError:
+            raise RestLookupError(
+                f"No region rest entity found matching region_number {self.number}"
+            )
 
 
 @attr.s

--- a/cfme/tests/configure/test_rest_config.py
+++ b/cfme/tests/configure/test_rest_config.py
@@ -1,7 +1,10 @@
+import fauxfactory
 import pytest
 
 from cfme import test_requirements
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.rest import assert_response
+from cfme.utils.wait import wait_for
 
 pytestmark = [test_requirements.rest, pytest.mark.tier(1)]
 
@@ -33,3 +36,40 @@ def test_update_advanced_settings_new_key(appliance, request):
 
     view = navigate_to(appliance.server, "Advanced")
     assert view.is_displayed
+
+
+@pytest.mark.meta(automates=[1805844])
+@pytest.mark.parametrize("from_detail", [True, False], ids=["from_detail", "from_collection"])
+def test_edit_region(temp_appliance_preconfig_funcscope, from_detail):
+    """
+    Bugzilla:
+        1805844
+
+    Polarion:
+        assignee: pvala
+        casecomponent: Configuration
+        caseimportance: medium
+        initialEstimate: 1/10h
+    """
+    appliance = temp_appliance_preconfig_funcscope
+    ui_region = appliance.server.zone.region
+    view = navigate_to(ui_region, "Details")
+    payload = {
+        "description": fauxfactory.gen_alpha(start=f"Edited {ui_region.region_string} ", length=20)
+    }
+    expected_title = f'CFME Region "{payload["description"]} [{ui_region.number}]"'
+    currently_selected = f'CFME Region: {payload["description"]} [{ui_region.number}]'
+
+    region = ui_region.rest_api_entity
+    if from_detail:
+        region.action.edit(**payload)
+    else:
+        payload.update(region._ref_repr())
+        appliance.rest_api.collections.regions.action.edit(payload)
+
+    assert_response(appliance)
+    wait_for(
+        lambda: region.description == payload["description"], fail_func=region.reload, timeout=30
+    )
+    wait_for(lambda: view.title.text == expected_title, fail_func=view.browser.refresh, timeout=800)
+    assert currently_selected in view.accordions.settings.tree.currently_selected


### PR DESCRIPTION
## Purpose or Intent

- __Extending__ 
    1. Add `rest_api_entity` property for region.
    2. Modify `settings_string` and `region_string` to return the correct value even when region description is not set to default.

- __Adding tests__
    1. `test_edit_zone` covering BZ(1805844)

### PRT Run
{{ pytest: cfme/tests/configure/test_rest_config.py::test_edit_region -svvv}