### PR TITLE
[1LP][RFR] Fix clenaups of VMs.

### DIFF
--- a/cfme/common/vm.py
+++ b/cfme/common/vm.py
@@ -989,7 +989,7 @@ class VM(BaseVM, RetirementMixin):
         Helper method to avoid NotFoundError's during test case tear down.
         """
         if self.exists_on_provider:
-            wait_for(lambda: self.mgmt.cleanup, handle_exception=handle_cleanup_exception,
+            wait_for(self.mgmt.cleanup, handle_exception=handle_cleanup_exception,
                      timeout=300)
         else:
             logger.debug('cleanup_on_provider: entity "%s" does not exist', self.name)


### PR DESCRIPTION
## Purpose or Intent
__Fixing__ VM cleanups. `lambda` was used with attribute access where a call was intended. Fixed by just sending the method (attribute) to the `wait_for` instead of making the `lambda`.

{{py.test: -sv cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_with_additional_volume --long-running --use-provider complete }} 

Without this:
```
cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_with_additional_volume[openstack-13] PASSED                                                                         [100%]
cfme/tests/cloud_infra_common/test_provisioning.py::test_provision_with_additional_volume[openstack-13] ERROR                                                                          [100%]
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> captured stdout >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

Trying to set up provider env-rhos13

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> traceback >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

    def cleanup_and_wait_for_instance_gone():
        instance.mgmt.refresh()
        prov_instance_raw = instance.mgmt.raw
        instance_volumes = getattr(prov_instance_raw, 'os-extended-volumes:volumes_attached')
    
        instance.cleanup_on_provider()
>       wait_for(lambda: not instance.exists_on_provider, num_sec=180, delay=5)
E       wait_for.TimedOutError: Could not do 'lambda defined as `wait_for(lambda: not instance.exists_on_provider, num_sec=180, delay=5)`' at /home/jhenner/work/miq/origin_master/cfme/tests/cloud_infra_common/test_provisioning.py:725 in time

cfme/tests/cloud_infra_common/test_provisioning.py:725: TimedOutError
>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> entering PDB >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>

>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> PDB post_mortem (IO-capturing turned off) >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
[13] > /home/jhenner/work/miq/origin_master/cfme/tests/cloud_infra_common/test_provisioning.py(725)cleanup_and_wait_for_instance_gone()
-> wait_for(lambda: not instance.exists_on_provider, num_sec=180, delay=5)
   4 frames hidden (try 'help hidden_frames')
(Pdb++) q
```