### PR TITLE
[1LP][RFR] Fix AttributeError in pytest_polarion_collect

### DIFF
--- a/cfme/fixtures/vm.py
+++ b/cfme/fixtures/vm.py
@@ -2,6 +2,7 @@ import fauxfactory
 import pytest
 from pytest_polarion_collect.utils import get_parsed_docstring
 from pytest_polarion_collect.utils import process_json_data
+from pytest_polarion_collect.utils import set_cache
 from wrapanapi import VmState
 
 from cfme.cloud.provider.ec2 import EC2Provider
@@ -27,6 +28,7 @@ def pytest_collection_finish(session):
     """This hook will call the process_json_data and cause _docstrings_cache
     to be populated so that we can access required information in the _create_vm."""
     if not session.config.getoption('--no-assignee-vm-name'):
+        set_cache(session)
         process_json_data(session, session.items)
 
 


### PR DESCRIPTION
The method called in the VM fixture to process the polarion docblocks assumes that the session cache attributes have already been set

A call to set_cache will make sure that they actually are created, avoiding an AttributeError during collection

```
pytest --collect-only --dummy-appliance -m 'requirement.ansible'

<redacted>

INTERNALERROR>   File "/home/setup/repos/integration_tests/cfme/fixtures/vm.py", line 30, in pytest_collection_finish
INTERNALERROR>     process_json_data(session, session.items)
INTERNALERROR>   File "/home/setup/repos/integration_tests/.cfme_venv/lib64/python3.7/site-packages/pytest_polarion_collect/utils.py", line 351, in process_json_data
INTERNALERROR>     if not (all_items or in_test_dir(str(item.fspath), session._test_dirs_cache)):
INTERNALERROR> AttributeError: 'Session' object has no attribute '_test_dirs_cache'
```