### PR TITLE
[RFR] Fix travis distutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 # https://docs.travis-ci.com/user/languages/python/#python-37-and-higher
-dist: xenial
+dist: bionic
 addons:
   apt:
     packages:
-      - python3-venv
+      - python3
       - gcc
       - gnutls-dev
       - postgresql
@@ -34,44 +34,24 @@ jobs:
     - stage: linting
       python: '3.7'
       env:
+      before_install:
+        - sudo apt-get update
       install:
-      - pip install pre-commit flake8
+        - pip install pre-commit flake8
       script:
-      - pre-commit clean
-      - pre-commit run --all-files
+        - pre-commit clean
+        - pre-commit run --all-files
       after_failure:
-      - git diff
+        - git diff
 
     - stage: test
       python: '3.7'
-      dist: xenial
-      addons:
-        apt:
-          packages:
-            - python3-venv
-            - gcc
-            - gnutls-dev
-            - postgresql
-            - libxml2-dev
-            - libxslt1-dev
-            - libzmq3-dev
-            - libcurl4-openssl-dev
-            - g++
-            - openssl
-            - libffi-dev
-            - python3-dev
-            - libtesseract-dev
-            - libpng-dev
-            - libfreetype6-dev
-            - libssl-dev
-            - python3-dbg
-            - git
       env:
         # work around travis being missconfigured
         - BOTO_CONFIG=/dev/null
       install:
         - pip3 install -U setuptools pip
-        - python3 -m cfme.scripting.quickstart
+        - python3 -m cfme.scripting.quickstart --mk-virtualenv $HOME/virtualenv/python3.7
         # use templates for conf files necessary for collecting
         - cp conf/cfme_data.yaml.template conf/cfme_data.yaml
         - cp conf/env.yaml.template conf/env.yaml

--- a/cfme/scripting/disable_bytecode.py
+++ b/cfme/scripting/disable_bytecode.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
-import distutils
 from os import path
+
+from cfme.utils.log import logger
 
 
 DISABLE_BYTECODE = "import sys\nsys.dont_write_bytecode = True\n"
@@ -21,10 +22,11 @@ def ensure_file_contains(target, content):
 
 if __name__ == '__main__':
     try:
-        site_packages = distutils.sysconfig_get_python_lib()
-    except AttributeError:
         import site
         site_packages = site.getsitepackages()[0]
-    print(site_packages)
-    target = path.join(site_packages, 'sitecustomize.py')
-    ensure_file_contains(target, content=DISABLE_BYTECODE)
+        print(site_packages)
+        target = path.join(site_packages, 'sitecustomize.py')
+        ensure_file_contains(target, content=DISABLE_BYTECODE)
+    except AttributeError:
+        logger.warning('bytecode NOT disabled, site.getsitepackages not found.'
+                       'Something is wrong with the site module, due to virtualenv creation.')

--- a/cfme/scripting/quickstart/__init__.py
+++ b/cfme/scripting/quickstart/__init__.py
@@ -16,10 +16,8 @@ if sys.version_info.major != 3 and sys.version_info.minor >= 7:
     print("ERROR: quickstart only runs in python 3.7+")
     sys.exit(2)
 
-
 IN_VENV = os.path.exists(os.path.join(sys.prefix, 'pyvenv.cfg'))
 IN_LEGACY_VIRTUALENV = getattr(sys, 'real_prefix', None) is not None
-
 IN_VIRTUAL_ENV = IN_VENV or IN_LEGACY_VIRTUALENV
 
 

--- a/cfme/scripting/quickstart/system.py
+++ b/cfme/scripting/quickstart/system.py
@@ -82,7 +82,7 @@ REDHAT_PACKAGES_SPECS = [
 
 
 DEB_PKGS = (
-    " python3-venv python3-virtualenv gcc gnutls-dev postgresql libxml2-dev"
+    " python3-venv gcc gnutls-dev postgresql libxml2-dev"
     " libxslt1-dev libzmq3-dev libcurl4-openssl-dev"
     " g++ openssl libffi-dev python3-dev libtesseract-dev"
     " libpng-dev libfreetype6-dev libssl-dev python3-dbg git"

--- a/requirements/frozen.txt
+++ b/requirements/frozen.txt
@@ -330,7 +330,6 @@ tzlocal==2.0.0
 uritemplate==3.0.0
 urllib3==1.25.8
 varmeth==0.0.2
-virtualenv==16.4.3
 vspk==5.3.2
 wait-for==1.1.3
 warlock==1.3.0


### PR DESCRIPTION
Travis is failing with a distutils import error.

Couldn't replicate locally, but travis's ubuntu image is running with python 3.7.1.

Updated travis to bionic and cleaned up the config a bit

Explicitly set virtualenv path for quickstart

Ignored/logged site import failure in disable_bytecache, as it should be non-blocking failure.

```
QS $ /home/travis/virtualenv/python3.7.1/bin/python3 -m cfme.scripting.disable_bytecode

Traceback (most recent call last):

  File "/home/travis/build/ManageIQ/integration_tests/cfme/scripting/disable_bytecode.py", line 24, in <module>

    site_packages = distutils.sysconfig_get_python_lib()

AttributeError: module 'distutils' has no attribute 'sysconfig_get_python_lib'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):

  File "/opt/python/3.7.1/lib/python3.7/runpy.py", line 193, in _run_module_as_main

    "__main__", mod_spec)

  File "/opt/python/3.7.1/lib/python3.7/runpy.py", line 85, in _run_code

    exec(code, run_globals)

  File "/home/travis/build/ManageIQ/integration_tests/cfme/scripting/disable_bytecode.py", line 27, in <module>

    site_packages = site.getsitepackages()[0]

AttributeError: module 'site' has no attribute 'getsitepackages'
```