### PR TITLE
[RFR] Fix CodeMirror filling.

### DIFF
--- a/cfme/tests/services/test_provision_stack.py
+++ b/cfme/tests/services/test_provision_stack.py
@@ -206,7 +206,6 @@ def svc_cleanup(service):
 
 
 @test_requirements.provision
-@pytest.mark.meta(blockers=[BZ(1754543)])
 def test_provision_stack(order_stack, stack_created):
     """Tests stack provisioning
 
@@ -251,7 +250,6 @@ def test_reconfigure_service(appliance, service_catalogs, request):
                       filters=[cloud_filter, not_ec2],
                       selector=ONE_PER_TYPE,
                       scope='module')
-@pytest.mark.meta(blockers=[BZ(1754543)])
 def test_remove_non_read_only_orch_template(appliance, provider, template, service_catalogs,
                                             request):
     """
@@ -316,7 +314,6 @@ def test_remove_read_only_orch_template_neg(appliance, provider, template, order
     assert order_stack.is_succeeded()
 
 
-@pytest.mark.meta(blockers=[BZ(1754543)])
 def test_retire_stack(stack_created):
     """Tests stack retirement.
 
@@ -468,7 +465,6 @@ def test_retire_catalog_bundle_service_orchestration_item(appliance, request, ca
 
 
 @pytest.mark.meta(automates=[1698439])
-@pytest.mark.meta(blockers=[BZ(1754543)])
 @pytest.mark.tier(2)
 @pytest.mark.provider([EC2Provider], selector=ONE, scope='module')
 def test_read_dialog_timeout_ec2_stack(order_stack):

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1032,8 +1032,9 @@ class ReactCodeMirror(Widget):
     https://github.com/JedWatson/react-codemirror"""
 
     ROOT = "//div[contains(@class,'miq-codemirror')]//textarea"
-    PARENT_DIV = "./.."  # we need to change visibility of this one
-    CLICK_DIV = "./../.."  # the widget has very nested divs,we need to click on that one ¯\_(ツ)_/¯
+
+    # The CodeMirror has very nested divs, we need to setValue on this one ¯\_(ツ)_/¯.
+    SET_VALUE_ELEMENT = "../.."
 
     def __init__(self, parent, logger=None):
         Widget.__init__(self, parent, logger=logger)
@@ -1042,14 +1043,6 @@ class ReactCodeMirror(Widget):
     def element(self):
         return self.browser.element(self)
 
-    @property
-    def is_editable(self):
-        return self.element.get_attribute("contentEditable") == "true"
-
-    def make_editable(self):
-        if not self.is_editable:
-            self.browser.set_attribute("contentEditable", "true", self)
-
     def fill(self, value):
         # CodeMirror is too smart for filling with send_keys.
         # Fixing BZ#1740753 and BZ#1754543 didn't really help.
@@ -1057,7 +1050,7 @@ class ReactCodeMirror(Widget):
         # additional indents are created when using send_keys.
         self.browser.execute_script(
             """arguments[0].CodeMirror.setValue(arguments[1])""",
-            self.browser.element(self.CLICK_DIV),
+            self.browser.element(self.SET_VALUE_ELEMENT),
             value,
         )
         return True

--- a/widgetastic_manageiq/__init__.py
+++ b/widgetastic_manageiq/__init__.py
@@ -1051,11 +1051,15 @@ class ReactCodeMirror(Widget):
             self.browser.set_attribute("contentEditable", "true", self)
 
     def fill(self, value):
-        # TODO(anikifor): remove the 2 workarounds below as soon as BZ 1740753 is verified
-        self.make_editable()
-        self.browser.set_attribute("style", "overflow: visible", self.PARENT_DIV)
-        self.browser.element(self.CLICK_DIV).click()
-        self.element.send_keys(value)
+        # CodeMirror is too smart for filling with send_keys.
+        # Fixing BZ#1740753 and BZ#1754543 didn't really help.
+        # Now the problem is that the CodeMirror auto-indents which means
+        # additional indents are created when using send_keys.
+        self.browser.execute_script(
+            """arguments[0].CodeMirror.setValue(arguments[1])""",
+            self.browser.element(self.CLICK_DIV),
+            value,
+        )
         return True
 
     def read(self):


### PR DESCRIPTION
# Purpose of intent
Some time ago, the CodeMirror component used for entering yaml templates started failing to get filled by selenium. There are currently two ON_QA bugs related to CodeMirror but even with them "fixed" I either did get indenting wrong (which is significant for yamls) or nothing else than parentheses `{` being input.

This PR set's the content of the CM using Javascript. Perhaps not ideal, but surely good enough to have the tests working.

# PRT failures advocacy.
From first glance the errors on PRT are not related. The tests have not been executed for a while or were executed failing on the CodeMirror. I think most of them belong to @niyazRedhat. Niyaz, can you take a look?

{{ pytest: --use-sprout -s --sprout-group downstream-511z -sv 'cfme/tests/services/test_provision_stack.py'  -v --use-provider 'complete'  --long-running }}