### PR TITLE
[1LP][RFR] Add appliance pugins annotations

### DIFF
--- a/cfme/utils/appliance/plugin.py
+++ b/cfme/utils/appliance/plugin.py
@@ -45,11 +45,11 @@ class AppliancePluginDescriptor(Generic[TAppliancePlugin]):
         if instance is None:
             return self
 
-        if instance not in self.cache:
+        plugin = self.cache.get(instance, None)
+        if plugin is None:
             plugin = self.plugin_type(instance, *self.args, **self.kwargs)
             self.cache[instance] = plugin
-        result = self.cache[instance]
-        return result
+        return plugin
 
 
 @attr.s


### PR DESCRIPTION
## Purpose or Intent
Add annotations to appliance_plugins. This makes Pycharm resolve the types of the plugins, for example `IPAppliance.appliance_console` for example, that helps when writing and understanding the code and surely discovering bugs in the code 

## PRT results
There is a test for the certs in the CFME appliance that used to be blocked by https://bugzilla.redhat.com/show_bug.cgi?id=1712929. BZ is closed as WONTFIX. The test is failing. Not related to the PR.