### PR TITLE
[1LP][RFR] - Check STDOUT of provisioned ansible service

### DIFF
--- a/cfme/services/catalogs/catalog_items/__init__.py
+++ b/cfme/services/catalogs/catalog_items/__init__.py
@@ -36,6 +36,7 @@ from widgetastic_manageiq import EntryPoint
 from widgetastic_manageiq import FileInput
 from widgetastic_manageiq import FonticonPicker
 from widgetastic_manageiq import ManageIQTree
+from widgetastic_manageiq import ReactSelect
 from widgetastic_manageiq import SummaryForm
 from widgetastic_manageiq import SummaryFormItem
 from widgetastic_manageiq import SummaryTable
@@ -520,6 +521,32 @@ class BaseCatalogItem(BaseEntity, Updateable, Pretty, Taggable):
         else:
             return False
 
+    def set_ownership(self, owner, group):
+        view = navigate_to(self, "SetOwnership")
+        view.form.select_an_owner.fill(owner)
+        view.form.select_group.fill(group)
+        view.submit.click()
+
+
+class SetOwnershipView(ServicesCatalogView):
+    submit = Button("Submit")
+    reset = Button("Reset")
+    cancel = Button("Cancel")
+
+    @View.nested
+    class form(View):
+        select_an_owner = ReactSelect("user_name")
+        select_group = ReactSelect("group_name")
+
+    @property
+    def is_displayed(self):
+        return (
+            self.form.select_an_owner.is_displayed
+            and self.form.select_group.is_displayed
+            and self.submit.is_displayed
+            and self.cancel.is_enabled
+        )
+
 
 @attr.s
 class CloudInfraCatalogItem(BaseCatalogItem):
@@ -826,3 +853,12 @@ class EditTags(CFMENavigateStep):
 
     def step(self, *args, **kwargs):
         self.prerequisite_view.policy.item_select('Edit Tags')
+
+
+@navigator.register(BaseCatalogItem, "SetOwnership")
+class CatalogItemSetOwnership(CFMENavigateStep):
+    VIEW = SetOwnershipView
+    prerequisite = NavigateToSibling("Details")
+
+    def step(self, *args, **kwargs):
+        self.prerequisite_view.configuration.item_select("Set Ownership")

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -144,7 +144,7 @@ class MyServiceDetailView(MyServicesView):
                       'normalize-space(.)="Plays"]]')
         details = SummaryTable(title='Details')
         credentials = SummaryTable(title='Credentials')
-        standart_output = Text('.//div[@id="provisioning"]//pre')
+        standart_output = Text('.//div[@id="provisioning"]/ansible-raw-stdout')
 
     @View.nested
     class retirement(View):  # noqa

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -701,8 +701,10 @@ def test_ansible_group_id_in_payload(
     ansible_service_catalog.order()
     ansible_service_request.wait_for_request()
     view = navigate_to(ansible_service, "Details")
+    view.provisioning_tab.click()
+    assert view.provisioning.standart_output.is_displayed
+    wait_for(lambda: view.provisioning.standart_output.text != "Loading...", timeout=30)
     stdout = view.provisioning.standart_output
-    wait_for(lambda: stdout.is_displayed, timeout=10)
     pre = stdout.text
     json_str = pre.split("--------------------------------")
     # Standard output has several sections splitted by --------------------------------

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -1746,8 +1746,8 @@ def test_appliance_overwrite_ssl_ipa(unconfigured_appliance, freeipa_provider):
 
 
 @pytest.mark.tier(0)
-@pytest.mark.manual
 @pytest.mark.meta(coverage=[1720223])
+@pytest.mark.manual("manualonly")
 def test_appliance_console_logfile_config_reboot():
     """
         test to verify logfiles disk


### PR DESCRIPTION
- Added test to check provisioned service's standard output of particular user
- Fixed standard_output locator of service
- Written view for "Set Ownership" for ansible catalog item.
- `test_appliance_console_logfile_config_reboot` moved test to manual only because need large effort to automate it.

{{pytest: cfme/tests/configure/test_access_control.py::test_ansible_playbook_stdout cfme/tests/ansible/test_embedded_ansible_services.py::test_ansible_group_id_in_payload  cfme/tests/ansible/test_embedded_ansible_services.py::test_service_ansible_playbook_pass_extra_vars  --long-running -v}}

