### PR TITLE
read crypt key and pass it instead of the file

### DIFF
--- a/cfme/test_framework/config.py
+++ b/cfme/test_framework/config.py
@@ -3,6 +3,7 @@ classes to manage the cfme test framework configuration
 """
 import os
 import warnings
+from pathlib import Path
 
 import attr
 import yaycl
@@ -30,9 +31,10 @@ class Configuration:
 
         assert self.yaycl_config is None
         if crypt_key_file and os.path.exists(crypt_key_file):
+            crypt_key = Path(crypt_key_file).read_text().strip()
             self.yaycl_config = yaycl.Config(
                 config_dir=config_dir,
-                crypt_key_file=crypt_key_file)
+                crypt_key=crypt_key)
         else:
             self.yaycl_config = yaycl.Config(config_dir=config_dir)
 


### PR DESCRIPTION
deal with utf-8 encodings that pop up when writing the crypt key file.

Functionally should be the same. 

Looking to avoid exceptions like the following, which occur when the crypt key file is written with vim on some CI machines.
```
20:16:08 yaycl_crypt.YayclCryptError: <class 'yaml.reader.ReaderError'> when loading <path>credentials.eyaml, yaycl crypt key may be incorrect. Original traceback:
20:16:08 unacceptable character #x0085: invalid start byte
```