### PR TITLE
[1LP][RFR] Sort out DB HA related tests

### DIFF
--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -2,7 +2,7 @@ import pytest
 from wait_for import wait_for
 
 from cfme import test_requirements
-from cfme.utils.appliance.console import waiting_for_ha_monitor_started
+from cfme.utils.appliance.console import check_db_ha_failover
 from cfme.utils.log_validator import LogValidator
 
 pytestmark = [
@@ -270,17 +270,4 @@ def test_appliance_console_cli_ha_crud(unconfigured_appliances, app_creds):
         'vmdb_production', apps[1].unpartitioned_disks[0]
     )
 
-    with waiting_for_ha_monitor_started(apps[2], app1_ip, timeout=300):
-        # Configure automatic failover on EVM appliance
-        command_set = ('ap', '', '10', '1', '')
-        apps[2].appliance_console.run_commands(command_set)
-
-    with LogValidator(evm_log,
-                      matched_patterns=['Starting to execute failover'],
-                      hostname=apps[2].hostname).waiting(timeout=450):
-        # Cause failover to occur
-        result = apps[0].ssh_client.run_command('systemctl stop $APPLIANCE_PG_SERVICE', timeout=15)
-        assert result.success, f"Failed to stop APPLIANCE_PG_SERVICE: {result.output}"
-
-    apps[2].evmserverd.wait_for_running()
-    apps[2].wait_for_miq_ready()
+    check_db_ha_failover(apps[0], apps[2])

--- a/cfme/tests/cli/test_appliance_cli.py
+++ b/cfme/tests/cli/test_appliance_cli.py
@@ -3,6 +3,7 @@ from wait_for import wait_for
 
 from cfme import test_requirements
 from cfme.utils.appliance.console import check_db_ha_failover
+from cfme.utils.blockers import GH
 from cfme.utils.log_validator import LogValidator
 
 pytestmark = [
@@ -236,6 +237,7 @@ def test_appliance_console_cli_configure_dedicated_db(unconfigured_appliance, ap
 
 @test_requirements.ha_proxy
 @pytest.mark.tier(2)
+@pytest.mark.meta(blockers=[GH('ManageIQ/manageiq:20455')])
 def test_appliance_console_cli_ha_crud(unconfigured_appliances, app_creds):
     """Tests the configuration of HA with three appliances including failover to standby node
 

--- a/cfme/tests/cli/test_appliance_console.py
+++ b/cfme/tests/cli/test_appliance_console.py
@@ -702,37 +702,6 @@ def test_appliance_console_restart(temp_appliance_preconfig_funcscope):
     navigate_to(appliance.server, "LoggedIn")
 
 
-@test_requirements.ha_proxy
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_appliance_console_ha_dc_re_establish():
-    """
-    Test that upon re-connection of networks the repmgr process continues
-    to replicate correctly to the disconnected node within DC2.
-    To setup HA follow:
-    https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.7/h
-    tml/high_availability_guide//installation
-
-    Polarion:
-        assignee: jhenner
-        casecomponent: HAProxy
-        initialEstimate: 1/2h
-        setup: Restore network connectivity between DC1 and DC2
-        startsin: 5.8
-        testSteps:
-            1. Setup HA
-            2. Disconnect DC2.
-            3. Check repmgr process replicating to DC1.
-            4. Restore network connectivity between DC1 and DC2
-        expectedResults:
-            1.
-            2.
-            3.
-            4. Confirm replication is working correctly
-    """
-    pass
-
-
 @pytest.mark.tier(2)
 def test_appliance_console_evm_stop(temp_appliance_preconfig_funcscope):
     """

--- a/cfme/tests/cli/test_appliance_update.py
+++ b/cfme/tests/cli/test_appliance_update.py
@@ -4,6 +4,7 @@ from collections import namedtuple
 import fauxfactory
 import pytest
 
+from cfme import test_requirements
 from cfme.fixtures.cli import do_appliance_versions_match
 from cfme.fixtures.cli import provider_app_crud
 from cfme.fixtures.cli import provision_vm
@@ -312,6 +313,9 @@ def test_update_replicated_webui(replicated_appliances_preupdate_with_providers,
     soft_assert(vm2.provider.mgmt.does_vm_exist(vm2.name), "vm not provisioned")
 
 
+@test_requirements.appliance
+@test_requirements.ha_proxy
+@test_requirements.update
 @pytest.mark.ignore_stream("upstream")
 @pytest.mark.meta(automates=[1704835])
 @pytest.mark.parametrize("update_strategy", [update_appliance, do_yum_update], ids=["webui", "yum"])


### PR DESCRIPTION
## Purpose or Intent
The commit messages of the commits are describing why and what is being done. In summary:
 * dedup work
 * removal of obsolete tests or dead code
 * blocker added

## PRT results
I didn't specify what to run. I was removing stuff. The only test that got changed slightly seem to be broken and is blocked now:
http://TRACKERBOT/pr10300-r2911-downstream-511z-SnMcfa/artifacts/report.html#cfme/tests/cli/test_appliance_cli.py/test_appliance_console_cli_ha_crud

the failures seem unrelated. I reran the tests locally and they PASSED. Just for curiosity I reran the PRT as well.
