### PR TITLE
[1LP][RFR] Add multiple_iso_datastore test and minor improvements 

### DIFF
--- a/cfme/tests/cloud_infra_common/test_provisioning_manual.py
+++ b/cfme/tests/cloud_infra_common/test_provisioning_manual.py
@@ -376,22 +376,3 @@ def test_auto_placement_provision_to_dvswitch_vlan_vmware():
         initialEstimate: 1/12h
     """
     pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(2)
-def test_add_multiple_iso_datastore():
-    """
-    Add two RHEV providers.
-    Under Infrastructure- PXE -ISO datastore - add ISO datastore for first
-    provider
-    Add new datastore button should not be disabled once the datastore was
-    added and second datastore can be added.
-
-    Polarion:
-        assignee: jhenner
-        casecomponent: Services
-        initialEstimate: 1/8h
-        startsin: 5.5
-    """
-    pass


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
Adding tests/Enhancement: Added test for the provisioning of multiple iso datastores with 2 providers. The test assures that a secondary datastore can be added as long as there is at least 2 distinct providers. Additional markers were introduced to replace the outdated 'pytest_generate_tests()' method. 

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->

{{pytest: cfme/tests/infrastructure/test_iso_provisioning.py -k "test_add_multiple_iso_datastore"}}
