### PR TITLE
[RFR] updating openstack console to use right elements for OSP 16

### DIFF
--- a/cfme/cloud/provider/openstack.py
+++ b/cfme/cloud/provider/openstack.py
@@ -28,8 +28,8 @@ class OpenStackProvider(CloudProvider):
     ems_pretty_name = 'OpenStack'
 
     # xpath locators for elements, to be used by selenium
-    _console_connection_status_element = '//*[@id="noVNC_status"]'
-    _canvas_element = '//*[@id="noVNC_canvas"]'
+    _console_connection_status_element = '//*[@id="noVNC_status" or @id="status"]'
+    _canvas_element = '//*[@id="noVNC_canvas" or @id="screen"]'
     _ctrl_alt_del_xpath = '//*[@id="sendCtrlAltDelButton"]'
 
     api_port = attr.ib(default=None)


### PR DESCRIPTION
## Purpose or Intent
- __Fixing__ OpenStack Console test to accommodate new elements in OSP 16 based VM consoles

### PRT Run

{{pytest: cfme/tests/cloud_infra_common/test_html5_vm_console.py --use-provider env-rhos16 --use-provider env-rhos13 -k 'test_html5_vm_console' -vvv }}

