### PR TITLE
[RFR] Add refresh to the funky characters test fixture

### DIFF
--- a/cfme/tests/infrastructure/test_providers.py
+++ b/cfme/tests/infrastructure/test_providers.py
@@ -532,7 +532,7 @@ def test_compare_templates(appliance, setup_provider_min_templates, provider, mi
 
 
 @pytest.fixture
-def provider_with_special_characters(provider):
+def provider_with_special_characters(provider: AnsibleTowerProvider):
     """
     Adds a special character sequence to extra_vars on a AWX provider to test BZ 1819310.
     Note it seems the the AWX version 3.4 cannot be patched. It is refusing the request.
@@ -567,6 +567,10 @@ def provider_with_special_characters(provider):
         response = session.patch(f'{url}/job_templates/{template["id"]}/',
                                  json=empty_extra_vars)
         assert response.ok
+
+        # Let's make sure the provider refreshes so if there was a regression -- special chars
+        # were problem, the problem would be isolated to only the test(s) using this fixture.
+        provider.refresh_provider_relationships()
 
 
 @pytest.mark.meta(automates=[1819310])


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
... just to make the resolution of a possible problem less time consuming.

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{pytest: --use-provider complete --long-running -v cfme/tests/infrastructure/test_providers.py::test_awx_with_special_chars_refreshes}}