### PR TITLE
[1LP][RFR] Automating disable ssui dashboard from Role

### DIFF
--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -6,6 +6,7 @@ from cfme.cloud.provider import CloudProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.markers.env_markers.provider import ONE_PER_TYPE
 from cfme.markers.env_markers.provider import providers
+from cfme.services.dashboard.ssui import DashboardView
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaSSUI
 from cfme.utils.appliance.implementations.ssui import navigate_to
@@ -115,21 +116,32 @@ def test_refresh_ssui_page(appliance, generic_service):
         assert view.is_displayed
 
 
-@pytest.mark.manual
 @pytest.mark.tier(2)
-def test_disabling_dashboard_under_service_ui_for_a_role_shall_disable_the_dashboard():
+@pytest.mark.customer_scenario
+@pytest.mark.meta(automates=[1589409])
+def test_ssui_disable_dashboard(appliance, user_self_service_role):
     """
-    Polarion:
-        assignee: nansari
-        casecomponent: SelfServiceUI
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.9
-        tags: ssui
     Bugzilla:
         1589409
+    Polarion:
+        assignee: nansari
+        startsin: 5.11
+        casecomponent: SelfServiceUI
+        initialEstimate: 1/16h
     """
-    pass
+    user, role = user_self_service_role
+
+    product_features = [(['Everything', 'Service UI', 'Dashboard'], False)]
+    role.update({'product_features': product_features})
+
+    # login with user having self service role
+    with user:
+        with appliance.context.use(ViaSSUI):
+            appliance.server.login(user)
+
+            view = appliance.browser.create_view(DashboardView)
+            # Dashboard should not be present
+            assert not view.is_displayed
 
 
 @pytest.mark.manual


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/ssui/test_ssui_service_catalogs.py::test_ssui_disable_dashboard --long-running -svv }}


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
