### PR TITLE
[1LP][RFR ] - Fix testcase 

### DIFF
--- a/cfme/tests/infrastructure/test_vm_migrate.py
+++ b/cfme/tests/infrastructure/test_vm_migrate.py
@@ -5,6 +5,7 @@ from cfme import test_requirements
 from cfme.infrastructure.provider.rhevm import RHEVMProvider
 from cfme.infrastructure.provider.virtualcenter import VMwareProvider
 from cfme.utils.appliance.implementations.ui import navigate_to
+from cfme.utils.blockers import BZ
 from cfme.utils.log_validator import LogValidator
 
 
@@ -16,6 +17,17 @@ pytestmark = [
 ]
 
 
+@pytest.mark.meta(
+    blockers=[
+        BZ(
+            1879912,
+            forced_streams=["5.11"],
+            unblock=lambda provider: (
+                not (provider.one_of(RHEVMProvider) and provider.version == 4.2)
+            ),
+        )
+    ]
+)
 def test_vm_migrate(appliance, create_vm, provider):
     """Tests migration of a vm
 

--- a/cfme/tests/test_replication.py
+++ b/cfme/tests/test_replication.py
@@ -93,8 +93,8 @@ def test_replication_powertoggle(request, provider, setup_replication, small_tem
     instance_name = fauxfactory.gen_alphanumeric(start="test_replication_", length=25).lower()
     remote_app, global_app = setup_replication
 
-    provider_app_crud(OpenStackProvider, remote_app).setup()
     provider.appliance = remote_app
+    provider.setup()
 
     remote_instance = remote_app.collections.cloud_instances.instantiate(
         instance_name, provider, small_template.name


### PR DESCRIPTION
<!-- Make sure to prefix the PR Title with any one of the below options...

   [WIP] - Work in Progress
   [WIPTEST] - Work in Progress with PRT Testing
   [RFR] - Ready for 1st Review
   [1LP][WIP] - 1st Level Pass, Work in Progress
   [1LP][WIPTEST] - 1st Level Pass, Work in Progress with PRT Testing
   [1LP][RFR] - 1st Level Pass, Ready for 2nd Review
-->

## Purpose or Intent
<!-- Please provide some information related to PR. Some examples are:

- __Fixing__ X because it is currently doing Y which is incorrect. It should be doing Z.
- __Extending__ X because I need it to do Y so that I can update/add more test cases; PR #123
depends on it.
- __Adding tests__ for feature X to cover cases Y and Z. They were implemented in product
version1.2.3.
- __Updating tests__ for feature X because the behavior changed in product version 1.2.3.
- __Enhancement__ for feature X

Note: You can introduce Screenshots/Gifs for providing more information.
-->
- Adding test BZ-1879912 blocker for **test_vm_migrate** test case
- Fixed **test_replication_powertoggle** test case. ( testcase was checking OSP instance on the different provider and we were creating instance on diffrent provider.)
### PRT Run
<!--
- It's an internal RH service and only runs against signed whitelisted commits.
- It runs against a single appliance.
- Need to provide specific pytest expression else default it will run smoke tests [-m smoke].
- DOUBLE CURLY BRACES REQUIRED. Examples are in single to not get picked

Some examples are:
- {pytest: cfme/tests/test_foo_file.py -v}
- {pytest: cfme/tests/test_foo_file.py -k "test_foo_1 or test_foo_2" -v}
- {pytest: cfme/tests/ -k "test_foo_1 or test_foo_2 or test_foo_3" -v}
- {pytest: cfme/tests/test_foo_file.py --use-provider rhv43 -v}
- {pytest: cfme/tests/test_foo_file.py --long-running -v}

Notes:
- If PRT fails other than PR purpose/intent; please add a respective comment.
- For any guidance or assistance with PRT results; please contact to maintainers.
-->
{{ pytest: cfme/tests/test_replication.py::test_replication_powertoggle cfme/tests/infrastructure/test_vm_migrate.py::test_vm_migrate   -svvvv  --long-running  --use-template-cache
}}
