### PR TITLE
[1LP][RFR] Fix dangerous arg value

### DIFF
--- a/cfme/tests/containers/test_projects_dashboard.py
+++ b/cfme/tests/containers/test_projects_dashboard.py
@@ -38,7 +38,7 @@ def get_api_object_counts(appliance, project_name, provider):
     }
 
 
-def flatten_list(org_list, flattened_list=[]):
+def flatten_list(org_list, flattened_list=None):
     """Expands nested list elements to new flatten list
     Use for get len for of nested list
 
@@ -47,6 +47,9 @@ def flatten_list(org_list, flattened_list=[]):
             flattened_list: (list) empty list
     Returns: flatten list
     """
+    if not flattened_list:
+        flattened_list = []
+
     for elem in org_list:
         if not isinstance(elem, list):
             flattened_list.append(elem)


### PR DESCRIPTION
Using mutable as default arg value is dangerous as it is evaluated once, when function is being created (module loaded).

This value is preserved between each function calls and when modified, the subsequent calls will use the new state of that default object.

```
In [2]: def foo(aaa=[]): 
   ...:     aaa.append(3) 
   ...:     return aaa 
   ...:                                                                                                                                                                                       

In [3]: a=foo()                                                                                                                                                                               

In [4]: a                                                                                                                                                                                     
Out[4]: [3]

In [5]: a=foo()                                                                                                                                                                               

In [6]: a                                                                                                                                                                                     
Out[6]: [3, 3]
```