### PR TITLE
[1LP][RFR] Fix quota_limit fixture

### DIFF
--- a/cfme/tests/infrastructure/test_tenant_quota.py
+++ b/cfme/tests/infrastructure/test_tenant_quota.py
@@ -141,11 +141,11 @@ def migration_destination_host(create_vm_modscope, provider):
 
 @pytest.fixture
 def quota_limit(root_tenant):
-    in_use_storage = int(root_tenant.quota["storage"]["in_use"].strip(" GB"))
+    in_use_storage = round(float(root_tenant.quota["storage"]["in_use"].strip(" GB")), 2)
     # set storage quota limit to something more than the in_use_storage space
     root_tenant.set_quota(storage_cb=True, storage=(in_use_storage + 3))
 
-    yield int(root_tenant.quota["storage"]["available"].strip(" GB"))
+    yield round(float(root_tenant.quota["storage"]["available"].strip(" GB")), 2)
 
     root_tenant.set_quota(storage_cb=False)
 


### PR DESCRIPTION
The `quota_limit` fixture in `test_tenant_quota.py` was failing with a `ValueError` because it was trying to cast a float string into an `int`:

```
2020-06-30 12:14:34,544 [E] [cfme] @pytest.fixture
    def quota_limit(root_tenant):
>       in_use_storage = int(root_tenant.quota["storage"]["in_use"].strip(" GB"))
E       ValueError: invalid literal for int() with base 10: '1014.65234375'

cfme/tests/infrastructure/test_tenant_quota.py:144: ValueError (cfme/fixtures/log.py:84)
```
This PR casts these strings to `float` instead.

{{ pytest: -v --use-provider vsphere67-nested -k test_quota_with_reconfigure_resize_disks cfme/tests/infrastructure/test_tenant_quota.py }}