### PR TITLE
[1LP][RFR] Automating ssui Ansible_playbook standard output test

### DIFF
--- a/cfme/services/myservice/ssui.py
+++ b/cfme/services/myservice/ssui.py
@@ -71,6 +71,7 @@ class DetailsMyServiceView(MyServicesView):
     )
     resource_power_status = PowerIcon(".//span/i[contains(@class, 'pficon') and contains("
                                       "@uib-tooltip,'Power State')]")
+    standard_output = Text('.//div[@class="well"]')
 
 
 class ServiceEditForm(MyServicesView):

--- a/cfme/tests/services/test_dialog_element_in_catalog.py
+++ b/cfme/tests/services/test_dialog_element_in_catalog.py
@@ -486,6 +486,7 @@ def test_copy_save_service_dialog_with_the_same_name():
     Polarion:
         assignee: nansari
         startsin: 5.10
+        caseimportance: medium
         casecomponent: Services
         initialEstimate: 1/6h
         testSteps:
@@ -650,6 +651,7 @@ def test_access_child_services_from_the_my_service():
     Polarion:
         assignee: nansari
         startsin: 5.10
+        caseimportance: medium
         casecomponent: Services
         initialEstimate: 1/16h
         testSteps:
@@ -724,6 +726,7 @@ def test_datepicker_field_set_to_required():
     Polarion:
         assignee: nansari
         startsin: 5.10
+        caseimportance: medium
         casecomponent: Services
         initialEstimate: 1/6h
         testSteps:

--- a/cfme/tests/services/test_service_catalog_dialog_manual.py
+++ b/cfme/tests/services/test_service_catalog_dialog_manual.py
@@ -10,23 +10,6 @@ pytestmark = [
 
 @pytest.mark.manual
 @pytest.mark.tier(3)
-def test_changing_action_order_in_catalog_bundle_should_not_removes_resource():
-    """
-    Polarion:
-        assignee: nansari
-        casecomponent: Services
-        initialEstimate: 1/16h
-        testtype: functional
-        startsin: 5.8
-        tags: service
-    Bugzilla:
-        1615853
-    """
-    pass
-
-
-@pytest.mark.manual
-@pytest.mark.tier(3)
 def test_request_filter_on_request_page():
     """
     Polarion:

--- a/cfme/tests/ssui/test_ssui_service_catalogs.py
+++ b/cfme/tests/ssui/test_ssui_service_catalogs.py
@@ -11,6 +11,7 @@ from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.appliance import ViaSSUI
 from cfme.utils.appliance.implementations.ssui import navigate_to
 from cfme.utils.providers import ProviderFilter
+from cfme.utils.wait import wait_for
 
 pytestmark = [
     pytest.mark.meta(server_roles="+automate"),
@@ -144,19 +145,40 @@ def test_ssui_disable_dashboard(appliance, user_self_service_role):
             assert not view.is_displayed
 
 
-@pytest.mark.manual
+@pytest.mark.customer_scenario
 @pytest.mark.tier(2)
-def test_sui_monitor_ansible_playbook_std_output():
-    """
-
-    Polarion:
-        assignee: nansari
-        casecomponent: SelfServiceUI
-        testtype: functional
-        initialEstimate: 1/4h
-        startsin: 5.8
-        tags: ssui
+@pytest.mark.meta(automates=[1437210])
+def test_ssui_ansible_playbook_stdout(appliance, ansible_service_catalog, ansible_service_request,
+                                      ansible_service):
+    """ Test standard output of ansible playbook service
     Bugzilla:
         1437210
+    Polarion:
+        assignee: nansari
+        initialEstimate: 1/4h
+        casecomponent: SelfServiceUI
+        setup:
+            1. Create ansible playbook
+        testSteps:
+            1. Create ansible playbook service catalog item
+            2. Create service catalog
+            3. Order service
+            4. Log in into SSUI
+            5. Navigate to My Services->Service details
+            6. check stdout of service
+        expectedResults:
+            1.
+            2.
+            3.
+            4.
+            5.
+            6. able to see standard output
     """
-    pass
+    ansible_service_catalog.order()
+    ansible_service_request.wait_for_request()
+
+    with appliance.context.use(ViaSSUI):
+        view = navigate_to(ansible_service, "Details")
+        assert view.standard_output.is_displayed
+        wait_for(lambda: view.standard_output.text != "Loading...", timeout=30)
+        assert "Hello World" in view.standard_output.text


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
{{pytest: cfme/tests/ssui/test_ssui_service_catalogs.py::test_ssui_ansible_playbook_stdout --long-running -svvvv }}

<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
