### PR TITLE
[NOTEST][RFR] adding BZ coverage and cleanup tcs

### DIFF
--- a/cfme/tests/automate/test_service_automate.py
+++ b/cfme/tests/automate/test_service_automate.py
@@ -357,33 +357,6 @@ def test_passing_value_between_catalog_items(request, appliance, catalog_item_se
         assert provision_request.is_succeeded(method="ui")
 
 
-@pytest.mark.manual
-@pytest.mark.tier(2)
-@pytest.mark.meta(coverage=[1748353])
-def test_service_retire_automate():
-    """
-    Bugzilla:
-        1748353
-
-    Polarion:
-        assignee: dgaikwad
-        initialEstimate: 1/8h
-        caseposneg: positive
-        casecomponent: Automate
-        testSteps:
-            1. Create email retirement method & add it to automate
-            2. Provision service with a retirement date
-            3. Reach retirement date
-            4. See automation logs
-        expectedResults:
-            1.
-            2.
-            3.
-            4. The retirement should not run multiple times at the same time
-    """
-    pass
-
-
 @pytest.mark.tier(2)
 @pytest.mark.meta(automates=[1740796], blockers=[BZ(1740796, forced_streams=["5.10"])])
 def test_import_dialog_file_without_selecting_file(appliance, dialog):

--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -3073,3 +3073,73 @@ def test_ssui_login_http():
             2. able to login SSUI
     """
     pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+@pytest.mark.customer_scenario
+@pytest.mark.meta(coverage=[1710998])
+def test_verify_datastores_list():
+    """
+    Datastore filter should work properly after even delete the datastores
+    Bugzilla:
+        1710998
+    Polarion:
+        assignee: dgaikwad
+        casecomponent: Auth
+        caseimportance: high
+        initialEstimate: 1/4h
+    setup:
+        1. create setup like below
+            My VMWARE structure:
+            vcenter-server
+            |
+            | -> Datacenter1
+                | -> Cluster1
+            |
+            | -> Datacenter2
+                | -> Cluster2
+            |
+            | -> Datacenter3
+                | -> Cluster3
+    testSteps:
+        1. create a role and group `group1` and assigne filters for only `Cluster3`,
+        2. created user `user1`, logged in with user `user1` and verified that I can only
+        see `Cluster3`.
+        3. delete the 'cluster3'
+        4. navigate to check cluster list
+    expectedResults:
+        1. role and group successfully created
+        2. able to see only `cluster3`
+        3. cluster should be deleted successfully
+        4. There should not be any cluster in the list
+    """
+    pass
+
+
+@pytest.mark.manual
+@pytest.mark.tier(1)
+@pytest.mark.meta(coverage=[1854839])
+def test_chargeback_report():
+    """
+    Chargeback report should show correct data
+    Bugzilla:
+        1854839
+    Polarion:
+        assignee: dgaikwad
+        casecomponent: Auth
+        caseimportance: medium
+        initialEstimate: 1/4h
+        testSteps:
+            1. create rules (see screen copy): overview -> chargeback -> rates -> compute ->
+             configuration -> Add new chargeback rate
+            2. assign this rule to the whole company (see screen copy): overview -> chargeback ->
+             assignments -> compute : assign previously define rule to enterprise
+            3. create a report based on these rules: overview -> reports
+        expectedResults:
+            1.
+            2.
+            3. report generated with correct data
+
+    """
+    pass


### PR DESCRIPTION
- Adding BugZilla coverage 
- Removing coverage of **test_service_retire_automate** because BZ closed by marking NOTABUG

<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
