### PR TITLE
[1LP][RFR] Update use of provisioning tab in ansible tower service

### DIFF
--- a/cfme/tests/configure/test_access_control.py
+++ b/cfme/tests/configure/test_access_control.py
@@ -3075,7 +3075,6 @@ def test_ansible_playbook_stdout(
         ).waiting(timeout=120):
             ansible_service_request.wait_for_request()
             view = navigate_to(ansible_service, "Details")
-            view.provisioning_tab.click()
-            assert view.provisioning.standart_output.is_displayed
-            wait_for(lambda: view.provisioning.standart_output.text != "Loading...", timeout=30)
-            assert "Hello World" in view.provisioning.standart_output.text
+            assert view.provisioning.standard_output.is_displayed
+            wait_for(lambda: view.provisioning.standard_output.text != "Loading...", timeout=30)
+            assert "Hello World" in view.provisioning.standard_output.text


### PR DESCRIPTION
This was missed in the original PR for ansible service test fixture refactoring. The view now uses proper tabs, which do not need to be explicitly clicked.