### PR TITLE
[RFR] Added two button fixture and automated manual test

### DIFF
--- a/cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py
+++ b/cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py
@@ -350,7 +350,7 @@ def test_generic_object_button_delete_flash(button_without_group):
     )
 
 
-@pytest.mark.meta(blockers=[BZ(1753281), BZ(1753388)], coverage=[1753281, 1753388])
+@pytest.mark.meta(blockers=[BZ(1753281), BZ(1753388)], automates=[1753281, 1753388])
 def test_generic_object_button_delete_multiple(appliance, two_buttons_without_group):
     """
     Bugzilla:

--- a/cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py
+++ b/cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py
@@ -82,6 +82,24 @@ def button_without_group(appliance, generic_definition):
         button.delete_if_exists()
 
 
+@pytest.fixture(scope="module")
+def two_buttons_without_group(appliance, generic_definition):
+    with appliance.context.use(ViaUI):
+        button1 = generic_definition.add_button(
+            name=fauxfactory.gen_alphanumeric(start="btn1", separator="-"),
+            description=fauxfactory.gen_alphanumeric(),
+            request=fauxfactory.gen_alphanumeric()
+        )
+        button2 = generic_definition.add_button(
+            name=fauxfactory.gen_alphanumeric(start="btn2", separator="-"),
+            description=fauxfactory.gen_alphanumeric(),
+            request=fauxfactory.gen_alphanumeric()
+        )
+        yield button1, button2
+        button1.delete_if_exists()
+        button2.delete_if_exists()
+
+
 @pytest.mark.meta(automates=[1744478, 1753289])
 def test_custom_group_on_generic_class_crud(appliance, generic_definition):
     """ Test custom button group crud operation on generic class definition
@@ -332,9 +350,8 @@ def test_generic_object_button_delete_flash(button_without_group):
     )
 
 
-@pytest.mark.manual
 @pytest.mark.meta(blockers=[BZ(1753281), BZ(1753388)], coverage=[1753281, 1753388])
-def test_generic_object_button_delete_multiple():
+def test_generic_object_button_delete_multiple(appliance, two_buttons_without_group):
     """
     Bugzilla:
         1753281
@@ -355,7 +372,10 @@ def test_generic_object_button_delete_multiple():
             3.
             4. The second button should be deleted, not both, no 404 error
     """
-    pass
+    view = navigate_to(two_buttons_without_group[1], "Details")
+    view.configuration.item_select('Remove this Custom Button from Inventory', handle_alert=False)
+    view = navigate_to(two_buttons_without_group[0], "Details")
+    assert view.is_displayed
 
 
 @pytest.mark.manual


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: cfme/tests/automate/generic_objects/buttons/test_generic_class_custom_button.py -k "test_generic_object_button_delete_multiple" -v}}
