### PR TITLE
[RFR] 5.10 Fix find_request to loop over static list of dict keys

### DIFF
--- a/cfme/services/requests.py
+++ b/cfme/services/requests.py
@@ -299,7 +299,7 @@ class RequestsView(RequestBasicView):
         contains = '' if not partial_check else '__contains'
         column_list = self.table.attributized_headers
         cells = copy(cells)
-        for key in cells.keys():
+        for key in list(cells):
             for column_name, column_text in column_list.items():
                 if key == column_text:
                     cells[f'{column_name}{contains}'] = cells.pop(key)


### PR DESCRIPTION
This PR backports a fix from master to 5.10-breakpoint-patched, so that `RequestsView.find_request()` loops over a static list of dictionary keys instead of the dynamic view returned by `dict.keys()` in Python 3. This fixes exceptions like the following:

```
>       for key in cells.keys():
E       RuntimeError: dictionary keys changed during iteration

cfme/services/requests.py:302: RuntimeError (cfme/fixtures/log.py:83)
```