### PR TITLE
[RFR] Automate replication subscription update

### DIFF
--- a/cfme/configure/configuration/region_settings.py
+++ b/cfme/configure/configuration/region_settings.py
@@ -984,7 +984,7 @@ class ReplicationGlobalView(ReplicationView):
     subscription_table = VanillaTable(
         '//form[@id="form_div"]//table[contains(@class, "table")]',
         column_widgets={
-            "Actions": Button("Update"),
+            8: Button("Update"),
             10: Kebab(locator='//td[10]/div[contains(@class, "dropdown-kebab-pf")]')
         }
     )
@@ -1004,17 +1004,12 @@ class ReplicationKebab(Kebab):
 
 class ReplicationGlobalAddView(ReplicationView):
     database = Input(locator='//input[contains(@ng-model, "dbname")]')
-    port = Input(name='port')
     host = Input(locator='//input[contains(@ng-model, "host")]')
-    username = Input(name='userid')
+    username = Input(locator='//input[contains(@ng-model, "user")]')
     password = Input(name='password')
+    port = Input(name='port')
     accept_button = Button('Accept')
-    action_dropdown = ReplicationKebab(
-        locator=(
-            '//tr[contains(@ng-if, "pglogicalReplicationModel.addEnabled")]'
-            '//div[contains(@class, "dropdown-kebab-pf")]'
-        )
-    )
+    action_dropdown = ReplicationKebab(locator='//div[contains(@class, "dropdown-kebab-pf")]')
 
     @property
     def is_displayed(self):
@@ -1082,16 +1077,17 @@ class Replication(NavigatableMixin):
     def _global_replication_row(self, host=None):
         """ Get replication row from table
 
-            Args:
-                host: host values
+            Kwargs:
+                host: :py:class`str` to match on the Host column in the table
             Returns:
-                host row object, of is host is not passed first table row is returned
+                :py:class:`TableRow` of matching row.
+                If host is not specified, then the first table row is returned.
         """
         view = navigate_to(self, 'Global')
         if host:
             return view.subscription_table.row(host=host)
         else:
-            return view.subscription_table.row[0]
+            return view.subscription_table[0]
 
     def get_replication_status(self, replication_type='global', host=None):
         """ Get replication status, if replication is active

--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -31,42 +31,6 @@ def test_configure_icons_roles_by_server():
 @test_requirements.settings
 @test_requirements.multi_region
 @pytest.mark.tier(3)
-def test_replication_subscription_crud():
-    """
-    Add/Edit/Remove replication subscription
-
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: Configuration
-        caseimportance: critical
-        initialEstimate: 1/4h
-        testSteps:
-            1. Set up two appliances where first appliance resides in global region (99) and
-            second one resides in remote region (10). Those should use the same security key
-            2. Add a provider to second appliance
-            3. Set replication subscription type to Remote in second appliance
-            4. Set replication subscription type to Global in first appliance
-            5. Try adding subscription to second appliance with wrong password in first appliance
-            6. Update not working subscription to use correct password
-            7. Delete subscription
-        expectedResults:
-            1.
-            2.
-            3.
-            4.
-            5. Subscription was added. User was prewarned that subscription wasn't established.
-               Provider didn't show up in global appliance.
-            6. Provider and its data showed up in global region appliance
-            7. Subscription was deleted. Provider and its data disappeared from global region
-            appliance.
-    """
-    pass
-
-
-@pytest.mark.manual
-@test_requirements.settings
-@test_requirements.multi_region
-@pytest.mark.tier(3)
 def test_add_duplicate_subscription():
     """
     Try adding duplicate record


### PR DESCRIPTION
Remove the manual test `test_replication_subscription_crud` and automate replication subscription updates in `test_replication_subscription_update`. Creation and deletion tests already exist.

{{ pytest: -vv --long-running -k test_replication_subscription_update cfme/tests/test_replication.py }}