### PR TITLE
[RFR] Use widgetastic_patternfly Kebab

### DIFF
--- a/cfme/fixtures/service_fixtures.py
+++ b/cfme/fixtures/service_fixtures.py
@@ -164,14 +164,14 @@ def order_service(appliance, provider, provisioning, dialog, catalog, request):
     # The above BZ got closed because of  INSUFFICIENT_DATA, so I havve reported the same issue
     # in BZ 775779.
     """ Orders service once the catalog item is created"""
-    if hasattr(request, 'param'):
-        vm_count = request.param['vm_count'] if 'vm_count' in request.param else '1'
-        console_test = request.param['console_test'] if 'console_test' in request.param else False
-
-        catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog,
-                            vm_count=vm_count, console_test=console_test)
-    else:
-        catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog)
+    param = getattr(request, 'param', None)
+    vm_count = '1'
+    console_test = False
+    if isinstance(param, dict):
+        vm_count = param.get('vm_count', vm_count)
+        console_test = param.get('console_test', console_test)
+    catalog_item = create_catalog_item(appliance, provider, provisioning, dialog, catalog,
+                                       vm_count=vm_count, console_test=console_test)
     service_catalogs = ServiceCatalogs(appliance, catalog_item.catalog, catalog_item.name)
     provision_request = service_catalogs.order()
     provision_request.wait_for_request(method='ui')

--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -6,9 +6,9 @@ from widgetastic.widget import TextInput
 from widgetastic_patternfly import Button
 from widgetastic_patternfly import CandidateNotFound
 from widgetastic_patternfly import Input
+from widgetastic_patternfly import Kebab
 
 from cfme.base.ssui import SSUIBaseLoggedInPage
-from cfme.dashboard import Kebab
 from cfme.exceptions import ItemNotFound
 from cfme.services.myservice import MyService
 from cfme.utils.appliance import MiqImplementationContext
@@ -59,7 +59,8 @@ class DetailsMyServiceView(MyServicesView):
 
     notification = Notification()
     policy = SSUIDropdown('Policy')
-    power_operations = Kebab()
+    power_operations = Kebab(
+        locator='.//div[contains(@class, "dropdown-kebab-pf") and ./button][1]')
     access_dropdown = SSUIAppendToBodyDropdown('Access')
     remove_service = Button("Remove Service")
     configuration = SSUIDropdown('Configuration')
@@ -290,10 +291,7 @@ def retire(self):
 @MiqImplementationContext.external_for(MyService.service_power, ViaSSUI)
 def service_power(self, power=None):
     view = navigate_to(self, 'Details')
-    if self.appliance.version < "5.10":
-        view.power_operations.item_select(power)
-    else:
-        view.power_operations.select(power)
+    view.power_operations.item_select(power)
     view.wait_displayed('60s')
     # TODO - assert vm state through rest api
 

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -15,6 +15,7 @@ from cfme.common import TagPageView
 from cfme.common.vm_views import VMDetailsEntities
 from cfme.exceptions import displayed_not_implemented
 from cfme.exceptions import ItemNotFound
+from cfme.exceptions import RestLookupError
 from cfme.services.myservice import MyService
 from cfme.utils.appliance import MiqImplementationContext
 from cfme.utils.appliance.implementations.ui import CFMENavigateStep
@@ -296,7 +297,7 @@ def exists(self):
     try:
         navigate_to(self, 'Details')
         return True
-    except (CandidateNotFound, ItemNotFound):
+    except (CandidateNotFound, ItemNotFound, RestLookupError):
         return False
 
 

--- a/cfme/tests/intelligence/test_dashboard.py
+++ b/cfme/tests/intelligence/test_dashboard.py
@@ -48,12 +48,12 @@ def test_widgets_operation(dashboards, widgets, soft_assert, infra_provider):
         soft_assert(widget.minimized, f'Widget {widget.name} could not be minimized')
         widget.restore()
         soft_assert(not widget.minimized, f'Widget {widget.name} could not be maximized')
-        # TODO: Once modal problems resolved, uncomment
-        # if widget.can_zoom:
-        #     widget.zoom()
-        #     assert widget.is_zoomed
-        #     widget.close_zoom()
-        #     assert not widget.is_zoomed
+
+        if widget.can_zoom:
+            widget.zoom()
+            assert widget.is_zoomed
+            widget.close_zoom()
+            assert not widget.is_zoomed
         widget.footer
         widget.contents
         if widget.content_type in ['chart', 'table']:

--- a/cfme/tests/test_replication.py
+++ b/cfme/tests/test_replication.py
@@ -353,13 +353,13 @@ def test_replication_global_region_dashboard(request, setup_replication):
                   'Top Storage Consumers')
     remote_app_data, global_app_data = {}, {}
 
-    def get_tabel_data(widget):
+    def get_table_data(widget):
         ret = [row.name.text for row in widget.contents]
         logger.info("Widget text data:{%s}" % ret)
         return ret
 
     def data_check(view, table):
-        return bool(get_tabel_data(view.dashboards("Default Dashboard").widgets(table)))
+        return bool(get_table_data(view.dashboards("Default Dashboard").widgets(table)))
 
     view = navigate_to(remote_app.server, "Dashboard")
     for table_name in data_items:
@@ -369,7 +369,7 @@ def test_replication_global_region_dashboard(request, setup_replication):
             fail_func=view.dashboards("Default Dashboard").browser.refresh,
             message=f"Waiting for table data item: {table_name} "
         )
-        remote_app_data[table_name] = get_tabel_data(view.dashboards(
+        remote_app_data[table_name] = get_table_data(view.dashboards(
             "Default Dashboard").widgets(table_name))
 
     view = navigate_to(global_app.server, "Dashboard")
@@ -381,7 +381,7 @@ def test_replication_global_region_dashboard(request, setup_replication):
             message=f"Waiting for table data item: {table_name}"
         )
 
-        global_app_data[table_name] = get_tabel_data(view.dashboards(
+        global_app_data[table_name] = get_table_data(view.dashboards(
             "Default Dashboard").widgets(table_name))
 
     # TODO(ndhandre): Widget not implemented so some widget not checking in this test case they are


### PR DESCRIPTION
This PR removes the `Kebab` class definition from `cfme.dashboard` and uses the `widgetastic_patternfly` one. There are also a few small fixes to fixtures / tests that were failing when trying to run PRT.

{{ pytest: -vv --long-running --use-provider complete -k 'test_widgets_operation or test_service_start' cfme/tests/ssui/test_ssui_myservice.py cfme/tests/intelligence/test_dashboard.py }}