### PR TITLE
Fix dialog dropdown weird behavior.

### DIFF
--- a/cfme/fixtures/ansible_tower.py
+++ b/cfme/fixtures/ansible_tower.py
@@ -79,6 +79,7 @@ def ansible_tower_dialog_rest(request, appliance):
                                 "display": "edit",
                                 "required": True,
                                 "default_value": "QE",
+                                "data_type": "string",
                                 "values": [
                                     [
                                         "HR",


### PR DESCRIPTION
If the type of the dropdown values is not defined, the dialog behaves
weirdly. For example it doesn't make the Submit button available if something is
selected. Also when nothing is touched when Ordering the catalog using this
dialog, Submit btn is enabled.. This quite the oposite how it should work.

This is surely a problem of CFME backend -- it shouldn't allow us to not define
a dropdown without a value type defined. But this cannot happen trough
the UI so perhaps not worthy fixing.

There is probably no test that is broken. I checked the catalog ordering by hand after the test prepared everything
`cfme/tests/services/test_config_provider_servicecatalogs.py::test_order_tower_catalog_item[ansible_tower-3.5-template_survey_job-v1]`

Note that https://github.com/ManageIQ/manageiq/issues/20382 affects the test above.