### PR TITLE
[RFR] browser chrome options

### DIFF
--- a/cfme/utils/browser.py
+++ b/cfme/utils/browser.py
@@ -257,7 +257,7 @@ class BrowserManager:
                 if browser_conf[
                         'webdriver_options'][
                             'desired_capabilities']['browserName'].lower() == 'chrome':
-                    browser_kwargs['desired_capabilities']['chromeOptions'] = {}
+                    browser_kwargs['desired_capabilities'].setdefault('chromeOptions', {})
                     browser_kwargs[
                         'desired_capabilities']['chromeOptions']['args'] = ['--no-sandbox',
                                                                             '--start-maximized',


### PR DESCRIPTION
When the chromeOptions was set, we should not throw them away, but keep them. I found this when trying to debug some problem with the selenium and chrome. IIRC it was the parameters set in env.yaml.local which were not honoured.