### PR TITLE
[1LP][RFR]Automate: test_default_miq_group_is_tenant_group

### DIFF
--- a/cfme/tests/configure/test_config_manual.py
+++ b/cfme/tests/configure/test_config_manual.py
@@ -236,22 +236,3 @@ def test_subscription_disruption():
             appeared in global appliance
     """
     pass
-
-
-@pytest.mark.manual
-@pytest.mark.meta(coverage=[1625788])
-def test_default_miq_group_is_tenant_group():
-    """
-    Test whether the
-    Tenant.root_tenant.default_miq_group.tenant_group? == true
-
-    Polarion:
-        assignee: jhenner
-        casecomponent: Configuration
-        initialEstimate: 1/8h
-        startsin: 5.10.0.18
-        caseimportance: high
-    Bugzilla:
-        1625788
-    """
-    pass


### PR DESCRIPTION
## Purpose or Intent

- __Adding tests__ 
    1. test_default_miq_group_is_tenant_group

### PRT Run
{{ pytest: cfme/tests/cloud_infra_common/test_discovery_and_support.py::test_default_miq_group_is_tenant_group -svvv }}