### PR TITLE
[RFR]Automate: test_service_provision_retire_from_global_region_generic

### DIFF
--- a/cfme/services/myservice/rest.py
+++ b/cfme/services/myservice/rest.py
@@ -11,3 +11,14 @@ def add_resource_generic_object(self, gen_obj):
             name=gen_obj.name
         )._ref_repr()
     )
+
+
+@MiqImplementationContext.external_for(MyService.retire, ViaREST)
+def retire(self, wait=True):
+    retire_request = self.rest_api_entity.action.request_retire()
+    service_request = self.appliance.collections.requests.instantiate(
+        description=retire_request.description
+    )
+    if wait:
+        service_request.wait_for_request()
+    return service_request


### PR DESCRIPTION
## Purpose or Intent
- __Adding tests__ 
    1. test_service_provision_retire_from_global_region_generic
- __Enhancement__
    1. Implement `retire` service for REST API.

### PRT Run
{{ pytest: cfme/tests/services/test_service_catalogs_multi_region.py::test_service_provision_retire_from_global_region_generic --long-running -vvv }}