### PR TITLE
[RFR] Fix to switch_to.alert call

### DIFF
--- a/cfme/utils/appliance/implementations/common.py
+++ b/cfme/utils/appliance/implementations/common.py
@@ -35,7 +35,7 @@ class HandleModalsMixin:
             return None
 
         try:
-            return self.selenium.switch_to.alert()
+            return self.selenium.switch_to.alert
         except NoAlertPresentException:
             modal = self._modal_alert
             return modal if modal.is_displayed else None


### PR DESCRIPTION
In PR https://github.com/ManageIQ/integration_tests/pull/10237 the fix to replace deprecated `switch_to_alert()` with the property method `switch_to.alert` incorrectly used `switch_to.alert()`, which led to errors like the following when a popup / alert is found:

```
        try:
>           return self.selenium.switch_to.alert()
E           TypeError: 'Alert' object is not callable

cfme/utils/appliance/implementations/common.py:38: TypeError (cfme/fixtures/log.py:84)
```

This PR makes the fix and includes a PRT test that ran into this problem.

{{ pytest: -v -k test_zone_crud cfme/tests/configure/test_zones.py }}