### PR TITLE
[RFR] Make AWX 3.6 work fine

### DIFF
--- a/cfme/fixtures/ansible_tower.py
+++ b/cfme/fixtures/ansible_tower.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 import fauxfactory
 import pytest
 
+from cfme.infrastructure.config_management.ansible_tower import AnsibleTowerProvider
 from cfme.rest.gen_data import _creating_skeleton
 from cfme.utils.blockers import GH
 from cfme.utils.update import update
@@ -131,7 +132,7 @@ def ansible_tower_dialog(request, appliance):
 
 
 @pytest.fixture
-def ansible_api_version_change(provider, ansible_api_version):
+def ansible_api_version_change(provider: AnsibleTowerProvider, ansible_api_version):
     """
     Fixture to update Tower url to /api/vx in the UI so that all supported versions of API
     can be tested.

--- a/cfme/tests/automate/test_ansible_tower_automate.py
+++ b/cfme/tests/automate/test_ansible_tower_automate.py
@@ -10,6 +10,7 @@ from cfme.utils.log_validator import LogValidator
 
 pytestmark = [
     test_requirements.automate,
+    test_requirements.tower,
     pytest.mark.provider([AnsibleTowerProvider], scope='module'),
     pytest.mark.usefixtures('setup_provider')
 ]

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -11,6 +11,7 @@ from cfme.utils.version import Version
 
 pytestmark = [
     test_requirements.service,
+    test_requirements.tower,
     pytest.mark.tier(2),
     pytest.mark.provider([AnsibleTowerProvider], scope='module'),
     pytest.mark.usefixtures('setup_provider'),

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -6,6 +6,7 @@ from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
 from cfme.utils.blockers import BZ
 from cfme.utils.log import logger
+from cfme.utils.version import Version
 
 
 pytestmark = [
@@ -39,6 +40,11 @@ def ansible_workflow_catitem(appliance, provider, dialog, catalog, workflow_type
     catalog_item.delete_if_exists()
 
 
+def versioncheck(provider: AnsibleTowerProvider, ansible_api_version):
+    return provider.version >= Version(3.6) and ansible_api_version == 'v1'
+
+
+@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
 @pytest.mark.parametrize('workflow_type', ['multiple_job_workflow', 'inventory_sync_workflow'],
         ids=['multiple_job_workflow', 'inventory_sync_workflow'], scope='module')
 @pytest.mark.meta(automates=[BZ(1719051)])
@@ -69,6 +75,7 @@ def test_tower_workflow_item(appliance, ansible_workflow_catitem, workflow_type,
     )
 
 
+@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
 @pytest.mark.parametrize('workflow_type', ['multiple_job_workflow'], ids=['multiple_job_workflow'])
 def test_retire_ansible_workflow(appliance, ansible_workflow_catitem, workflow_type,
         ansible_api_version_change):

--- a/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
+++ b/cfme/tests/services/test_ansible_workflow_servicecatalogs.py
@@ -45,7 +45,7 @@ def versioncheck(provider: AnsibleTowerProvider, ansible_api_version):
     return provider.version >= Version(3.6) and ansible_api_version == 'v1'
 
 
-@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
+@pytest.mark.uncollectif(versioncheck, reason='API V1 not supported since Tower 3.6.')
 @pytest.mark.parametrize('workflow_type', ['multiple_job_workflow', 'inventory_sync_workflow'],
         ids=['multiple_job_workflow', 'inventory_sync_workflow'], scope='module')
 @pytest.mark.meta(automates=[BZ(1719051)])
@@ -76,7 +76,7 @@ def test_tower_workflow_item(appliance, ansible_workflow_catitem, workflow_type,
     )
 
 
-@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
+@pytest.mark.uncollectif(versioncheck, reason='API V1 not supported since Tower 3.6.')
 @pytest.mark.parametrize('workflow_type', ['multiple_job_workflow'], ids=['multiple_job_workflow'])
 def test_retire_ansible_workflow(appliance, ansible_workflow_catitem, workflow_type,
         ansible_api_version_change):

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -4,6 +4,7 @@ from cfme import test_requirements
 from cfme.infrastructure.config_management.ansible_tower import AnsibleTowerProvider
 from cfme.services.myservice import MyService
 from cfme.services.service_catalogs import ServiceCatalogs
+from cfme.tests.services.test_ansible_workflow_servicecatalogs import versioncheck
 from cfme.utils.appliance.implementations.ui import navigate_to
 from cfme.utils.blockers import BZ
 from cfme.utils.blockers import GH
@@ -39,6 +40,7 @@ def catalog_item(appliance, request, provider, ansible_tower_dialog, catalog, jo
     return catalog_item
 
 
+@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
 @pytest.mark.parametrize('job_type', ['template', 'template_limit', 'template_survey',
         'textarea_survey'],
         ids=['template_job', 'template_limit_job', 'template_survey_job', 'textarea_survey_job'],
@@ -83,6 +85,7 @@ def test_order_tower_catalog_item(appliance, provider: AnsibleTowerProvider,
                                                               'List View')
 
 
+@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
 @pytest.mark.parametrize('job_type', ['template'], ids=['template_job'])
 def test_retire_ansible_service(appliance, catalog_item, request, job_type,
         ansible_api_version_change):
@@ -108,6 +111,7 @@ def test_retire_ansible_service(appliance, catalog_item, request, job_type,
     myservice.retire()
 
 
+@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
 @pytest.mark.ignore_stream('5.10')
 @pytest.mark.customer_scenario
 @pytest.mark.meta(automates=[1740814])

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -14,6 +14,7 @@ from cfme.utils.version import Version
 
 pytestmark = [
     test_requirements.service,
+    test_requirements.tower,
     pytest.mark.provider([AnsibleTowerProvider], scope='module'),
     pytest.mark.usefixtures('setup_provider'),
     pytest.mark.tier(2),
@@ -123,7 +124,7 @@ def test_change_ansible_tower_job_template(catalog_item, job_type, ansible_api_v
         1740814
 
     Polarion:
-        assignee: nansari
+        assignee: jhenner
         casecomponent: Services
         initialEstimate: 1/16h
         startsin: 5.11

--- a/cfme/tests/services/test_config_provider_servicecatalogs.py
+++ b/cfme/tests/services/test_config_provider_servicecatalogs.py
@@ -41,7 +41,7 @@ def catalog_item(appliance, request, provider, ansible_tower_dialog, catalog, jo
     return catalog_item
 
 
-@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
+@pytest.mark.uncollectif(versioncheck, reason='API V1 not supported since Tower 3.6.')
 @pytest.mark.parametrize('job_type', ['template', 'template_limit', 'template_survey',
         'textarea_survey'],
         ids=['template_job', 'template_limit_job', 'template_survey_job', 'textarea_survey_job'],
@@ -86,7 +86,7 @@ def test_order_tower_catalog_item(appliance, provider: AnsibleTowerProvider,
                                                               'List View')
 
 
-@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
+@pytest.mark.uncollectif(versioncheck, reason='API V1 not supported since Tower 3.6.')
 @pytest.mark.parametrize('job_type', ['template'], ids=['template_job'])
 def test_retire_ansible_service(appliance, catalog_item, request, job_type,
         ansible_api_version_change):
@@ -112,7 +112,7 @@ def test_retire_ansible_service(appliance, catalog_item, request, job_type,
     myservice.retire()
 
 
-@pytest.mark.uncollectif(versioncheck, reason='API V2 not supported since Tower 3.6.')
+@pytest.mark.uncollectif(versioncheck, reason='API V1 not supported since Tower 3.6.')
 @pytest.mark.ignore_stream('5.10')
 @pytest.mark.customer_scenario
 @pytest.mark.meta(automates=[1740814])


### PR DESCRIPTION
## Purpose or Intent
Make the AWX tests running fine against the tower 3.6 that I've got fom @nachandr and manually prepared to make the tests passing.

### PRT Run
Needs GITLAB/cfme-qe/cfme-qe-yamls/-/merge_requests/940

Disabled at the moment: {{pytest: --long-running -v 'cfme/tests/services/test_config_provider_servicecatalogs.py' 'cfme/tests/services/test_ansible_workflow_servicecatalogs.py' --use-provider complete}}