### PR TITLE
[1LP][RFR] Automating ssui/ui dynamic refresh dialog test

### DIFF
--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -116,23 +116,6 @@ def test_refresh_ssui_page(appliance, generic_service):
 
 
 @pytest.mark.manual
-@pytest.mark.tier(1)
-def test_sui_ordering_service_catalog_the_dynamic_drop_down_dialogs_fields_should_auto_refreshed():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: SelfServiceUI
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.8
-        tags: ssui
-    Bugzilla:
-        1568342
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(2)
 def test_disabling_dashboard_under_service_ui_for_a_role_shall_disable_the_dashboard():
     """


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_dynamic_dropdown_auto_refresh_load }}


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
