### PR TITLE
[1LP][RFR] Add missing provider fixture for test_cloud_timelines

### DIFF
--- a/cfme/tests/cloud/test_cloud_timelines.py
+++ b/cfme/tests/cloud/test_cloud_timelines.py
@@ -18,7 +18,7 @@ pytestmark = [
     pytest.mark.tier(2),
     # Only one prov out of the 2 is taken, if not supplying --use-provider=complete
     pytest.mark.provider([AzureProvider, EC2Provider], required_flags=['timelines', 'events']),
-    pytest.mark.usefixtures('setup_provider'),
+    pytest.mark.usefixtures('setup_provider', 'provider'),
     pytest.mark.meta(blockers=[
         GH("ManageIQ/manageiq-providers-amazon:620",
            unblock=lambda provider: not provider.one_of(EC2Provider))


### PR DESCRIPTION
The testcases didn't have `provider` in their fixtures, resulting in un-collection.  