### PR TITLE
[WIPTEST] Use module-scoped replicated_appliances fixture for service retirement

### DIFF
--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1724,7 +1724,7 @@ class ReportDataControllerMixin:
         return result
 
     def get_ids_by_keys(self, **keys):
-        updated_keys = keys.copy()
+        updated_keys = list(keys)
         for key in updated_keys:
             # js api compares values in lower case but don't replace space with underscore
             updated_keys[key.replace("_", " ")] = str(updated_keys.pop(key))


### PR DESCRIPTION
{{ pytest: -vv --long-running --use-provider complete cfme/tests/services/test_service_catalogs_multi_region.py }}