### PR TITLE
[RFR] Fix deprecation warnings for switch_to_alert() and log_message()

### DIFF
--- a/cfme/utils/appliance/implementations/common.py
+++ b/cfme/utils/appliance/implementations/common.py
@@ -35,7 +35,7 @@ class HandleModalsMixin:
             return None
 
         try:
-            return self.selenium.switch_to_alert()
+            return self.selenium.switch_to.alert()
         except NoAlertPresentException:
             modal = self._modal_alert
             return modal if modal.is_displayed else None

--- a/cfme/utils/appliance/implementations/ssui.py
+++ b/cfme/utils/appliance/implementations/ssui.py
@@ -184,7 +184,7 @@ class SSUINavigateStep(NavigateStep):
         except NotImplementedError:
             nav_args['wait_for_view'] = 0
             self.log_message(
-                "is_displayed not implemented for {} view".format(self.VIEW or ""), level="warn")
+                "is_displayed not implemented for {} view".format(self.VIEW or ""), level="warning")
         except Exception as e:
             self.log_message(
                 f"Exception raised [{e}] whilst checking if already here", level="error")

--- a/cfme/utils/appliance/implementations/ui.py
+++ b/cfme/utils/appliance/implementations/ui.py
@@ -561,7 +561,7 @@ class CFMENavigateStep(NavigateStep):
         except NotImplementedError:
             nav_args['wait_for_view'] = 0
             self.log_message(
-                "is_displayed not implemented for {} view".format(self.VIEW or ""), level="warn")
+                "is_displayed not implemented for {} view".format(self.VIEW or ""), level="warning")
         except Exception as e:
             self.log_message(
                 f"Exception raised [{e}] whilst checking if already here", level="error")


### PR DESCRIPTION
This PR resolves two deprecation warnings:

1.) Replace deprecated use of `level="warn"` with `level="warning"` in `CFMENavigateStep`'s `log_message()` method:

```
cfme/tests/cloud_infra_common/test_retirement.py::test_set_retirement_date[ec2-no_warning]
  /XXX/cfme/utils/appliance/implementations/ui.py:527: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    getattr(logger, level)(str_msg)
```

2.) Replace deprecated use of `selenium.switch_to_alert()` with `selenium.switch_to.alert()` in `HandleModalsMixin`'s `get_alert()` method:

```
cfme/tests/cloud_infra_common/test_retirement.py::test_set_retirement_date[ec2-no_warning]
  /XXX/cfme/utils/appliance/implementations/common.py:38: DeprecationWarning: use driver.switch_to.alert instead
    return self.selenium.switch_to_alert()
```

{{ pytest: -v --long-running --use-provider ec2west -k 'test_set_retirement_date[ec2-no_warning]' cfme/tests/cloud_infra_common/test_retirement.py }}