### PR TITLE
[RFR] Refactor provider rest tests

### DIFF
--- a/cfme/infrastructure/config_management/__init__.py
+++ b/cfme/infrastructure/config_management/__init__.py
@@ -470,19 +470,6 @@ class ConfigManagerProvider(BaseProvider, Updateable, Pretty):
         assert_response(self.appliance)
         return True
 
-    def delete_rest(self):
-        """Deletes the config manager from CFME using REST"""
-        try:
-            self.rest_api_entity.action.delete()
-        except APIException as err:
-            raise AssertionError(f"Provider wasn't deleted: {err}")
-
-        response = self.appliance.rest_api.response
-        if not response:
-            raise AssertionError(
-                f"Provider wasn't deleted, status code {response.status_code}"
-            )
-
     def refresh_relationships(self, cancel=False):
         """Refreshes relationships and power states of this manager"""
         view = navigate_to(self, 'AllOfType')

--- a/cfme/tests/cloud_infra_common/test_rest_providers.py
+++ b/cfme/tests/cloud_infra_common/test_rest_providers.py
@@ -3,6 +3,7 @@ import pytest
 
 from cfme import test_requirements
 from cfme.cloud.provider import CloudProvider
+from cfme.infrastructure.config_management.ansible_tower import AnsibleTowerProvider
 from cfme.infrastructure.provider import InfraProvider
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.markers.env_markers.provider import ONE
@@ -17,36 +18,11 @@ from cfme.utils.wait import wait_for
 pytestmark = [
     test_requirements.rest,
     pytest.mark.tier(1),
-    pytest.mark.provider([CloudProvider, InfraProvider])
+    pytest.mark.provider([CloudProvider, InfraProvider]),
 ]
 
 
-def delete_provider(appliance, name):
-    provs = appliance.rest_api.collections.providers.find_by(name=name)
-
-    if not provs:
-        return
-
-    prov = provs[0]
-
-    prov.action.delete()
-    prov.wait_not_exists()
-
-
-@pytest.fixture(scope="function")
-def provider_rest(request, appliance, provider):
-    """Creates provider using REST API."""
-    delete_provider(appliance, provider.name)
-    request.addfinalizer(lambda: delete_provider(appliance, provider.name))
-
-    provider.create_rest()
-    assert_response(appliance)
-
-    provider_rest = appliance.rest_api.collections.providers.get(name=provider.name)
-    return provider_rest
-
-
-def test_query_provider_attributes(provider, provider_rest, soft_assert):
+def test_query_provider_attributes(setup_provider, provider, soft_assert):
     """Tests access to attributes of /api/providers.
 
     Metadata:
@@ -62,11 +38,14 @@ def test_query_provider_attributes(provider, provider_rest, soft_assert):
         caseimportance: medium
         initialEstimate: 1/30h
     """
-    outcome = query_resource_attributes(provider_rest)
+    outcome = query_resource_attributes(provider.rest_api_entity)
     for failure in outcome.failed:
         # once BZ1546112 is fixed other failure than internal server error is expected
-        soft_assert(False, '{} "{}": status: {}, error: `{}`'.format(
-            failure.type, failure.name, failure.response.status_code, failure.error))
+        soft_assert(
+            False,
+            f'{failure.type} "{failure.name}": status: {failure.response.status_code},'
+            f" error: `{failure.error}`",
+        )
 
 
 def test_provider_options(appliance):
@@ -82,10 +61,11 @@ def test_provider_options(appliance):
         initialEstimate: 1/4h
     """
     options = appliance.rest_api.options(appliance.rest_api.collections.providers._href)
-    assert 'provider_settings' in options['data']
+    assert "provider_settings" in options["data"]
 
 
-def test_create_provider(provider_rest):
+@pytest.mark.provider([CloudProvider, InfraProvider, AnsibleTowerProvider])
+def test_create_provider(has_no_providers, appliance, provider, request):
     """Tests creating provider using REST API.
 
     Metadata:
@@ -97,10 +77,14 @@ def test_create_provider(provider_rest):
         caseimportance: high
         initialEstimate: 1/4h
     """
-    assert "ManageIQ::Providers::" in provider_rest.type
+    provider.create_rest()
+    assert_response(appliance)
+    assert provider.rest_api_entity.exists
+    request.addfinalizer(provider.delete_rest)
+    assert "ManageIQ::Providers::" in provider.rest_api_entity.type
 
 
-def test_provider_refresh(provider_rest, appliance):
+def test_provider_refresh(setup_provider, provider, appliance):
     """Test checking that refresh invoked from the REST API works.
 
     Metadata:
@@ -112,6 +96,8 @@ def test_provider_refresh(provider_rest, appliance):
         caseimportance: high
         initialEstimate: 1/4h
     """
+    provider_rest = provider.rest_api_entity
+
     # initiate refresh
     def _refresh_success():
         provider_rest.action.refresh()
@@ -129,14 +115,13 @@ def test_provider_refresh(provider_rest, appliance):
     if task_id:
         task = appliance.rest_api.get_entity("tasks", task_id)
         wait_for(
-            lambda: task.state.lower() in ("finished", "queued"),
-            fail_func=task.reload,
-            num_sec=30,
+            lambda: task.state.lower() in ("finished", "queued"), fail_func=task.reload, num_sec=30,
         )
         assert task.status.lower() == "ok", f"Task failed with status '{task.status}'"
 
 
-def test_provider_edit(request, provider_rest, appliance):
+@pytest.mark.provider([CloudProvider, InfraProvider, AnsibleTowerProvider])
+def test_provider_edit(request, setup_provider, provider, appliance):
     """Test editing a provider using REST API.
 
     Metadata:
@@ -148,6 +133,7 @@ def test_provider_edit(request, provider_rest, appliance):
         caseimportance: high
         initialEstimate: 1/4h
     """
+    provider_rest = provider.rest_api_entity
     new_name = fauxfactory.gen_alphanumeric()
     old_name = provider_rest.name
     request.addfinalizer(lambda: provider_rest.action.edit(name=old_name))
@@ -157,8 +143,9 @@ def test_provider_edit(request, provider_rest, appliance):
     assert provider_rest.name == new_name == edited.name
 
 
+@pytest.mark.provider([CloudProvider, InfraProvider, AnsibleTowerProvider])
 @pytest.mark.parametrize("method", ["post", "delete"], ids=["POST", "DELETE"])
-def test_provider_delete_from_detail(provider_rest, method):
+def test_provider_delete_from_detail(setup_provider, provider, method):
     """Tests deletion of the provider from detail using REST API.
 
     Bugzilla:
@@ -174,10 +161,10 @@ def test_provider_delete_from_detail(provider_rest, method):
         caseimportance: medium
         initialEstimate: 1/4h
     """
-    delete_resources_from_detail([provider_rest], method=method, num_sec=50)
+    delete_resources_from_detail([provider.rest_api_entity], method=method, num_sec=50)
 
 
-def test_provider_delete_from_collection(provider_rest):
+def test_provider_delete_from_collection(setup_provider, provider):
     """Tests deletion of the provider from collection using REST API.
 
     Bugzilla:
@@ -193,12 +180,14 @@ def test_provider_delete_from_collection(provider_rest):
         caseimportance: medium
         initialEstimate: 1/4h
     """
-    delete_resources_from_collection([provider_rest], num_sec=50)
+    delete_resources_from_collection([provider.rest_api_entity], num_sec=50)
 
 
 @pytest.mark.tier(3)
 @pytest.mark.meta(automates=[1656502])
-@pytest.mark.provider([RHEVMProvider], selector=ONE, required_flags=["metrics_collection"])
+@pytest.mark.provider(
+    [RHEVMProvider], selector=ONE, required_fields=[(["cap_and_util", "capandu_vm"], "cu-24x7")]
+)
 def test_create_rhev_provider_with_metric(setup_provider, provider):
     """
     Bugzilla:
@@ -215,6 +204,7 @@ def test_create_rhev_provider_with_metric(setup_provider, provider):
             1. Provider must be added with all the details provided.
                 In this case metric data. no data should be missing.
     """
+    candu_hostname = provider.endpoints["candu"].hostname
     navigate_to(provider, "Edit")
     view = provider.create_view(provider.endpoints_form)
-    assert view.candu.hostname.read() == provider.endpoints["candu"].hostname
+    assert view.candu.hostname.read() == candu_hostname

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1725,7 +1725,7 @@ class ReportDataControllerMixin:
 
     def get_ids_by_keys(self, **keys):
         updated_keys = keys.copy()
-        for key in updated_keys:
+        for key in list(updated_keys):
             # js api compares values in lower case but don't replace space with underscore
             updated_keys[key.replace("_", " ")] = str(updated_keys.pop(key))
 


### PR DESCRIPTION
## Purpose or Intent

- __Fixing__ 
    1. Tests related to config manager rest.
- __Updating tests__ 
    1. Merged test cases for normal providers and config managers.

### PRT Run
{{ pytest: cfme/tests/cloud_infra_common/test_rest_providers.py --use-provider=complete -vvvv }}