### PR TITLE
[RFR] [NOTEST] Mark tests as manualonly.

### DIFF
--- a/cfme/tests/automate/generic_objects/test_definitions.py
+++ b/cfme/tests/automate/generic_objects/test_definitions.py
@@ -76,7 +76,7 @@ def test_generic_object_definition_crud(appliance, context, soft_assert):
         assert not definition.exists
 
 
-@pytest.mark.manual
+@pytest.mark.manual('manualonly')
 @pytest.mark.tier(3)
 def test_generic_objects_class_accordion_should_display_when_locale_is_french():
     """ Generic objects class accordion should display when locale is french

--- a/cfme/tests/distributed/test_appliance_manual.py
+++ b/cfme/tests/distributed/test_appliance_manual.py
@@ -10,6 +10,7 @@ pytestmark = [
 ]
 
 
+@pytest.mark.manual('manualonly')
 def test_distributed_add_provider_to_remote_zone():
     """
     Adding a provider from the global region to a remote zone.

--- a/cfme/tests/intelligence/test_chargeback_manual.py
+++ b/cfme/tests/intelligence/test_chargeback_manual.py
@@ -25,6 +25,7 @@ assignments = [
     RateAssignment('storage', 'tenant')]
 
 
+@pytest.mark.manual('manualonly')
 @pytest.mark.parametrize('report_period', ['daily_report', 'weekly_report', 'monthly_report'])
 @pytest.mark.parametrize('rate_period', ['hourly_rate', 'weekly_rate', 'monthly_rate'])
 @pytest.mark.parametrize('resource', ['cpu', 'memory', 'storage'])


### PR DESCRIPTION
Mark some tests that will not be automated as 'manual only'.