### PR TITLE
[RFR] Add rhel8.cfg for pxe provisioning

### DIFF
--- a/data/rhel8.cfg
+++ b/data/rhel8.cfg
@@ -1,0 +1,82 @@
+<%
+  # Account for some missing values
+  evm[:root_password]  = root_fallback_password if evm[:root_password].blank?
+  evm[:hostname]       = evm[:vm_target_hostname] if evm[:hostname].blank?
+  evm[:addr_mode]      = ['dhcp'] if evm[:ip_addr].blank? || evm[:subnet_mask].blank? || evm[:gateway].blank?
+
+  rhn_activation_key = ""
+
+  # Dynamically create the network string based on values from the dialog
+  if evm[:addr_mode].first == 'static'
+    network_string = "network --onboot yes --bootproto=static --noipv6"
+    ["ip", :ip_addr, "netmask", :subnet_mask, "gateway", :gateway, "hostname", :hostname, "nameserver", :dns_servers].each_slice(2) do |ks_key, evm_key|
+      network_string << " --#{ks_key} #{evm[evm_key]}" unless evm[evm_key].blank?
+    end
+  else
+    network_string = "network --onboot yes --bootproto=dhcp --noipv6"
+    network_string << " --#{"hostname"} #{evm[:hostname]}" unless evm[:hostname].blank?
+  end
+%>
+# Install OS instead of upgrade
+install
+# Firewall configuration
+firewall --enabled --ssh --service=ssh
+# Use network installation
+url --url="$url1"
+# Network information
+network  --bootproto=dhcp --device=eth0
+# Root password
+rootpw  --iscrypted <%=MiqPassword.md5crypt(evm[:root_password]) %>
+# System authorization information
+auth  --useshadow  --passalgo=sha512
+# Use text mode install
+text
+# System keyboard
+keyboard us
+# System language
+lang en_US
+# SELinux configuration
+selinux --enforcing
+# Do not configure the X Window System
+skipx
+# Installation logging level
+logging --level=info
+# Power Off after installation - Needed to complete EVM provisioning
+shutdown
+# System timezone
+timezone  America/New_York
+# System bootloader configuration
+# Clear the Master Boot Record
+zerombr
+# Partition clearing information
+clearpart --all --initlabel
+# Disk partitioning information
+autopart --fstype=ext4
+bootloader --location=mbr --append="rhgb quiet"
+
+repo --name=rhel-x86_64-server-8 --baseurl=$url1
+repo --name=rhel-x86_64-server-optional-8 --baseurl=$url2
+repo --name=rhv --baseurl=$url3
+
+%packages
+@base
+@core
+xorg-x11-xauth
+nfs-utils
+autofs
+ovirt-guest-agent-common
+wget
+%end
+
+%post --log=/root/kickstart-post.log
+set -x
+
+dhclient
+
+systemctl enable ovirt-guest-agent.service
+systemctl start ovirt-guest-agent.service
+
+
+#Callback to CFME during post-install
+wget --no-check-certificate <%=evm[:post_install_callback_url] %>
+%end


### PR DESCRIPTION
Need a rhel8.cfg file for provisioning testing on rhv44

{{pytest: --long-running --use-provider rhv44 cfme/tests/infrastructure/test_pxe_provisioning.py::test_pxe_provision_from_template }}