### PR TITLE
[RFR] Cover cust. BZ 1856470 - repmgr10 failover fail.

### DIFF
--- a/cfme/fixtures/cli.py
+++ b/cfme/fixtures/cli.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from configparser import ConfigParser
 from contextlib import contextmanager
 from io import StringIO
+from typing import Tuple
 
 import fauxfactory
 import pytest
@@ -18,6 +19,7 @@ from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.test_framework.sprout.client import AuthException
 from cfme.test_framework.sprout.client import SproutClient
 from cfme.utils import conf
+from cfme.utils.appliance import IPAppliance
 from cfme.utils.appliance.console import configure_appliances_ha
 from cfme.utils.conf import auth_data
 from cfme.utils.conf import cfme_data
@@ -56,6 +58,9 @@ def unconfigured_appliance_secondary(request, appliance, pytestconfig):
         _collect_logs(request.config, apps)
 
 
+TThreeAppliances = Tuple[IPAppliance, IPAppliance, IPAppliance]
+
+
 @pytest.fixture()
 def unconfigured_appliances(request, appliance, pytestconfig):
     with sprout_appliances(
@@ -65,7 +70,7 @@ def unconfigured_appliances(request, appliance, pytestconfig):
             config=pytestconfig,
             provider_type='rhevm',
     ) as apps:
-        yield apps
+        yield tuple(apps)
         _collect_logs(request.config, apps)
 
 

--- a/cfme/utils/appliance/console.py
+++ b/cfme/utils/appliance/console.py
@@ -20,7 +20,7 @@ from cfme.utils.wait import wait_for
 if typing.TYPE_CHECKING:
     from cfme.utils.appliance import IPAppliance
 
-AP_WELCOME_SCREEN_TIMEOUT = 30
+AP_WELCOME_SCREEN_TIMEOUT = 60
 
 
 class ApplianceConsole(AppliancePlugin):
@@ -149,7 +149,7 @@ class ApplianceConsole(AppliancePlugin):
                 re.escape('Apply this Replication Server Configuration? (Y/N): '), 'y')
             interaction.answer('Press any key to continue.', '')
 
-    def reconfigure_primary_replication_node(self, pwd):
+    def reconfigure_primary_replication_node(self, pwd: str):
         # Configure primary replication node
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
@@ -172,7 +172,7 @@ class ApplianceConsole(AppliancePlugin):
                 re.escape('Apply this Replication Server Configuration? (Y/N): '), 'y')
             interaction.answer('Press any key to continue.', '')
 
-    def configure_standby_replication_node(self, pwd, primary_ip):
+    def configure_standby_replication_node(self, pwd: str, primary_ip: str):
         # Configure secondary (standby) replication node
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
@@ -208,7 +208,8 @@ class ApplianceConsole(AppliancePlugin):
                 re.escape('Apply this Replication Server Configuration? (Y/N): '), 'y')
             interaction.answer('Press any key to continue.', '', timeout=10 * 60)
 
-    def reconfigure_standby_replication_node(self, pwd, primary_ip, repmgr_reconfigure=False):
+    def reconfigure_standby_replication_node(self, pwd: str, primary_ip: str,
+                                             repmgr_reconfigure=False):
         # Configure secondary (standby) replication node
         with SSHExpect(self.appliance) as interaction:
             interaction.send('ap')
@@ -304,7 +305,11 @@ def check_db_ha_failover(appl_to_fail: 'IPAppliance', appl_to_takeover: 'IPAppli
     appl_to_takeover.wait_for_miq_ready()
 
 
-def configure_appliances_ha(appliances, pwd):
+if typing.TYPE_CHECKING:
+    from cfme.fixtures.cli import TThreeAppliances
+
+
+def configure_appliances_ha(appliances: 'TThreeAppliances', pwd: str):
     """Configure HA environment
 
     Appliance one configuring dedicated database, 'ap' launch appliance_console,


### PR DESCRIPTION
## Purpose or Intent
 * Adds covering of the customer bug by rebooting the secondary first to make sure it boots into a state that is ready to take over.
https://github.com/ManageIQ/integration_tests/pull/10327/files#diff-3c0b49bb78a46b38be44a0e843f40270R467
 * Increase timeout for the appliance_console welcome screen to appear.
 * Other changes were just some types definitions and naming to make this modification and the future maintenance of the code easier.

<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->

### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
