### PR TITLE
[RFR] fix cloud-init tests

### DIFF
--- a/cfme/utils/ssh.py
+++ b/cfme/utils/ssh.py
@@ -33,12 +33,18 @@ from cfme.utils.wait import wait_for
 if typing.TYPE_CHECKING:
     from cfme.base.credential import Credential
 
-# Default blocking time before giving up on an ssh command execution,
-# in seconds (float)
 RUNCMD_TIMEOUT = 1200.0
+""" Default blocking time before giving up on an ssh command execution, in seconds (float)"""
+
 CONNECT_RETRIES_TIMEOUT = 2 * 60
+""" The timeout for the whole connect_ssh. Approximately the amout of time the connect_ssh is
+allowed to keep blocking."""
+
 CONNECT_TIMEOUT = 10
+""" The default for SSHClient timeout parameter. """
+
 CONNECT_SSH_DELAY = 1
+""" The delay between trials to connect the obtained addresses. """
 
 
 @attr.s(frozen=True, eq=False)


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ cloud-init tests that didn't work as they needed IPv6 connectivity between the test executing machine and the VM on provider. This was solved by tunnelling to the provider host and using any IP reported by provder that is connective from the host.
__Adding__ test for DHCP configuration.

{{py.test: -sv cfme/tests/cloud_infra_common/test_cloud_init_provisioning.py::test_provision_cloud_init_payload --long-running --use-provider complete }}