### PR TITLE
[RFR] Automate test_service_provision_retire_from_global_region_bundle

### DIFF
--- a/cfme/services/myservice/__init__.py
+++ b/cfme/services/myservice/__init__.py
@@ -41,7 +41,7 @@ class MyService(Updateable, Navigatable, Taggable, sentaku.modeling.ElementMixin
     @property
     def rest_api_entity(self):
         try:
-            return self.appliance.rest_api.collections.services.get(name=self.name)
+            return self.appliance.rest_api.collections.services.get(name=self.name, display=True)
         except ValueError:
             raise RestLookupError(f'No service rest entity found matching name {self.name}')
 

--- a/cfme/services/myservice/ui.py
+++ b/cfme/services/myservice/ui.py
@@ -57,15 +57,9 @@ class MyServicesView(BaseLoggedInPage):
 
     @property
     def in_myservices(self):
-        # Slicing in currently_selected is workaround for BZ-1733489
-        nav_selected = (
-            self.navigation.currently_selected[:2]
-            if BZ(1733489).blocks
-            else self.navigation.currently_selected
-        )
         return (
             self.logged_in_as_current_user and
-            nav_selected == ["Services", "My Services"]
+            self.navigation.currently_selected == ["Services", "My Services"]
         )
 
     @property


### PR DESCRIPTION
This PR automates multi-region service provisioning and retirement for a catalog containing a catalog bundle. The remaining manual test for multi-region service retirement, for catalogs using orchestration templates, is also marked as `manualonly`, because after internal discussion about the bug described in https://bugzilla.redhat.com/show_bug.cgi?id=1754543 , we decided that the possible workarounds to get orchestration template creation working in automation are not worth the effort. 

{{ pytest: -vv --use-provider complete --long-running -k test_service_provision_retire_from_global_region_bundle cfme/tests/services/test_service_catalogs_multi_region.py }}
