### PR TITLE
[1LP][RFR] Increasing timeout interval

### DIFF
--- a/cfme/utils/appliance/__init__.py
+++ b/cfme/utils/appliance/__init__.py
@@ -1673,7 +1673,7 @@ class IPAppliance:
             logger.exception('Exception clearing cached_property "guid"')
         return str(result).rstrip('\n')  # should return UUID from stdout
 
-    def wait_for_ssh(self, timeout=30):
+    def wait_for_ssh(self, timeout=120):
         """Waits for appliance SSH connection to be ready
 
         Args:


### PR DESCRIPTION
Signed-off-by: mnadeem92 <mnadeem@redhat.com>

This PR will increase time out for wait_for_ssh method.
https://github.com/ManageIQ/integration_tests/blob/2b861a399464db98b384888dab784c97ee876fa4/cfme/utils/appliance/__init__.py#L1676

Instance creation is async operation in OSP, though command completed successfully, however it takes some time (60 seconds) to boot the OS and make ssh service available to login. The time out of 30 seconds is really not enough here, So this PR is increasing the timeout to 120 sec.  
