### PR TITLE
[1LP][RFR] Automate test_distributed_delete_offline_worker_appliance

### DIFF
--- a/cfme/base/ui.py
+++ b/cfme/base/ui.py
@@ -1481,6 +1481,13 @@ class ZoneDiagnosticsView(ConfigurationView):
     @View.nested
     class rolesbyservers(WaitTab):  # noqa
         TAB_NAME = "Roles by Servers"
+        title = Text(
+            '//*[@id="zone_tree_div"]/'
+            'h3[contains(normalize-space(.), "Status of Roles for Servers in Zone")]'
+        )
+        tree = DiagnosticsTreeView("roles_by_server_treebox")
+        selected_item = SummaryForm("Selected Item")
+        configuration = Dropdown("Configuration")
 
     @View.nested
     class serversbyroles(WaitTab):  # noqa

--- a/cfme/modeling/base.py
+++ b/cfme/modeling/base.py
@@ -10,6 +10,7 @@ from widgetastic_patternfly import CandidateNotFound
 
 from cfme.exceptions import ItemNotFound
 from cfme.exceptions import KeyPairNotFound
+from cfme.exceptions import RestLookupError
 from cfme.utils.appliance import NavigatableMixin
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.log import logger
@@ -179,6 +180,7 @@ class BaseEntity(NavigatableMixin):
             NameError,
             NavigationDestinationNotFound,
             NoSuchElementException,
+            RestLookupError,
             RowNotFound,
             TimedOutError,
         ):

--- a/cfme/tests/distributed/test_appliance_manual.py
+++ b/cfme/tests/distributed/test_appliance_manual.py
@@ -64,23 +64,6 @@ def test_distributed_zone_mixed_appliance_ip_versions():
     pass
 
 
-@pytest.mark.tier(3)
-def test_distributed_delete_offline_worker_appliance():
-    """
-    Steps to Reproduce:
-    have 3 servers .
-    Shutdown one server. This become inactive.
-    go to WebUI > Configuration > Diagnostics > Select "Zone: Default
-    zone" > Select worker > Configuration > Delete
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: Appliance
-        initialEstimate: 1/2h
-    """
-    pass
-
-
 def test_distributed_zone_in_different_networks():
     """
     Polarion:


### PR DESCRIPTION
Automate `test_distributed_delete_offline_worker_appliance` as `test_distributed_delete_appliance`.

{{ pytest: -vv -k test_distributed_delete_appliance --long-running cfme/tests/distributed/test_appliance_replication.py }}