### PR TITLE
[1LP][RFR] Enhance create_rest for OCP

### DIFF
--- a/cfme/containers/provider/__init__.py
+++ b/cfme/containers/provider/__init__.py
@@ -45,6 +45,7 @@ from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.appliance.implementations.ui import navigator
 from cfme.utils.browser import browser
 from cfme.utils.log import logger
+from cfme.utils.net import resolve_hostname
 from cfme.utils.pretty import Pretty
 from cfme.utils.version import LOWEST
 from cfme.utils.version import VersionPicker
@@ -227,6 +228,30 @@ class ContainersProvider(BaseProvider, Pretty, PolicyProfileAssignable):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         self.parent = self.appliance.collections.containers_providers
+
+    @property
+    def hostname(self):
+        return getattr(self.default_endpoint, "hostname", None)
+
+    @hostname.setter
+    def hostname(self, value):
+        if self.default_endpoint:
+            if value:
+                self.default_endpoint.hostname = value
+        else:
+            logger.warning("can't set hostname because default endpoint is absent")
+
+    @property
+    def ip_address(self):
+        return getattr(self.default_endpoint, "ipaddress", resolve_hostname(str(self.hostname)))
+
+    @ip_address.setter
+    def ip_address(self, value):
+        if self.default_endpoint:
+            if value:
+                self.default_endpoint.ipaddress = value
+        else:
+            logger.warning("can't set ipaddress because default endpoint is absent")
 
     @property
     def view_value_mapping(self):

--- a/cfme/tests/containers/test_container_provider_crud.py
+++ b/cfme/tests/containers/test_container_provider_crud.py
@@ -5,6 +5,7 @@ from cfme import test_requirements
 from cfme.common.provider_views import ContainerProvidersView
 from cfme.containers.provider import ContainersProvider
 from cfme.markers.env_markers.provider import ONE_PER_VERSION
+from cfme.utils.rest import assert_response
 from cfme.utils.update import update
 
 
@@ -64,3 +65,29 @@ def test_container_provider_crud(request, appliance, has_no_providers, provider)
     provider.wait_for_delete()
 
     assert not provider.exists
+
+
+@test_requirements.rest
+def test_container_provider_crud_rest(appliance, has_no_providers, provider):
+    """
+    Test
+    Polarion:
+        assignee: pvala
+        caseimportance: critical
+        casecomponent: Containers
+        initialEstimate: 1/6h
+    """
+    provider.create_rest()
+    provider_rest = appliance.rest_api.collections.providers.get(name=provider.name)
+    assert provider_rest.type == "ManageIQ::Providers::Openshift::ContainerManager"
+
+    new_name = fauxfactory.gen_alphanumeric()
+    edited = provider_rest.action.edit(name=new_name)
+    assert_response(appliance)
+    provider_rest.reload()
+    assert provider_rest.name == new_name == edited.name
+
+    provider_rest.action.delete()
+    provider_rest.wait_not_exists()
+
+    assert not provider_rest.exists


### PR DESCRIPTION
## Purpose or Intent

- __Extending__ 
    1. `BaseProvider.create_rest` method to work for Openshift provider.
    2. Make `BaseProvider.setup` completely rely on `BaseProvider.create_rest`.
- __Adding tests__ 
    1. `test_container_provider_crud_rest` to test the enhancement.
- __Enhancement__ 
    1. Add `ipaddress` and `hostname` methods from `CloudInfraProviderMixin` to `ContainersProvider` to make `create_rest` work.


### PRT Run
{{ pytest: cfme/tests/containers/test_container_provider_crud.py::test_container_provider_crud_rest cfme/tests/cloud_infra_common/test_rest_providers.py::test_create_provider --use-provider={complete,ocp-39-hawk}  }}