### PR TITLE
[1LP][RFR] Automating dialog test details view

### DIFF
--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -9,23 +9,6 @@ pytestmark = [
 
 
 @pytest.mark.manual
-@pytest.mark.tier(2)
-def test_notification_banner_vm_provisioning_notification_and_service_request_should_be_in_syn():
-    """ Notification Banner - VM Provisioning Notification and Service Request should be in  Sync
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.7
-        tags: service
-    Bugzilla:
-        1389312
-    """
-    pass
-
-
-@pytest.mark.manual
 @pytest.mark.tier(3)
 def test_user_should_be_able_to_see_requests_irrespective_of_tags_assigned():
     """ User should be able to see requests irrespective of tags assigned
@@ -55,25 +38,6 @@ def test_changing_action_order_in_catalog_bundle_should_not_removes_resource():
         tags: service
     Bugzilla:
         1615853
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_notification_banner_service_event_should_be_shown_in_notification_bell():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        initialEstimate: 1/4h
-        testtype: functional
-        startsin: 5.9
-        tags: service
-        testSteps:
-            1. OPS UI  and SSUI service requests should create an event in notification bell
-            2. Also check , Clear All and "MArk as read" in notification bell
-            3. Number of events shown in notification bell
     """
     pass
 


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/services/test_dialog_element_in_catalog.py::test_navigate_details_dialog_view }}

- automated test_edit_dialog_1834219
- removed already covered and non-required test 


<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
