### PR TITLE
[1LP][RFR][NOTEST] Remove manual test test_distributed_zone_in_different_networks

### DIFF
--- a/cfme/tests/distributed/test_appliance_manual.py
+++ b/cfme/tests/distributed/test_appliance_manual.py
@@ -50,16 +50,6 @@ def test_distributed_zone_mixed_appliance_ip_versions():
     pass
 
 
-def test_distributed_zone_in_different_networks():
-    """
-    Polarion:
-        assignee: tpapaioa
-        casecomponent: Infra
-        initialEstimate: 1h
-    """
-    pass
-
-
 def test_distributed_diagnostics_servers_view():
     """
 


### PR DESCRIPTION
This PR removes the manual test `test_distributed_zone_in_different_networks`. It doesn't appear to be based on any known BZ or customer case, and general distributed / multi-appliance functionality is already automated in other tests.