### PR TITLE
[1LP][RFR] Automate test_distributed_zone_delete_occupied

### DIFF
--- a/cfme/tests/distributed/test_appliance_manual.py
+++ b/cfme/tests/distributed/test_appliance_manual.py
@@ -37,20 +37,6 @@ def test_distributed_zone_add_provider_to_nondefault_zone():
 
 
 @pytest.mark.tier(1)
-def test_distributed_zone_delete_occupied():
-    """
-    Delete Zone that has appliances in it.
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: Appliance
-        caseimportance: critical
-        initialEstimate: 1/12h
-    """
-    pass
-
-
-@pytest.mark.tier(1)
 def test_distributed_zone_mixed_appliance_ip_versions():
     """
     IPv6 and IPv4 appliances


### PR DESCRIPTION
{{ pytest: -vv --long-running cfme/tests/distributed/test_appliance_replication.py::test_distributed_zone_delete_occupied }}