### PR TITLE
[RFR] Add module-scoped replicated_appliances fixture

### DIFF
--- a/cfme/fixtures/appliance.py
+++ b/cfme/fixtures/appliance.py
@@ -134,13 +134,25 @@ def temp_appliance_preconfig_long(request, appliance, pytestconfig):
 
 
 @pytest.fixture(scope="function")
-def temp_appliance_preconfig_funcscope_rhevm(appliance, pytestconfig):
+def temp_appliance_preconfig_funcscope_rhevm(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig, preconfigured=True,
             provider_type='rhevm'
     ) as appliances:
         yield appliances[0]
+        _collect_logs(request.config, appliances)
+
+
+@pytest.fixture(scope="module")
+def temp_appliance_preconfig_modscope_rhevm(request, appliance, pytestconfig):
+    with sprout_appliances(
+            appliance,
+            config=pytestconfig, preconfigured=True,
+            provider_type='rhevm'
+    ) as appliances:
+        yield appliances[0]
+        _collect_logs(request.config, appliances)
 
 
 # Single appliance, unconfigured
@@ -172,6 +184,18 @@ def temp_appliance_unconfig_funcscope(request, appliance, pytestconfig):
 
 @pytest.fixture(scope="function")
 def temp_appliance_unconfig_funcscope_rhevm(request, appliance, pytestconfig):
+    with sprout_appliances(
+            appliance,
+            config=pytestconfig,
+            preconfigured=False,
+            provider_type='rhevm'
+    ) as appliances:
+        yield appliances[0]
+        _collect_logs(request.config, appliances)
+
+
+@pytest.fixture(scope="module")
+def temp_appliance_unconfig_modscope_rhevm(request, appliance, pytestconfig):
     with sprout_appliances(
             appliance,
             config=pytestconfig,

--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -285,15 +285,7 @@ def distributed_appliances(temp_appliance_preconfig_funcscope_rhevm,
     return primary_appliance, secondary_appliance
 
 
-@pytest.fixture
-def replicated_appliances(temp_appliance_preconfig_funcscope_rhevm,
-        temp_appliance_unconfig_funcscope_rhevm):
-    """Configure a global appliance with region 99, sharing the same encryption key as the
-    preconfigured remote appliance with region 0. Then set up database replication between them.
-    """
-    remote_appliance = temp_appliance_preconfig_funcscope_rhevm
-    global_appliance = temp_appliance_unconfig_funcscope_rhevm
-
+def _replicated_appliances(remote_appliance, global_appliance):
     logger.info("Starting appliance replication configuration.")
     global_appliance.configure(region=99, key_address=remote_appliance.hostname)
 
@@ -306,6 +298,30 @@ def replicated_appliances(temp_appliance_preconfig_funcscope_rhevm,
     global_appliance.browser_steal = True
 
     return remote_appliance, global_appliance
+
+
+@pytest.fixture
+def replicated_appliances(temp_appliance_preconfig_funcscope_rhevm,
+        temp_appliance_unconfig_funcscope_rhevm):
+    """Configure a global appliance with region 99, sharing the same encryption key as the
+    preconfigured remote appliance with region 0. Then set up database replication between them.
+    """
+    remote_appliance = temp_appliance_preconfig_funcscope_rhevm
+    global_appliance = temp_appliance_unconfig_funcscope_rhevm
+
+    return _replicated_appliances(remote_appliance, global_appliance)
+
+
+@pytest.fixture(scope='module')
+def replicated_appliances_modscope(temp_appliance_preconfig_modscope_rhevm,
+        temp_appliance_unconfig_modscope_rhevm):
+    """Configure a global appliance with region 99, sharing the same encryption key as the
+    preconfigured remote appliance with region 0. Then set up database replication between them.
+    """
+    remote_appliance = temp_appliance_preconfig_modscope_rhevm
+    global_appliance = temp_appliance_unconfig_modscope_rhevm
+
+    return _replicated_appliances(remote_appliance, global_appliance)
 
 
 @pytest.fixture


### PR DESCRIPTION
Added module-scoped multi-region appliance fixture `replicated_appliances_modscope`, and replaced the function-scoped with this new module-scoped fixture in the tests in `cfme/tests/distributed/test_appliance_replication.py`. Because the tests previously didn't have to worry about cleanup, I've also added some finalizers to remove provider and other records after each test.

{{ pytest: --long-running --use-provider complete -k 'test_replication_ or test_appliance_replicate_' cfme/tests/distributed/test_appliance_replication.py }}
