### PR TITLE
[1LP][RFR] Add BZ blocker for Azure chargeback / metering tests

### DIFF
--- a/cfme/tests/intelligence/reports/test_metering_report.py
+++ b/cfme/tests/intelligence/reports/test_metering_report.py
@@ -21,7 +21,7 @@ from cfme.common.provider import BaseProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import providers
-from cfme.utils.blockers import GH
+from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
@@ -36,9 +36,8 @@ pytestmark = [
     pytest.mark.tier(2),
     pytest.mark.provider(gen_func=providers, filters=[cloud_and_infra, not_scvmm], scope='module'),
     test_requirements.chargeback,
-    pytest.mark.meta(blockers=[
-        GH('ManageIQ/manageiq:20237', unblock=lambda provider: not provider.one_of(AzureProvider))
-    ])
+    pytest.mark.meta(blockers=[BZ(1843942, forced_streams=['5.11'],
+        unblock=lambda provider: not provider.one_of(AzureProvider))])
 ]
 
 # Allowed deviation between the reported value in the Metering report and the estimated value.

--- a/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
+++ b/cfme/tests/intelligence/reports/test_validate_chargeback_report.py
@@ -36,7 +36,7 @@ from cfme.cloud.provider.gce import GCEProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.scvmm import SCVMMProvider
 from cfme.markers.env_markers.provider import providers
-from cfme.utils.blockers import GH
+from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
 from cfme.utils.providers import ProviderFilter
 from cfme.utils.wait import wait_for
@@ -54,9 +54,8 @@ pytestmark = [
     pytest.mark.provider(gen_func=providers, filters=[cloud_and_infra, not_scvmm], scope='module'),
     pytest.mark.usefixtures('has_no_providers_modscope', 'setup_provider_modscope'),
     test_requirements.chargeback,
-    pytest.mark.meta(blockers=[
-        GH('ManageIQ/manageiq:20237', unblock=lambda provider: not provider.one_of(AzureProvider))
-    ])
+    pytest.mark.meta(blockers=[BZ(1843942, forced_streams=['5.11'],
+        unblock=lambda provider: not provider.one_of(AzureProvider))])
 ]
 
 # Allowed deviation between the reported value in the Chargeback report and the estimated value.


### PR DESCRIPTION
The upstream GH issue for Azure metrics capture, which was previously blocking chargeback tests, has been closed now that a downstream BZ has been created. This PR updates the blocker information for some chargeback / metering tests to point to the new BZ, so that the tests continue to be skipped. All tests in the PRT run should be skipped.

{{ pytest: -v --long-running --use-provider azure cfme/tests/intelligence/reports/test_metering_report.py cfme/tests/intelligence/reports/test_validate_chargeback_report.py }}