### PR TITLE
[RFR] Fix navigation for temp appliance tests

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -279,6 +279,9 @@ def distributed_appliances(temp_appliance_preconfig_funcscope_rhevm,
     secondary_appliance.configure(region=0, key_address=primary_appliance.hostname,
         db_address=primary_appliance.hostname)
 
+    primary_appliance.browser_steal = True
+    secondary_appliance.browser_steal = True
+
     return primary_appliance, secondary_appliance
 
 
@@ -299,6 +302,9 @@ def replicated_appliances(temp_appliance_preconfig_funcscope_rhevm,
     global_appliance.add_pglogical_replication_subscription(remote_appliance.hostname)
     logger.info("Finished appliance replication configuration.")
 
+    remote_appliance.browser_steal = True
+    global_appliance.browser_steal = True
+
     return remote_appliance, global_appliance
 
 
@@ -317,6 +323,9 @@ def replicated_appliances_preupdate(multiple_preupdate_appliances):
     global_appliance.set_pglogical_replication(replication_type=':global')
     global_appliance.add_pglogical_replication_subscription(remote_appliance.hostname)
     logger.info("Finished appliance replication configuration.")
+
+    global_appliance.browser_steal = True
+    remote_appliance.browser_steal = True
 
     return remote_appliance, global_appliance
 


### PR DESCRIPTION
When using temp appliance fixtures, `navigate_to` from within the temp appliance's context manager will sometimes use the expected appliance, and sometimes instead it uses the default appliance.

Entering the temp appliance's context manager will push that appliance onto the ApplianceStack, and `navigate_to(provider, 'Details')` works, because `BaseProvider` inherits from `Navigatable`, which returns the current appliance from the stack when you get its `appliance` attribute.

Trying to navigate using an instance of a `BaseEntity`-derived class, on the other hand, will use the default appliance, because `BaseEntity`'s appliance property is always going to be the appliance for which the collection was created.

A few of the PRT tests errored out but are either non-multi-appliance retirement tests or errored out during temp appliance configuration, so the errors are unrelated to this PR.

{{ pytest: -vv --long-running cfme/tests/cloud_infra_common/test_retirement.py cfme/tests/distributed/test_appliance_replication.py }}