### PR TITLE
[1LP][RFR] Fixing conversion host timeout issue

### DIFF
--- a/cfme/fixtures/v2v_fixtures.py
+++ b/cfme/fixtures/v2v_fixtures.py
@@ -287,7 +287,7 @@ def set_conversion_host_api(
         wait_for(
             lambda: response.task.state == "Finished",
             fail_func=response.task.reload,
-            num_sec=240,
+            num_sec=600,
             delay=3,
             message="Waiting for conversion configuration task to be finished")
 


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

This PR will fix the timeout failure for conversion host configuration.
~~~~~~~~
TimedOutError
b"Could not do 'Waiting for conversion configuration task to be finished'
~~~~~~~~~~

4 minutes is a very marginal limit for the time taken by the ansible-playbook to configure the conversion host. So I have increase the max limit to 10 minutes, though it keeps checking the status at every 3 seconds.

{{ pytest: cfme/tests/v2v/test_conversion_host_ui.py -k "test_add_conversion_host_ui_crud" --use-provider osp13-ims --use-provider vsphere67-ims --provider-limit 2 }}

Note: **Please ignore the PRT result, as in 5.11.7 we hit a major bug in configuring the conversion hosts:
 https://bugzilla.redhat.com/show_bug.cgi?id=1857523

I have tested it locally by applying the workaround of above BZ and it is working fine, Also this PR won't change anything other than extending the time interval, So I guess it is safe to merge this PR.**
