### PR TITLE
[1LP][RFR] Refactor ansible service fixtures and embedded services tests

### DIFF
--- a/cfme/automate/explorer/method.py
+++ b/cfme/automate/explorer/method.py
@@ -448,13 +448,12 @@ class MethodCollection(BaseCollection):
     def create(
             self, name=None, display_name=None, location='inline', script=None, data=None,
             cancel=False, validate=True, repository=None, playbook=None, machine_credential=None,
-            hosts=None, max_ttl=None, logging_output=None, escalate_privilege=None, verbosity=None,
+            hosts=None, max_ttl=5, logging_output=None, escalate_privilege=None, verbosity=None,
             playbook_input_parameters=None, inputs=None, embedded_method=None):
 
         add_page = navigate_to(self, 'Add')
 
-        if self.browser.product_version > '5.11' and location.islower():
-            location = location.capitalize()
+        location = location.capitalize()
 
         add_page.fill({'location': location})
         if location.lower() == 'inline':

--- a/cfme/fixtures/ansible_fixtures.py
+++ b/cfme/fixtures/ansible_fixtures.py
@@ -118,7 +118,7 @@ def ansible_private_repository(request, appliance, ansible_scm_credentials):
     repository.delete_if_exists()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def ansible_catalog_item(appliance, ansible_repository):
     collection = appliance.collections.catalog_items
     cat_item = collection.create(
@@ -146,7 +146,7 @@ def ansible_catalog_item(appliance, ansible_repository):
     cat_item.delete_if_exists()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def ansible_catalog(appliance, ansible_catalog_item):
     catalog = appliance.collections.catalogs.create(fauxfactory.gen_alphanumeric(),
                                                     description="my ansible catalog",
@@ -159,7 +159,7 @@ def ansible_catalog(appliance, ansible_catalog_item):
         ansible_catalog_item.catalog = None
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def ansible_service_catalog(appliance, ansible_catalog_item, ansible_catalog):
     service_catalog = ServiceCatalogs(appliance, ansible_catalog, ansible_catalog_item.name)
     return service_catalog
@@ -200,7 +200,7 @@ def ansible_service(appliance, ansible_catalog_item):
         service.delete()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def order_ansible_service_in_ops_ui(appliance, ansible_catalog_item,
                                     ansible_service_catalog):
     """Orders an ansible service through the UI
@@ -220,7 +220,7 @@ def order_ansible_service_in_ops_ui(appliance, ansible_catalog_item,
         service.delete()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def ansible_catalog_item_create_empty_file(appliance, ansible_repository):
     collection = appliance.collections.catalog_items
     cat_item = collection.create(

--- a/cfme/fixtures/ansible_fixtures.py
+++ b/cfme/fixtures/ansible_fixtures.py
@@ -171,7 +171,7 @@ def bulk_service_teardown(appliance):
     requests = [r for r in appliance.rest_api.collections.service_requests]
     if requests:
         delete_resources_from_collection(
-            resources=[r for r in appliance.rest_api.collections.service_requests],
+            resources=requests,
             collection=appliance.rest_api.collections.service_requests,
             check_response=False
         )

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -35,6 +35,7 @@ from widgetastic_manageiq import ParametrizedSummaryTable
 from widgetastic_manageiq import ReactTextInput
 from widgetastic_manageiq import Search
 from widgetastic_manageiq import SummaryTable
+from widgetastic_manageiq import WaitTab
 
 
 class MyServiceToolbar(View):
@@ -135,11 +136,10 @@ class MyServiceDetailView(MyServicesView):
     title = Text('#explorer_title_text')
     toolbar = View.nested(MyServiceDetailsToolbar)
     entities = View.nested(MyServiceDetailsEntities)
-    provisioning_tab = Text('//*[@id="provisioning_tab"]')
-    retirement_tab = Text('//*[@id="retirement_tab"]')
 
     @View.nested
-    class provisioning(View):  # noqa
+    class provisioning(WaitTab):  # noqa
+        TAB_NAME = 'Provisioning'
         results = SummaryTable(title='Results')
         plays = Table('.//table[./thead/tr/th[contains(@align, "left") and '
                       'normalize-space(.)="Plays"]]')
@@ -148,20 +148,23 @@ class MyServiceDetailView(MyServicesView):
         standart_output = Text('.//div[@id="provisioning"]/ansible-raw-stdout')
 
     @View.nested
-    class retirement(View):  # noqa
+    class retirement(WaitTab):  # noqa
+        TAB_NAME = 'Retirement'
         results = SummaryTable(title='Results')
         plays = Table('.//table[./thead/tr/th[contains(@align, "left") and '
                       'normalize-space(.)="Plays"]]')
         details = SummaryTable(title='Details')
         credentials = SummaryTable(title='Credentials')
-        standart_output = Text('.//div[@id="retirement"]//pre')
+        standard_output = Text('.//div[@id="retirement"]//pre')
 
     @property
     def is_displayed(self):
+        expected_name = self.context["object"].name
         return (
             self.in_myservices and
             self.myservice.is_opened and
-            self.title.text == 'Service "{}"'.format(self.context['object'].name))
+            self.title.text == f'Service "{expected_name}"'
+        )
 
 
 class EditMyServiceView(ServiceEditForm):

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -145,7 +145,8 @@ class MyServiceDetailView(MyServicesView):
                       'normalize-space(.)="Plays"]]')
         details = SummaryTable(title='Details')
         credentials = SummaryTable(title='Credentials')
-        standart_output = Text('.//div[@id="provisioning"]/ansible-raw-stdout')
+        standard_output = Text('.//div[h3[normalize-space(.)="Standard Output"]]'
+                               '//div[contains(@class, "term-container")]')
 
     @View.nested
     class retirement(WaitTab):  # noqa
@@ -155,7 +156,8 @@ class MyServiceDetailView(MyServicesView):
                       'normalize-space(.)="Plays"]]')
         details = SummaryTable(title='Details')
         credentials = SummaryTable(title='Credentials')
-        standard_output = Text('.//div[@id="retirement"]//pre')
+        standard_output = Text('.//div[h3[normalize-space(.)="Standard Output"]]'
+                               '//div[contains(@class, "term-container")]')
 
     @property
     def is_displayed(self):

--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -81,20 +81,24 @@ class Request(BaseEntity):
     def rest(self):
         if self.partial_check:
             matching_requests = self.appliance.rest_api.collections.requests.find_by(
-                description='%{}%'.format(self.cells['Description']))
+                description=f'%{self.cells["Description"]}%')
         else:
             matching_requests = self.appliance.rest_api.collections.requests.find_by(
                 description=self.cells['Description'])
 
         if len(matching_requests) > 1:
+            # TODO: This forces anything using requests to handle this exception
+            # The class needs support for identifying a request by its ID
+            # This ID might not be available on instantiation, but needs to be set somehow
+            # Ideally before MIQ receives multiple orders for the same service, which have same desc
             raise RequestException(
-                'Multiple requests with matching \"{}\" '
-                'found - be more specific!'.format(
-                    self.description))
+                f'Multiple requests with matching "{self.description}" found - be more specific!'
+            )
         elif len(matching_requests) == 0:
             raise ItemNotFound(
-                'Nothing matching "{}" with partial_check={} was found'.format(
-                    self.cells['Description'], self.partial_check))
+                f'Nothing matching "{self.cells["Description"]}" with '
+                f'partial_check={self.partial_check} was found'
+            )
         else:
             return matching_requests[0]
 

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -20,7 +20,7 @@ pytestmark = [
 ]
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def ansible_action(appliance, ansible_catalog_item):
     action_collection = appliance.collections.actions
     action = action_collection.create(
@@ -35,13 +35,12 @@ def ansible_action(appliance, ansible_catalog_item):
     action.delete_if_exists()
 
 
-@pytest.fixture(scope="module")
-def policy_for_testing(appliance, create_vm_modscope, provider, ansible_action):
-    vm = create_vm_modscope
+@pytest.fixture(scope="function")
+def policy_for_testing(appliance, create_vm, provider, ansible_action):
     policy = appliance.collections.policies.create(
         VMControlPolicy,
         fauxfactory.gen_alpha(15, start="policy_"),
-        scope=f"fill_field(VM and Instance : Name, INCLUDES, {vm.name})",
+        scope=f"fill_field(VM and Instance : Name, INCLUDES, {create_vm.name})",
     )
     policy.assign_actions_to_event("Tag Complete", [ansible_action.description])
     policy_profile = appliance.collections.policy_profiles.create(
@@ -71,13 +70,13 @@ def ansible_credential(wait_for_ansible, appliance, full_template_modscope):
 
 
 @pytest.mark.tier(3)
-@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+@pytest.mark.parametrize("create_vm", ["full_template"], indirect=True)
 def test_action_run_ansible_playbook_localhost(
     request,
     ansible_catalog_item,
     ansible_action,
     policy_for_testing,
-    create_vm_modscope,
+    create_vm,
     ansible_credential,
     ansible_service_request,
     ansible_service,
@@ -92,8 +91,7 @@ def test_action_run_ansible_playbook_localhost(
     """
     with update(ansible_action):
         ansible_action.run_ansible_playbook = {"inventory": {"localhost": True}}
-    added_tag = create_vm_modscope.add_tag()
-    request.addfinalizer(lambda: create_vm_modscope.remove_tag(added_tag))
+    create_vm.add_tag()
     wait_for(ansible_service_request.exists, num_sec=600)
     ansible_service_request.wait_for_request()
     view = navigate_to(ansible_service, "Details")
@@ -103,13 +101,13 @@ def test_action_run_ansible_playbook_localhost(
 
 @pytest.mark.meta(blockers=[BZ(1822533, forced_streams=["5.11", "5.10"])])
 @pytest.mark.tier(3)
-@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+@pytest.mark.parametrize("create_vm", ["full_template"], indirect=True)
 def test_action_run_ansible_playbook_manual_address(
     request,
     ansible_catalog_item,
     ansible_action,
     policy_for_testing,
-    create_vm_modscope,
+    create_vm,
     ansible_credential,
     ansible_service_request,
     ansible_service,
@@ -122,31 +120,29 @@ def test_action_run_ansible_playbook_manual_address(
         initialEstimate: 1/6h
         casecomponent: Ansible
     """
-    vm = create_vm_modscope
     with update(ansible_catalog_item):
         ansible_catalog_item.provisioning = {"machine_credential": ansible_credential.name}
     with update(ansible_action):
         ansible_action.run_ansible_playbook = {
-            "inventory": {"specific_hosts": True, "hosts": vm.ip_address}
+            "inventory": {"specific_hosts": True, "hosts": create_vm.ip_address}
         }
-    added_tag = vm.add_tag()
-    request.addfinalizer(lambda: vm.remove_tag(added_tag))
+    create_vm.add_tag()
     wait_for(ansible_service_request.exists, num_sec=600)
     ansible_service_request.wait_for_request()
     view = navigate_to(ansible_service, "Details")
-    assert view.provisioning.details.get_text_of("Hosts") == vm.ip_address
+    assert view.provisioning.details.get_text_of("Hosts") == create_vm.ip_address
     assert view.provisioning.results.get_text_of("Status") == "Finished"
 
 
 @pytest.mark.meta(blockers=[BZ(1822533, forced_streams=["5.11", "5.10"])])
 @pytest.mark.tier(3)
-@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+@pytest.mark.parametrize("create_vm", ["full_template"], indirect=True)
 def test_action_run_ansible_playbook_target_machine(
     request,
     ansible_catalog_item,
     ansible_action,
     policy_for_testing,
-    create_vm_modscope,
+    create_vm,
     ansible_credential,
     ansible_service_request,
     ansible_service,
@@ -159,24 +155,22 @@ def test_action_run_ansible_playbook_target_machine(
         initialEstimate: 1/6h
         casecomponent: Ansible
     """
-    vm = create_vm_modscope
     with update(ansible_action):
         ansible_action.run_ansible_playbook = {"inventory": {"target_machine": True}}
-    added_tag = vm.add_tag()
-    request.addfinalizer(lambda: vm.remove_tag(added_tag))
+    create_vm.add_tag()
     wait_for(ansible_service_request.exists, num_sec=600)
     ansible_service_request.wait_for_request()
     view = navigate_to(ansible_service, "Details")
-    assert view.provisioning.details.get_text_of("Hosts") == vm.ip_address
+    assert view.provisioning.details.get_text_of("Hosts") == create_vm.ip_address
     assert view.provisioning.results.get_text_of("Status") == "Finished"
 
 
 @pytest.mark.tier(3)
-@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
+@pytest.mark.parametrize("create_vm", ["full_template"], indirect=True)
 def test_action_run_ansible_playbook_unavailable_address(
     request,
     ansible_catalog_item,
-    create_vm_modscope,
+    create_vm,
     ansible_action,
     policy_for_testing,
     ansible_credential,
@@ -191,35 +185,15 @@ def test_action_run_ansible_playbook_unavailable_address(
         initialEstimate: 1/6h
         casecomponent: Ansible
     """
-    vm = create_vm_modscope
     with update(ansible_catalog_item):
         ansible_catalog_item.provisioning = {"machine_credential": ansible_credential.name}
     with update(ansible_action):
         ansible_action.run_ansible_playbook = {
             "inventory": {"specific_hosts": True, "hosts": "unavailable_address"}
         }
-    added_tag = vm.add_tag()
-    request.addfinalizer(lambda: vm.remove_tag(added_tag))
+    create_vm.add_tag()
     wait_for(ansible_service_request.exists, num_sec=600)
     ansible_service_request.wait_for_request()
     view = navigate_to(ansible_service, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == "unavailable_address"
     assert view.provisioning.results.get_text_of("Status") == "Finished"
-
-
-@pytest.mark.tier(3)
-@pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
-def test_control_action_run_ansible_playbook_in_requests(
-    request, create_vm_modscope, policy_for_testing, ansible_service_request
-):
-    """Checks if execution of the Action result in a Task/Request being created.
-
-    Polarion:
-        assignee: gtalreja
-        initialEstimate: 1/6h
-        casecomponent: Ansible
-    """
-    vm = create_vm_modscope
-    added_tag = vm.add_tag()
-    request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    assert ansible_service_request.exists

--- a/cfme/tests/ansible/test_embedded_ansible_actions.py
+++ b/cfme/tests/ansible/test_embedded_ansible_actions.py
@@ -79,8 +79,8 @@ def test_action_run_ansible_playbook_localhost(
     policy_for_testing,
     create_vm_modscope,
     ansible_credential,
-    ansible_service_request_funcscope,
-    ansible_service_funcscope,
+    ansible_service_request,
+    ansible_service,
     appliance,
 ):
     """Tests a policy with ansible playbook action against localhost.
@@ -94,12 +94,11 @@ def test_action_run_ansible_playbook_localhost(
         ansible_action.run_ansible_playbook = {"inventory": {"localhost": True}}
     added_tag = create_vm_modscope.add_tag()
     request.addfinalizer(lambda: create_vm_modscope.remove_tag(added_tag))
-    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
-    ansible_service_request_funcscope.wait_for_request()
-    view = navigate_to(ansible_service_funcscope, "Details")
+    wait_for(ansible_service_request.exists, num_sec=600)
+    ansible_service_request.wait_for_request()
+    view = navigate_to(ansible_service, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == "localhost"
-    status = "successful" if appliance.version < "5.11" else "Finished"
-    assert view.provisioning.results.get_text_of("Status") == status
+    assert view.provisioning.results.get_text_of("Status") == "Finished"
 
 
 @pytest.mark.meta(blockers=[BZ(1822533, forced_streams=["5.11", "5.10"])])
@@ -112,8 +111,8 @@ def test_action_run_ansible_playbook_manual_address(
     policy_for_testing,
     create_vm_modscope,
     ansible_credential,
-    ansible_service_request_funcscope,
-    ansible_service_funcscope,
+    ansible_service_request,
+    ansible_service,
     appliance,
 ):
     """Tests a policy with ansible playbook action against manual address.
@@ -132,12 +131,11 @@ def test_action_run_ansible_playbook_manual_address(
         }
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
-    ansible_service_request_funcscope.wait_for_request()
-    view = navigate_to(ansible_service_funcscope, "Details")
+    wait_for(ansible_service_request.exists, num_sec=600)
+    ansible_service_request.wait_for_request()
+    view = navigate_to(ansible_service, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == vm.ip_address
-    status = "successful" if appliance.version < "5.11" else "Finished"
-    assert view.provisioning.results.get_text_of("Status") == status
+    assert view.provisioning.results.get_text_of("Status") == "Finished"
 
 
 @pytest.mark.meta(blockers=[BZ(1822533, forced_streams=["5.11", "5.10"])])
@@ -150,8 +148,8 @@ def test_action_run_ansible_playbook_target_machine(
     policy_for_testing,
     create_vm_modscope,
     ansible_credential,
-    ansible_service_request_funcscope,
-    ansible_service_funcscope,
+    ansible_service_request,
+    ansible_service,
     appliance,
 ):
     """Tests a policy with ansible playbook action against target machine.
@@ -166,12 +164,11 @@ def test_action_run_ansible_playbook_target_machine(
         ansible_action.run_ansible_playbook = {"inventory": {"target_machine": True}}
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
-    ansible_service_request_funcscope.wait_for_request()
-    view = navigate_to(ansible_service_funcscope, "Details")
+    wait_for(ansible_service_request.exists, num_sec=600)
+    ansible_service_request.wait_for_request()
+    view = navigate_to(ansible_service, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == vm.ip_address
-    status = "successful" if appliance.version < "5.11" else "Finished"
-    assert view.provisioning.results.get_text_of("Status") == status
+    assert view.provisioning.results.get_text_of("Status") == "Finished"
 
 
 @pytest.mark.tier(3)
@@ -183,8 +180,8 @@ def test_action_run_ansible_playbook_unavailable_address(
     ansible_action,
     policy_for_testing,
     ansible_credential,
-    ansible_service_request_funcscope,
-    ansible_service_funcscope,
+    ansible_service_request,
+    ansible_service,
     appliance,
 ):
     """Tests a policy with ansible playbook action against unavailable address.
@@ -203,18 +200,17 @@ def test_action_run_ansible_playbook_unavailable_address(
         }
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
-    ansible_service_request_funcscope.wait_for_request()
-    view = navigate_to(ansible_service_funcscope, "Details")
+    wait_for(ansible_service_request.exists, num_sec=600)
+    ansible_service_request.wait_for_request()
+    view = navigate_to(ansible_service, "Details")
     assert view.provisioning.details.get_text_of("Hosts") == "unavailable_address"
-    status = "failed" if appliance.version < "5.11" else "Finished"
-    assert view.provisioning.results.get_text_of("Status") == status
+    assert view.provisioning.results.get_text_of("Status") == "Finished"
 
 
 @pytest.mark.tier(3)
 @pytest.mark.parametrize("create_vm_modscope", ["full_template"], indirect=True)
 def test_control_action_run_ansible_playbook_in_requests(
-    request, create_vm_modscope, policy_for_testing, ansible_service_request_funcscope
+    request, create_vm_modscope, policy_for_testing, ansible_service_request
 ):
     """Checks if execution of the Action result in a Task/Request being created.
 
@@ -226,4 +222,4 @@ def test_control_action_run_ansible_playbook_in_requests(
     vm = create_vm_modscope
     added_tag = vm.add_tag()
     request.addfinalizer(lambda: vm.remove_tag(added_tag))
-    assert ansible_service_request_funcscope.exists
+    assert ansible_service_request.exists

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -426,13 +426,12 @@ def test_variable_pass(request, appliance, setup_ansible_repository, import_data
             r".*if Fred is married to Wilma and Barney is married to Betty and Peebles and BamBam "
             "are the kids, then the tests work !!!.*"
         ],
-    ).waiting(timeout=600):
+    ).waiting(wait=600):
         # Ordering service catalog bundle
         service_catalog.order()
         provision_request = appliance.collections.requests.instantiate(
             f"Provisioning Service [{catalog_item.name}] from [{catalog_item.name}]"
         )
-        request.addfinalizer(provision_request.remove_request)
         provision_request.wait_for_request(method="ui")
 
 

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -76,7 +76,7 @@ def management_event_instance(management_event_class, management_event_method):
     )
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def custom_vm_button(appliance, ansible_catalog_item):
     buttongroup = appliance.collections.button_groups.create(
         text=fauxfactory.gen_alphanumeric(start="grp_"),

--- a/cfme/tests/ansible/test_embedded_ansible_automate.py
+++ b/cfme/tests/ansible/test_embedded_ansible_automate.py
@@ -219,8 +219,8 @@ def test_ansible_playbook_button_crud(ansible_catalog_item, appliance, request):
 
 @pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
 def test_embedded_ansible_custom_button_localhost(create_vm_modscope, custom_vm_button,
-        appliance, ansible_service_request_funcscope,
-        ansible_service_funcscope, ansible_catalog_item):
+        appliance, ansible_service_request,
+        ansible_service, ansible_catalog_item):
     """
     Polarion:
         assignee: gtalreja
@@ -235,9 +235,9 @@ def test_embedded_ansible_custom_button_localhost(create_vm_modscope, custom_vm_
     order_dialog_view.submit_button.wait_displayed()
     order_dialog_view.fields("credential").fill("CFME Default Credential")
     order_dialog_view.submit_button.click()
-    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
-    ansible_service_request_funcscope.wait_for_request()
-    view = navigate_to(ansible_service_funcscope, "Details")
+    wait_for(ansible_service_request.exists, num_sec=600)
+    ansible_service_request.wait_for_request()
+    view = navigate_to(ansible_service, "Details")
     hosts = view.provisioning.details.get_text_of("Hosts")
     assert hosts == "localhost"
     status = "successful" if appliance.version < "5.11" else "Finished"
@@ -246,8 +246,8 @@ def test_embedded_ansible_custom_button_localhost(create_vm_modscope, custom_vm_
 
 @pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
 def test_embedded_ansible_custom_button_target_machine(create_vm_modscope, custom_vm_button,
-        ansible_credential, appliance, ansible_service_request_funcscope,
-        ansible_service_funcscope):
+        ansible_credential, appliance, ansible_service_request,
+        ansible_service):
     """
     Polarion:
         assignee: gtalreja
@@ -262,9 +262,9 @@ def test_embedded_ansible_custom_button_target_machine(create_vm_modscope, custo
     order_dialog_view.submit_button.wait_displayed()
     order_dialog_view.fields("credential").fill(ansible_credential.name)
     order_dialog_view.submit_button.click()
-    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
-    ansible_service_request_funcscope.wait_for_request()
-    view = navigate_to(ansible_service_funcscope, "Details")
+    wait_for(ansible_service_request.exists, num_sec=600)
+    ansible_service_request.wait_for_request()
+    view = navigate_to(ansible_service, "Details")
     hosts = view.provisioning.details.get_text_of("Hosts")
     assert hosts == create_vm_modscope.ip_address
     status = "successful" if appliance.version < "5.11" else "Finished"
@@ -273,8 +273,8 @@ def test_embedded_ansible_custom_button_target_machine(create_vm_modscope, custo
 
 @pytest.mark.parametrize('create_vm_modscope', ['full_template'], indirect=True)
 def test_embedded_ansible_custom_button_specific_hosts(create_vm_modscope, custom_vm_button,
-        ansible_credential, appliance, ansible_service_request_funcscope,
-        ansible_service_funcscope):
+        ansible_credential, appliance, ansible_service_request,
+        ansible_service):
     """
     Polarion:
         assignee: gtalreja
@@ -290,9 +290,9 @@ def test_embedded_ansible_custom_button_specific_hosts(create_vm_modscope, custo
     order_dialog_view.submit_button.wait_displayed()
     order_dialog_view.fields("credential").fill(ansible_credential.name)
     order_dialog_view.submit_button.click()
-    wait_for(ansible_service_request_funcscope.exists, num_sec=600)
-    ansible_service_request_funcscope.wait_for_request()
-    view = navigate_to(ansible_service_funcscope, "Details")
+    wait_for(ansible_service_request.exists, num_sec=600)
+    ansible_service_request.wait_for_request()
+    view = navigate_to(ansible_service, "Details")
     hosts = view.provisioning.details.get_text_of("Hosts")
     assert hosts == create_vm_modscope.ip_address
     status = "successful" if appliance.version < "5.11" else "Finished"

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -799,21 +799,20 @@ def test_service_ansible_verbosity(
 
     view = navigate_to(ansible_service, "Details")
     assert verbosity[0] == view.provisioning.details.get_text_of("Verbosity")
-    assert verbosity[0] == view.retirement.details.get_text_of("Verbosity")
 
 
 @pytest.mark.tier(3)
 @pytest.mark.provider([VMwareProvider])
-@pytest.mark.usefixtures("setup_provider")
-@pytest.mark.parametrize('create_vm', ['big_template'], indirect=True)
 @pytest.mark.meta(automates=[BZ(1448918)])
 def test_ansible_service_linked_vm(
     appliance,
-    create_vm,
+    provider,
+    setup_provider,
     ansible_policy_linked_vm,
     ansible_service_request,
     ansible_service,
-    request,
+    ansible_service_catalog,
+    ansible_catalog_item
 ):
     """Check Whether service has associated VM attached to it.
 
@@ -826,12 +825,16 @@ def test_ansible_service_linked_vm(
         initialEstimate: 1/3h
         tags: ansible_embed
     """
-    create_vm.add_tag()
-    wait_for(lambda: ansible_service_request.exists, num_sec=600)
+    ansible_service_catalog.order()
+    service_vm = appliance.provider_based_collection(provider).instantiate(
+        name=f"{ansible_catalog_item.prov_data['catalog']['vm_name']}0001",
+        provider=provider
+    )
+    wait_for(lambda: ansible_service_request.exists, num_sec=60)
     ansible_service_request.wait_for_request()
 
     view = navigate_to(ansible_service, "Details")
-    assert create_vm.name in view.entities.vms.all_entity_names
+    assert service_vm.name in view.entities.vms.all_entity_names
 
 
 @pytest.mark.tier(1)

--- a/cfme/tests/ansible/test_embedded_ansible_services.py
+++ b/cfme/tests/ansible/test_embedded_ansible_services.py
@@ -664,8 +664,6 @@ def test_ansible_group_id_in_payload(
     reason='Credential type not valid for parametrized provider'
 )
 def test_embed_tower_exec_play_against(
-    appliance,
-    request,
     ansible_catalog_item,
     ansible_service_request,
     ansible_service,
@@ -693,7 +691,7 @@ def test_embed_tower_exec_play_against(
     service_request.wait_for_request(num_sec=300, delay=20)
 
     view = navigate_to(ansible_service, "Details")
-    assert view.provisioning.results.get_text_of("Status") == "successful"
+    assert view.provisioning.results.get_text_of("Status") == "Finished"
 
 
 @pytest.mark.tier(2)

--- a/cfme/utils/log_validator.py
+++ b/cfme/utils/log_validator.py
@@ -137,9 +137,13 @@ class LogValidator:
             TimedOutError: If failed to match pattern in respective timeout
             FailPatternMatchError: If failure pattern matched
         """
-        delay = kwargs.pop('delay', 5)
+        wait = kwargs.pop('timeout', None) or wait
         if wait:
-            wait_for(lambda: self._is_valid, delay=delay, timeout=wait, message=message, **kwargs)
+            wait_for(lambda: self._is_valid,
+                     delay=kwargs.pop('delay', 5),
+                     timeout=wait,
+                     message=message,
+                     **kwargs)
             return True
         else:
             return self._is_valid


### PR DESCRIPTION
Renamed funcscope
Test failures due to the requests having the same name when coming from the same catalog item
The requests should be cleaned up after every test to ensure there's no collision, and that no test has to assume which of the requests are related to the catalog item ordered for that test scope

This should resolve some failures seen in PRT on #10289

# PRT Results

There are some tests still failing, but I'd like to scope the PR at the current changes. @Gauravtalreja1 has already been keeping an eye on them, and can follow-up this PR with specific test fixes.

`test_embedded_ansible_services` pass rate increased from 40% to ~72%