### PR TITLE
[1LP][RFR] Fix setting logger level from config

### DIFF
--- a/cfme/utils/log.py
+++ b/cfme/utils/log.py
@@ -149,7 +149,7 @@ MARKER_LEN = 80
 
 # set logging defaults
 _default_conf = {
-    'level': 'INFO',
+    'level': logging.INFO,
     'errors_to_console': False,
     'to_console': False,
 }
@@ -366,13 +366,9 @@ def setup_logger(logger, file_handler=None):
     Returns:
         tuple of (<logger>, <file handler attached to this logger>)
     """
-    # prevent the root logger effective level from affecting us
-    # this is a hack
-    logger.setLevel(logging.INFO)
-    # prevent root logger handlers from triggering (its sad that we need this)
-    logger.propagate = False
-    # Grab the logging conf
     conf = _load_conf(logger.name)
+    logger.setLevel(conf['level'])
+    logger.propagate = False
 
     # log_file is dynamic, so we can't used logging.config.dictConfig here without creating
     # a custom RotatingFileHandler class. At some point, we should do that, and move the


### PR DESCRIPTION
The loggers created via `cfme.utils.log.setup_logger` were hardcoded to have the `INFO` log level, ignoring any settings in `conf/env.local.yaml`. The associated file handlers do get created with the level from the yaml, but because the logger's level is fixed at `INFO`,  no `DEBUG` logging is possible. This PR uses the yaml settings when creating the logger too, so that settings like the following in `conf/env.local.yaml` will log debug statements in `cfme.log`.

```
logging:
    level: DEBUG

[or]

logging:
    cfme:
        level: DEBUG
```