### PR TITLE
[1LP][RFR] Automate multi-region service retirement tests

### DIFF
--- a/cfme/tests/services/test_service_catalogs_multi_region.py
+++ b/cfme/tests/services/test_service_catalogs_multi_region.py
@@ -1,14 +1,146 @@
+import fauxfactory
 import pytest
+from widgetastic.utils import partial_match
 
 from cfme import test_requirements
+from cfme.cloud.provider import CloudProvider
+from cfme.infrastructure.provider import InfraProvider
+from cfme.rest.gen_data import dialog as _dialog
+from cfme.rest.gen_data import service_catalog_obj as _catalog
+from cfme.services.myservice import MyService
+from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaREST
 from cfme.utils.appliance import ViaUI
-
+from cfme.utils.generators import random_vm_name
+from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
     pytest.mark.long_running,
+    pytest.mark.provider([CloudProvider, InfraProvider],
+        required_fields=[
+            ['provisioning', 'template'],
+            ['provisioning', 'host'],
+            ['provisioning', 'datastore'],
+            ['provisioning', 'vlan']],
+        scope='module')
 ]
+
+
+@pytest.fixture(scope='function')
+def catalog(request, replicated_appliances):
+    remote_appliance, _ = replicated_appliances
+    return _catalog(request, remote_appliance)
+
+
+@pytest.fixture(scope='function')
+def dialog(request, replicated_appliances):
+    remote_appliance, _ = replicated_appliances
+    return _dialog(request, remote_appliance)
+
+
+@pytest.fixture(scope='function')
+def setup_remote_provider(provider, replicated_appliances):
+    remote_appliance, _ = replicated_appliances
+    with remote_appliance:
+        provider.create(validate_inventory=True)
+
+
+@pytest.fixture(scope='function')
+def catalog_item(replicated_appliances, provider, setup_remote_provider, catalog, dialog,
+        provisioning_data):
+    remote_appliance, _ = replicated_appliances
+    with remote_appliance:
+        catalog_item = remote_appliance.collections.catalog_items.create(
+            provider.catalog_item_type,
+            name=fauxfactory.gen_alphanumeric(15, start="cat_item_"),
+            description="my catalog",
+            display_in=True,
+            catalog=catalog,
+            dialog=dialog,
+            prov_data=provisioning_data)
+
+        yield catalog_item
+
+        catalog_item.delete_if_exists
+
+
+@pytest.fixture(scope='function')
+def provisioning_data(provisioning, provider):
+    return {
+        'catalog': {
+            'catalog_name': {'name': provisioning.template, 'provider': provider.name},
+            'vm_name': random_vm_name('service')
+        },
+        'environment': {
+            'host_name': {'name': provisioning.host},
+            'datastore_name': {'name': provisioning.datastore}
+        },
+        'network': {'vlan': partial_match(provisioning.vlan)},
+    }
+
+
+@pytest.mark.tier(2)
+@test_requirements.multi_region
+@test_requirements.service
+@pytest.mark.parametrize('context', [ViaREST, ViaUI])
+def test_service_provision_retire_from_global_region(request, replicated_appliances, provider,
+        context, catalog_item):
+    """From the global appliance in a multi-region appliance configuration, order and then retire
+    a VM provisioning sevice on the remote appliance.
+
+    Polarion:
+        assignee: tpapaioa
+        caseimportance: high
+        casecomponent: Services
+        initialEstimate: 1/3h
+    """
+    remote_appliance, global_appliance = replicated_appliances
+
+    with global_appliance:
+        # Order the service
+        provision_request = ServiceCatalogs(global_appliance, catalog_item.catalog,
+            catalog_item.name).order()
+
+        provision_request.wait_for_request(method='ui')
+        assert provision_request.is_succeeded(method='ui')
+
+        service = MyService(global_appliance, catalog_item.dialog.label)
+
+        @request.addfinalizer
+        def _clear_request_service():
+            if provision_request.exists():
+                provision_request.remove_request()
+            if service.exists:
+                service.delete()
+
+        assert service.exists
+
+        # Retire the service via UI or REST, depending on context
+        if context.name == 'UI':
+            retire_request = service.retire()
+            assert retire_request and retire_request.exists()
+        else:
+            # TODO: implement retire() via REST using sentaku context
+            services = global_appliance.rest_api.collections.services
+            api_service = services.get(name=service.name)
+            api_retire_requests = services.action.request_retire(api_service)
+            assert len(api_retire_requests) == 1
+            api_retire_request = api_retire_requests[0]
+            assert api_retire_request and api_retire_request.exists
+            retire_request = global_appliance.collections.requests.instantiate(
+                f'Service Retire for: {service.name}')
+
+        @request.addfinalizer
+        def _remove_retire_request():
+            retire_request.remove_request()
+
+        wait_for(lambda: service.is_retired, delay=5, num_sec=300,
+            fail_func=service.browser.refresh, message="Waiting for service to retire")
+
+        vm_name = f"{catalog_item.prov_data['catalog']['vm_name']}0001"
+        vm = global_appliance.provider_based_collection(provider).instantiate(vm_name, provider)
+        assert vm.wait_for_vm_state_change(from_any_provider=True, desired_state='archived')
 
 
 @pytest.mark.manual
@@ -17,10 +149,8 @@ pytestmark = [
 @test_requirements.service
 @pytest.mark.parametrize('context', [ViaREST, ViaUI])
 @pytest.mark.parametrize('catalog_location', ['remote'])  # TODO add global
-@pytest.mark.parametrize('item_type', ['AMAZON', 'ANSIBLE', 'TOWER', 'AZURE', 'GENERIC',
-                                       'OPENSTACK', 'ORCHESTRATION', 'RHV', 'SCVMM', 'VMWARE',
-                                       'BUNDLE'])
-def test_service_provision_retire_from_global_region(item_type, catalog_location, context):
+@pytest.mark.parametrize('item_type', ['ansible', 'tower', 'generic', 'orchestration', 'bundle'])
+def test_service_provision_retire_from_global_region_manual(item_type, catalog_location, context):
     """
     Polarion:
         assignee: tpapaioa


### PR DESCRIPTION
This PR automates several of the manual tests in `test_service_provision_retire_from_global_region`:

- Original list, all manual:
```
    <Function test_service_provision_retire_from_global_region[AMAZON-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[AMAZON-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[ANSIBLE-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[ANSIBLE-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[TOWER-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[TOWER-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[AZURE-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[AZURE-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[GENERIC-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[GENERIC-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[OPENSTACK-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[OPENSTACK-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[ORCHESTRATION-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[ORCHESTRATION-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[RHV-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[RHV-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[SCVMM-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[SCVMM-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[VMWARE-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[VMWARE-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region[BUNDLE-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region[BUNDLE-remote-ViaUI]>
```

- New list:

  - Manual:
  ```
    <Function test_service_provision_retire_from_global_region_manual[ansible-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region_manual[ansible-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region_manual[tower-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region_manual[tower-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region_manual[generic-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region_manual[generic-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region_manual[orchestration-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region_manual[orchestration-remote-ViaUI]>
    <Function test_service_provision_retire_from_global_region_manual[bundle-remote-ViaREST]>
    <Function test_service_provision_retire_from_global_region_manual[bundle-remote-ViaUI]>
  ```
  - Automated:
  ```
    <Function test_service_provision_retire_from_global_region[virtualcenter-6.5-ViaREST]>
    <Function test_service_provision_retire_from_global_region[virtualcenter-6.5-ViaUI]>
    <Function test_service_provision_retire_from_global_region[virtualcenter-6.7-ViaREST]>
    <Function test_service_provision_retire_from_global_region[virtualcenter-6.7-ViaUI]>
    <Function test_service_provision_retire_from_global_region[rhevm-4.2-ViaREST]>
    <Function test_service_provision_retire_from_global_region[rhevm-4.2-ViaUI]>
    <Function test_service_provision_retire_from_global_region[rhevm-4.3-ViaREST]>
    <Function test_service_provision_retire_from_global_region[rhevm-4.3-ViaUI]>
  ```

The automated tests are for infrastructure or cloud providers. (Right now, only rhevm and virtualcenter providers are enabled in our provider YAML and have the required `provisioning` fields.) The manual tests are for all other catalog item types, and will be automated in a later PR.

{{ pytest: -vv --long-running cfme/tests/services/test_service_catalogs_multi_region.py }}
